### PR TITLE
Parameterize module-related directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ test/res
 *.prof
 target/
 .build/
+test/**/build/
 dist-newstyle/
 book/dist/
 test/sandbox/

--- a/.justfile
+++ b/.justfile
@@ -42,7 +42,7 @@ test-arm64-darwin:
     @NEUT={{justfile_directory()}}/bin/neut-arm64-darwin TARGET_ARCH=arm64 CLANG_PATH=${NEUT_ARM64_DARWIN_CLANG_PATH} ./test/test-darwin.sh ./test/term ./test/statement ./test/pfds ./test/misc
 
 update-core new-version:
-    @cd ./test/meta && neut add core https://github.com/vekatze/neut-core/raw/main/release/{{new-version}}.tar.zst
+    @cd ./test/meta && neut add core https://github.com/vekatze/neut-core/raw/main/archive/{{new-version}}.tar.zst
     @NEW_VERSION={{new-version}} ./test/update-core.sh ./test/statement ./test/term ./test/misc ./test/pfds
 
 release:

--- a/book/src/basics-of-modules.md
+++ b/book/src/basics-of-modules.md
@@ -22,7 +22,7 @@ When running compilation, every module is marked as "main" or "library". The mai
 A module can use other modules. Such module dependencies can be added using `neut add`:
 
 ```sh
-neut add core https://github.com/vekatze/neut-core/raw/main/release/0-2-3.tar.zst
+neut add core https://github.com/vekatze/neut-core/raw/main/archive/0-2-10.tar.zst
 ```
 
 By running the code above, the specified tarball is downloaded into `~/.cache/neut/library`:
@@ -40,7 +40,7 @@ where the `1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=` is the digest of the mo
 (dependency
   (core
     (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-3.tar.zst")))
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-10.tar.zst")))
 ```
 
 It might be worth noting that an alias of a library is chosen *by a user of the library*. Indeed, in the example above, we (user) chosed the alias `core` for the downloaded library. The "true" name of the library is its digest, and this is not something that can be chosen arbitrarily by the creator of the library.

--- a/book/src/basics-of-modules.md
+++ b/book/src/basics-of-modules.md
@@ -22,7 +22,7 @@ When running compilation, every module is marked as "main" or "library". The mai
 A module can use other modules. Such module dependencies can be added using `neut add`:
 
 ```sh
-neut add core https://github.com/vekatze/neut-core/raw/main/archive/0-2-10.tar.zst
+neut add core https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst
 ```
 
 By running the code above, the specified tarball is downloaded into `~/.cache/neut/library`:
@@ -30,17 +30,17 @@ By running the code above, the specified tarball is downloaded into `~/.cache/ne
 ```sh
 ls ~/.cache/neut/library
 # => ...
-#    1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=
+#    IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=
 #    ...
 ```
 
-where the `1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=` is the digest of the module. Also, the module information is added to the current module's `module.ens`:
+where the `IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=` is the digest of the module. Also, the module information is added to the current module's `module.ens`:
 
 ```ens
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))
 ```
 
 It might be worth noting that an alias of a library is chosen *by a user of the library*. Indeed, in the example above, we (user) chosed the alias `core` for the downloaded library. The "true" name of the library is its digest, and this is not something that can be chosen arbitrarily by the creator of the library.

--- a/book/src/importing-names.md
+++ b/book/src/importing-names.md
@@ -76,7 +76,7 @@ Suppose that you have added a library module to your module:
 (dependency
   (core
     (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-3.tar.zst")))
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-3.tar.zst")))
 ```
 
 You can import a file from such a library module by specifying its module alias and the relative path to the file:

--- a/book/src/importing-names.md
+++ b/book/src/importing-names.md
@@ -75,7 +75,7 @@ Suppose that you have added a library module to your module:
 ```ens
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
     (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-3.tar.zst")))
 ```
 
@@ -98,7 +98,7 @@ Here, the module alias of `core.text.io` is `core`, and the relative path is `te
 ```sh
 core => DIGEST_OF_THE_LIBRARY
 
-# core => 1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=
+# core => IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=
 ```
 
 and do the following name resolution:
@@ -108,7 +108,7 @@ core.text.io.get-line
 
 ↓
 
-1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=.text.io.get-line
+IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=.text.io.get-line
 ```
 
 ## Qualified Import

--- a/book/src/importing-names.md
+++ b/book/src/importing-names.md
@@ -199,4 +199,4 @@ jIx5FxfoymZ-X0jLXGcALSwK4J7NlR1yCdXqH2ij67o=.text.io.get-line
 ## Other Notes on Namespaces and Modules
 
 - A module named `core` is treated specially (the prelude library)
-- Compiled objects, caches, etc. are stored in `.build/` of the corresponding module
+- Compiled objects, caches, etc. are stored in `build/` of the corresponding module

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -32,8 +32,8 @@ We also need to register the URL and the digest of the core module (standard lib
 
 ```sh
 # add the below to your bashrc, zshrc, etc.
-export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-2-10.tar.zst"
-export NEUT_CORE_MODULE_DIGEST="1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo="
+export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst"
+export NEUT_CORE_MODULE_DIGEST="IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4="
 ```
 
 Now, let's create a sample project and build it to check if your installation is correct:

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -32,7 +32,7 @@ We also need to register the URL and the digest of the core module (standard lib
 
 ```sh
 # add the below to your bashrc, zshrc, etc.
-export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst"
+export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-2-10.tar.zst"
 export NEUT_CORE_MODULE_DIGEST="1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo="
 ```
 

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -65,8 +65,8 @@ An example scenario:
 
 ```sh
 # setting up the core module (i.e. standard library)
-export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-2-10.tar.zst"
-export NEUT_CORE_MODULE_DIGEST="1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo="
+export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst"
+export NEUT_CORE_MODULE_DIGEST="IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4="
 
 # get the compiler (choose one)
 curl -L -o ~/.local/bin/neut https://github.com/vekatze/neut/releases/latest/download/neut-arm64-darwin

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -65,7 +65,7 @@ An example scenario:
 
 ```sh
 # setting up the core module (i.e. standard library)
-export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/release/0-2-9.tar.zst"
+export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-2-10.tar.zst"
 export NEUT_CORE_MODULE_DIGEST="1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo="
 
 # get the compiler (choose one)

--- a/book/src/publishing-your-code.md
+++ b/book/src/publishing-your-code.md
@@ -2,22 +2,22 @@
 
 ## Creating an Archive for Your Module
 
-You can create a tarball for your module using `neut release VERSION`:
+You can create a tarball for your module using `neut archive VERSION`:
 
 ```sh
 # create a new release
-neut release 0-1-0-0
+neut archive 0-1-0-0
 
 tree .
 # => ./
-#    ├── release/
+#    ├── archive/
 #    │  └── 0-1-0-0.tar.zst ← NEW!
 #    ├── source/
 #    │  └── hey.nt
 #    └── module.ens
 ```
 
-The command `neut release` creates a tarball for the current module. The resulting tarball can be, for example, committed and pushed to your repository. Then, a user of your library can then add it to their module using `neut add ALIAS URL`.
+The command `neut archive` creates a tarball for the current module. The resulting tarball can be, for example, committed and pushed to your repository. Then, a user of your library can then add it to their module using `neut add ALIAS URL`.
 
 ## Identity of a Module
 
@@ -50,11 +50,11 @@ Neut resolves this problem via an approach based on Semantic Versioning, as desc
 
 ## Practical Significance of Semantic Versioning
 
-Firstly, the `VERSION` in `neut release VERSION` must follow a versioning scheme that is essentially the same as Semantic Versioning.
+Firstly, the `VERSION` in `neut archive VERSION` must follow a versioning scheme that is essentially the same as Semantic Versioning.
 
 If you release a version of your module that is compatible with existing modules, *the compatibility information is saved to the module file in the newly-created tarball*. The module file thus contains the list of digests of all the compatible but older alternatives.
 
-For example, suppose you have `release/0-1-0-0.tar.zst`. If you run `neut release 0-1-1-0`, which is a minor update release, the module file in `release/0-1-1-0.tar.zst` should contain:
+For example, suppose you have `archive/0-1-0-0.tar.zst`. If you run `neut archive 0-1-1-0`, which is a minor update release, the module file in `archive/0-1-1-0.tar.zst` should contain:
 
 ```ens
 (antecedent

--- a/src/Act/Archive.hs
+++ b/src/Act/Archive.hs
@@ -1,20 +1,20 @@
-module Act.Release (release) where
+module Act.Archive (archive) where
 
 import Context.App
 import Context.Module qualified as Module
 import Context.Path qualified as Path
-import Entity.Config.Release
+import Entity.Config.Archive
 import Scene.Archive qualified as Archive
 import Scene.Collect qualified as Collect
 import Scene.Initialize qualified as Initialize
 import Scene.Module.UpdateAntecedents
 import Scene.PackageVersion.Reflect qualified as PV
 
-release :: Config -> App ()
-release cfg = do
+archive :: Config -> App ()
+archive cfg = do
   Initialize.initializeCompiler (remarkCfg cfg) Nothing
   Path.ensureNotInLibDir
-  packageVersion <- PV.reflect (getReleaseName cfg)
+  packageVersion <- PV.reflect (getArchiveName cfg)
   currentModule <- Module.getMainModule
   Module.getMainModule >>= updateAntecedents packageVersion
   Collect.collectModuleFiles >>= Archive.archive packageVersion

--- a/src/Act/Check.hs
+++ b/src/Act/Check.hs
@@ -1,23 +1,13 @@
 module Act.Check (check) where
 
 import Context.App
+import Context.Remark qualified as Remark
 import Context.Throw qualified as Throw
-import Control.Monad
 import Entity.Config.Check
-import Scene.Collect qualified as Collect
-import Scene.Elaborate qualified as Elaborate
-import Scene.Initialize qualified as Initialize
-import Scene.Parse qualified as Parse
-import Scene.Unravel qualified as Unravel
+import Scene.Check qualified as Check
 
 check :: Config -> App ()
 check cfg = do
   let runner = if shouldInsertPadding cfg then id else Throw.run'
-  runner $ do
-    Initialize.initializeCompiler (remarkCfg cfg) Nothing
-    sgls <- Collect.collectSourceList (mFilePathString cfg)
-    forM_ sgls $ \sgl -> do
-      (_, dependenceSeq) <- Unravel.unravelFromSGL sgl
-      forM_ dependenceSeq $ \source -> do
-        Initialize.initializeForSource source
-        void $ Parse.parse >>= Elaborate.elaborate
+  logs <- runner $ Check.check (mFilePathString cfg)
+  Remark.printErrorList logs

--- a/src/Context/Locator.hs
+++ b/src/Context/Locator.hs
@@ -118,5 +118,5 @@ getMainDefiniteDescription source = do
 
 isMainFile :: Source.Source -> App Bool
 isMainFile source = do
-  sourcePathList <- mapM Module.getSourcePath $ Map.elems $ Module.moduleTarget (Source.sourceModule source)
+  let sourcePathList = Module.getTargetPathList $ Source.sourceModule source
   return $ elem (Source.sourceFilePath source) sourcePathList

--- a/src/Context/Module.hs
+++ b/src/Context/Module.hs
@@ -1,6 +1,5 @@
 module Context.Module
   ( getModuleFilePath,
-    getSourcePath,
     getModuleDirByID,
     getMainModule,
     setMainModule,
@@ -26,8 +25,6 @@ import Entity.ModuleDigest
 import Entity.ModuleDigest qualified as MD
 import Entity.ModuleID qualified as MID
 import Entity.ModuleURL
-import Entity.SourceLocator qualified as SL
-import Entity.StrictGlobalLocator qualified as SGL
 import Path
 import Path.IO
 import System.Environment
@@ -52,12 +49,6 @@ getModuleCacheMap =
 insertToModuleCacheMap :: Path Abs File -> Module -> App ()
 insertToModuleCacheMap k v =
   modifyRef' moduleCacheMap $ Map.insert k v
-
-getSourcePath :: SGL.StrictGlobalLocator -> App (Path Abs File)
-getSourcePath sgl = do
-  moduleDir <- getModuleDirByID Nothing $ SGL.moduleID sgl
-  let relPath = SL.reify $ SGL.sourceLocator sgl
-  return $ moduleDir </> sourceRelDir </> relPath
 
 getModuleDirByID :: Maybe H.Hint -> MID.ModuleID -> App (Path Abs Dir)
 getModuleDirByID mHint moduleID = do

--- a/src/Context/OptParse.hs
+++ b/src/Context/OptParse.hs
@@ -6,12 +6,12 @@ import Data.Text qualified as T
 import Entity.BuildMode qualified as BM
 import Entity.Command
 import Entity.Config.Add qualified as Add
+import Entity.Config.Archive qualified as Archive
 import Entity.Config.Build qualified as Build
 import Entity.Config.Check qualified as Check
 import Entity.Config.Clean qualified as Clean
 import Entity.Config.Create qualified as Create
 import Entity.Config.LSP qualified as LSP
-import Entity.Config.Release qualified as Release
 import Entity.Config.Remark qualified as Remark
 import Entity.Config.Version qualified as Version
 import Entity.ModuleURL
@@ -31,7 +31,7 @@ parseOpt = do
       [ cmd "build" parseBuildOpt "build given target",
         cmd "clean" parseCleanOpt "remove the resulting files",
         cmd "check" parseCheckOpt "type-check specified file",
-        cmd "release" parseReleaseOpt "package a tarball",
+        cmd "archive" parseArchiveOpt "package a tarball",
         cmd "create" parseCreateOpt "create a new module",
         cmd "add" parseGetOpt "add a dependency",
         cmd "lsp" parseLSPOpt "start the LSP server",
@@ -126,15 +126,15 @@ parseCheckOpt = do
           Check.remarkCfg = remarkCfg
         }
 
-parseReleaseOpt :: Parser Command
-parseReleaseOpt = do
-  releaseName <- argument str (mconcat [metavar "NAME", help "The name of the release"])
+parseArchiveOpt :: Parser Command
+parseArchiveOpt = do
+  archiveName <- argument str (mconcat [metavar "NAME", help "The name of the archive"])
   remarkCfg <- remarkConfigOpt
   pure $
-    Release $
-      Release.Config
-        { Release.getReleaseName = releaseName,
-          Release.remarkCfg = remarkCfg
+    Archive $
+      Archive.Config
+        { Archive.getArchiveName = archiveName,
+          Archive.remarkCfg = remarkCfg
         }
 
 remarkConfigOpt :: Parser Remark.Config

--- a/src/Context/Path.hs
+++ b/src/Context/Path.hs
@@ -152,7 +152,8 @@ getBaseBuildDir :: Module -> App (Path Abs Dir)
 getBaseBuildDir baseModule = do
   platformPrefix <- getPlatformPrefix
   versionDir <- P.parseRelDir $ "compiler-" ++ V.showVersion version
-  return $ getModuleRootDir baseModule </> buildRelDir </> platformPrefix </> versionDir
+  let moduleRootDir = getModuleRootDir baseModule
+  return $ moduleRootDir </> moduleBuildDir baseModule </> platformPrefix </> versionDir
 
 getBuildDir :: Module -> App (Path Abs Dir)
 getBuildDir baseModule = do

--- a/src/Entity/Command.hs
+++ b/src/Entity/Command.hs
@@ -1,19 +1,19 @@
 module Entity.Command where
 
 import Entity.Config.Add qualified as Add
+import Entity.Config.Archive qualified as Archive
 import Entity.Config.Build qualified as Build
 import Entity.Config.Check qualified as Check
 import Entity.Config.Clean qualified as Clean
 import Entity.Config.Create qualified as Create
 import Entity.Config.LSP qualified as LSP
-import Entity.Config.Release qualified as Release
 import Entity.Config.Version qualified as Version
 
 data Command
   = Build Build.Config
   | Check Check.Config
   | Clean Clean.Config
-  | Release Release.Config
+  | Archive Archive.Config
   | Add Add.Config
   | Create Create.Config
   | LSP LSP.Config

--- a/src/Entity/Config/Archive.hs
+++ b/src/Entity/Config/Archive.hs
@@ -1,9 +1,9 @@
-module Entity.Config.Release (Config (..)) where
+module Entity.Config.Archive (Config (..)) where
 
 import Data.Text qualified as T
 import Entity.Config.Remark qualified as Remark
 
 data Config = Config
-  { getReleaseName :: T.Text,
+  { getArchiveName :: T.Text,
     remarkCfg :: Remark.Config
   }

--- a/src/Entity/Const.hs
+++ b/src/Entity/Const.hs
@@ -51,7 +51,7 @@ sourceRelDir =
 
 buildRelDir :: Path Rel Dir
 buildRelDir =
-  $(mkRelDir ".build")
+  $(mkRelDir "build")
 
 archiveRelDir :: Path Rel Dir
 archiveRelDir =

--- a/src/Entity/Const.hs
+++ b/src/Entity/Const.hs
@@ -53,9 +53,9 @@ buildRelDir :: Path Rel Dir
 buildRelDir =
   $(mkRelDir ".build")
 
-releaseRelDir :: Path Rel Dir
-releaseRelDir =
-  $(mkRelDir "release")
+archiveRelDir :: Path Rel Dir
+archiveRelDir =
+  $(mkRelDir "archive")
 
 artifactRelDir :: Path Rel Dir
 artifactRelDir =

--- a/src/Entity/Module.hs
+++ b/src/Entity/Module.hs
@@ -96,7 +96,7 @@ ppModule someModule = do
               : map (string . ppExtraContent) (moduleExtraContents someModule),
           nodeOrNone $
             symbol keyForeign
-              : map (string . ppForeignContent) (moduleForeignDirList someModule),
+              : map (string . ppDirPath) (moduleForeignDirList someModule),
           nodeOrNone $
             symbol keyAntecedent
               : map (string . ppAntecedent) (moduleAntecedents someModule),
@@ -150,8 +150,8 @@ ppExtraContent somePath =
     Right filePath ->
       T.pack $ toFilePath filePath
 
-ppForeignContent :: Path Abs Dir -> T.Text
-ppForeignContent dirPath =
+ppDirPath :: Path Abs Dir -> T.Text
+ppDirPath dirPath =
   T.pack $ toFilePath dirPath
 
 getID :: Module -> Module -> MID.ModuleID

--- a/src/Entity/Module.hs
+++ b/src/Entity/Module.hs
@@ -24,6 +24,7 @@ type SomePath a =
 
 data Module = Module
   { moduleID :: MID.ModuleID,
+    moduleSourceDir :: Path Rel Dir,
     moduleTarget :: Map.HashMap Target.Target SGL.StrictGlobalLocator,
     moduleDependency :: Map.HashMap ModuleAlias ([ModuleURL], ModuleDigest),
     moduleExtraContents :: [SomePath Rel],
@@ -32,6 +33,10 @@ data Module = Module
     moduleForeignDirList :: [Path Rel Dir]
   }
   deriving (Show)
+
+keySource :: T.Text
+keySource =
+  "source"
 
 keyTarget :: T.Text
 keyTarget =
@@ -103,7 +108,9 @@ ppModule someModule = do
   TR.ppTreeList
     ( (),
       catMaybes
-        [ nodeOrNone $
+        [ nodeOrNone
+            [symbol keySource, string $ ppDirPath $ moduleSourceDir someModule],
+          nodeOrNone $
             symbol keyTarget
               : map ppEntryPoint (Map.toList (moduleTarget someModule)),
           nodeOrNone $

--- a/src/Entity/Module.hs
+++ b/src/Entity/Module.hs
@@ -7,7 +7,6 @@ import Data.List.NonEmpty qualified as NE
 import Data.Maybe (catMaybes)
 import Data.Text qualified as T
 import Entity.BaseName qualified as BN
-import Entity.Const
 import Entity.ModuleAlias
 import Entity.ModuleDigest
 import Entity.ModuleID qualified as MID
@@ -25,6 +24,7 @@ data Module = Module
   { moduleID :: MID.ModuleID,
     moduleSourceDir :: Path Rel Dir,
     moduleTarget :: Map.HashMap Target.Target SL.SourceLocator,
+    moduleReleaseDir :: Path Rel Dir,
     moduleDependency :: Map.HashMap ModuleAlias ([ModuleURL], ModuleDigest),
     moduleExtraContents :: [SomePath Rel],
     moduleAntecedents :: [ModuleDigest],
@@ -32,6 +32,10 @@ data Module = Module
     moduleForeignDirList :: [Path Rel Dir]
   }
   deriving (Show)
+
+keyRelease :: T.Text
+keyRelease =
+  "release"
 
 keySource :: T.Text
 keySource =
@@ -75,7 +79,9 @@ getTargetPath baseModule target = do
 
 getReleaseDir :: Module -> Path Abs Dir
 getReleaseDir baseModule =
-  getModuleRootDir baseModule </> releaseRelDir
+  getModuleRootDir baseModule </> moduleReleaseDir baseModule
+
+-- getModuleRootDir baseModule </> releaseRelDir
 
 getForeignContents :: Module -> [Path Abs Dir]
 getForeignContents baseModule = do
@@ -120,6 +126,8 @@ ppModule someModule = do
     ( (),
       catMaybes
         [ nodeOrNone
+            [symbol keyRelease, string $ ppDirPath $ moduleReleaseDir someModule],
+          nodeOrNone
             [symbol keySource, string $ ppDirPath $ moduleSourceDir someModule],
           nodeOrNone $
             symbol keyTarget

--- a/src/Entity/Module.hs
+++ b/src/Entity/Module.hs
@@ -24,7 +24,7 @@ data Module = Module
   { moduleID :: MID.ModuleID,
     moduleSourceDir :: Path Rel Dir,
     moduleTarget :: Map.HashMap Target.Target SL.SourceLocator,
-    moduleReleaseDir :: Path Rel Dir,
+    moduleArchiveDir :: Path Rel Dir,
     moduleDependency :: Map.HashMap ModuleAlias ([ModuleURL], ModuleDigest),
     moduleExtraContents :: [SomePath Rel],
     moduleAntecedents :: [ModuleDigest],
@@ -33,9 +33,9 @@ data Module = Module
   }
   deriving (Show)
 
-keyRelease :: T.Text
-keyRelease =
-  "release"
+keyArchive :: T.Text
+keyArchive =
+  "archive"
 
 keySource :: T.Text
 keySource =
@@ -77,11 +77,9 @@ getTargetPath baseModule target = do
   sourceLocator <- Map.lookup target (moduleTarget baseModule)
   return $ moduleSourceDir </> SL.reify sourceLocator
 
-getReleaseDir :: Module -> Path Abs Dir
-getReleaseDir baseModule =
-  getModuleRootDir baseModule </> moduleReleaseDir baseModule
-
--- getModuleRootDir baseModule </> releaseRelDir
+getArchiveDir :: Module -> Path Abs Dir
+getArchiveDir baseModule =
+  getModuleRootDir baseModule </> moduleArchiveDir baseModule
 
 getForeignContents :: Module -> [Path Abs Dir]
 getForeignContents baseModule = do
@@ -126,7 +124,7 @@ ppModule someModule = do
     ( (),
       catMaybes
         [ nodeOrNone
-            [symbol keyRelease, string $ ppDirPath $ moduleReleaseDir someModule],
+            [symbol keyArchive, string $ ppDirPath $ moduleArchiveDir someModule],
           nodeOrNone
             [symbol keySource, string $ ppDirPath $ moduleSourceDir someModule],
           nodeOrNone $

--- a/src/Entity/Module.hs
+++ b/src/Entity/Module.hs
@@ -25,6 +25,7 @@ data Module = Module
     moduleSourceDir :: Path Rel Dir,
     moduleTarget :: Map.HashMap Target.Target SL.SourceLocator,
     moduleArchiveDir :: Path Rel Dir,
+    moduleBuildDir :: Path Rel Dir,
     moduleDependency :: Map.HashMap ModuleAlias ([ModuleURL], ModuleDigest),
     moduleExtraContents :: [SomePath Rel],
     moduleAntecedents :: [ModuleDigest],
@@ -36,6 +37,10 @@ data Module = Module
 keyArchive :: T.Text
 keyArchive =
   "archive"
+
+keyBuild :: T.Text
+keyBuild =
+  "build"
 
 keySource :: T.Text
 keySource =
@@ -125,6 +130,8 @@ ppModule someModule = do
       catMaybes
         [ nodeOrNone
             [symbol keyArchive, string $ ppDirPath $ moduleArchiveDir someModule],
+          nodeOrNone
+            [symbol keyBuild, string $ ppDirPath $ moduleBuildDir someModule],
           nodeOrNone
             [symbol keySource, string $ ppDirPath $ moduleSourceDir someModule],
           nodeOrNone $

--- a/src/Entity/SourceLocator.hs
+++ b/src/Entity/SourceLocator.hs
@@ -2,6 +2,7 @@
 
 module Entity.SourceLocator
   ( SourceLocator (..),
+    getRelPathText,
     toText,
     fromBaseNameList,
     llvmLocator,
@@ -54,3 +55,7 @@ internalLocator =
 natLocator :: SourceLocator
 natLocator =
   SourceLocator $(mkRelFile "nat")
+
+getRelPathText :: SourceLocator -> T.Text
+getRelPathText sl =
+  T.pack $ toFilePath $ reify sl

--- a/src/Entity/StrictGlobalLocator.hs
+++ b/src/Entity/StrictGlobalLocator.hs
@@ -7,7 +7,6 @@ import Entity.Const
 import Entity.ModuleID qualified as MID
 import Entity.SourceLocator qualified as SL
 import GHC.Generics
-import Path
 
 data StrictGlobalLocator = StrictGlobalLocator
   { moduleID :: MID.ModuleID,
@@ -43,7 +42,3 @@ baseGlobalLocatorOf sl =
     { moduleID = MID.Base,
       sourceLocator = sl
     }
-
-getRelPathText :: StrictGlobalLocator -> T.Text
-getRelPathText sgl =
-  T.pack $ toFilePath $ SL.reify $ sourceLocator sgl

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,12 +1,12 @@
 module Main (main) where
 
 import Act.Add qualified as Add
+import Act.Archive qualified as Archive
 import Act.Build qualified as Build
 import Act.Check qualified as Check
 import Act.Clean qualified as Clean
 import Act.Create qualified as Create
 import Act.LSP qualified as LSP
-import Act.Release qualified as Release
 import Act.Version qualified as Version
 import Context.App
 import Context.External qualified as External
@@ -31,8 +31,8 @@ execute = do
           Check.check cfg
         C.Clean cfg ->
           Clean.clean cfg
-        C.Release cfg ->
-          Release.release cfg
+        C.Archive cfg ->
+          Archive.archive cfg
         C.Create cfg ->
           Create.create cfg
         C.Add cfg ->

--- a/src/Scene/Archive.hs
+++ b/src/Scene/Archive.hs
@@ -18,17 +18,17 @@ import Prelude hiding (log)
 archive :: PV.PackageVersion -> [FilePath] -> App ()
 archive packageVersion contents = do
   mainModule <- Module.getMainModule
-  outputPath <- toFilePath <$> getReleaseFile mainModule (PV.reify packageVersion)
+  outputPath <- toFilePath <$> getArchiveFile mainModule (PV.reify packageVersion)
   let moduleRootDir = parent $ moduleLocation mainModule
   let tarRootDir = toFilePath $ parent moduleRootDir
   External.run "tar" $ ["-c", "--zstd", "-f", outputPath, "-C", tarRootDir] ++ contents
 
-getReleaseFile :: Module -> T.Text -> App (Path Abs File)
-getReleaseFile targetModule versionText = do
-  let releaseDir = getReleaseDir targetModule
-  Path.ensureDir releaseDir
-  releaseFile <- Path.resolveFile releaseDir $ T.unpack $ versionText <> packageFileExtension
-  releaseExists <- Path.doesFileExist releaseFile
-  when releaseExists $ do
-    Throw.raiseError' $ "the release `" <> versionText <> "` already exists"
-  return releaseFile
+getArchiveFile :: Module -> T.Text -> App (Path Abs File)
+getArchiveFile targetModule versionText = do
+  let archiveDir = getArchiveDir targetModule
+  Path.ensureDir archiveDir
+  archiveFile <- Path.resolveFile archiveDir $ T.unpack $ versionText <> packageFileExtension
+  archiveExists <- Path.doesFileExist archiveFile
+  when archiveExists $ do
+    Throw.raiseError' $ "the archive `" <> versionText <> "` already exists"
+  return archiveFile

--- a/src/Scene/Check.hs
+++ b/src/Scene/Check.hs
@@ -14,9 +14,9 @@ check :: Maybe FilePath -> App [Remark]
 check mPath = do
   Throw.collectLogs $ do
     Initialize.initializeForTarget
-    sgls <- Collect.collectSourceList mPath
-    forM_ sgls $ \sgl -> do
-      (_, dependenceSeq) <- Unravel.unravelFromSGL sgl
+    paths <- Collect.collectSourceList mPath
+    forM_ paths $ \path -> do
+      (_, dependenceSeq) <- Unravel.unravelFromFile path
       forM_ dependenceSeq $ \source -> do
         Initialize.initializeForSource source
         void $ Parse.parse >>= Elaborate.elaborate

--- a/src/Scene/Collect.hs
+++ b/src/Scene/Collect.hs
@@ -46,23 +46,23 @@ collectModuleFiles = do
   mainModule <- Module.getMainModule
   let moduleRootDir = parent $ moduleLocation mainModule
   let tarRootDir = parent moduleRootDir
-  relModuleSourceDir <- Path.stripPrefix tarRootDir $ getSourceDir mainModule
-  relModuleFile <- Path.stripPrefix tarRootDir $ moduleLocation mainModule
-  foreignContents <- mapM (arrangeForeignContentPath tarRootDir) $ moduleForeignDirList mainModule
-  extraContents <- mapM (arrangeExtraContentPath tarRootDir) $ moduleExtraContents mainModule
-  return $ toFilePath relModuleFile : toFilePath relModuleSourceDir : foreignContents ++ extraContents
+  relModuleSourceDir <- getRelFilePath tarRootDir $ getSourceDir mainModule
+  relModuleFile <- getRelFilePath tarRootDir $ moduleLocation mainModule
+  foreignContents <- mapM (getRelFilePath tarRootDir) $ getForeignContents mainModule
+  extraContents <- mapM (arrangeExtraContentPath tarRootDir) $ getExtraContents mainModule
+  return $ relModuleFile : relModuleSourceDir : foreignContents ++ extraContents
 
-arrangeForeignContentPath :: Path Abs Dir -> Path Abs Dir -> App FilePath
-arrangeForeignContentPath tarRootDir foreignDir =
-  toFilePath <$> Path.stripPrefix tarRootDir foreignDir
+getRelFilePath :: Path Abs Dir -> Path Abs a -> App FilePath
+getRelFilePath baseDir path =
+  toFilePath <$> Path.stripPrefix baseDir path
 
-arrangeExtraContentPath :: Path Abs Dir -> SomePath -> App FilePath
-arrangeExtraContentPath tarRootDir somePath =
+arrangeExtraContentPath :: Path Abs Dir -> SomePath Abs -> App FilePath
+arrangeExtraContentPath baseDir somePath =
   case somePath of
     Left dirPath ->
-      toFilePath <$> Path.stripPrefix tarRootDir dirPath
+      getRelFilePath baseDir dirPath
     Right filePath ->
-      toFilePath <$> Path.stripPrefix tarRootDir filePath
+      getRelFilePath baseDir filePath
 
 parseSourcePathRelativeToSourceDir :: FilePath -> App (Path Rel File)
 parseSourcePathRelativeToSourceDir filePathStr = do

--- a/src/Scene/Link.hs
+++ b/src/Scene/Link.hs
@@ -34,7 +34,8 @@ link' target mainModule sourceList = do
 getForeignLibraries :: Module -> App [Path Abs File]
 getForeignLibraries targetModule = do
   let foreignDirList = moduleForeignDirList targetModule
-  concat <$> mapM getForeignLibraries' foreignDirList
+  let moduleRootDir = getModuleRootDir targetModule
+  concat <$> mapM (getForeignLibraries' . (moduleRootDir </>)) foreignDirList
 
 getForeignLibraries' :: Path Abs Dir -> App [Path Abs File]
 getForeignLibraries' foreignDir = do

--- a/src/Scene/Module/GetExistingVersions.hs
+++ b/src/Scene/Module/GetExistingVersions.hs
@@ -10,11 +10,11 @@ import Path.IO
 
 getExistingVersions :: Module -> App [PV.PackageVersion]
 getExistingVersions targetModule = do
-  let releaseDir = getReleaseDir targetModule
-  b <- doesDirExist releaseDir
+  let archiveDir = getArchiveDir targetModule
+  b <- doesDirExist archiveDir
   if not b
     then return []
     else do
-      (_, releaseFiles) <- listDir releaseDir
-      basenameList <- mapM getBaseName releaseFiles
+      (_, archiveFiles) <- listDir archiveDir
+      basenameList <- mapM getBaseName archiveFiles
       return $ sort $ mapMaybe PV.reflect basenameList

--- a/src/Scene/Module/Reflect.hs
+++ b/src/Scene/Module/Reflect.hs
@@ -55,12 +55,14 @@ fromFilePath :: MID.ModuleID -> Path Abs File -> App Module
 fromFilePath moduleID moduleFilePath = do
   (m, treeList) <- Tree.reflect moduleFilePath
   sourceDirTree <- liftEither $ Tree.accessOrEmpty m keySource treeList >>= Tree.extract
+  releaseDirTree <- liftEither $ Tree.accessOrEmpty m keyRelease treeList >>= Tree.extract
   (_, entryPointTree) <- liftEither $ Tree.accessOrEmpty m keyTarget treeList >>= mapM Tree.toDictionary
   dependencyTree <- liftEither $ Tree.accessOrEmpty m keyDependency treeList >>= mapM Tree.toDictionary
   (_, extraContentTree) <- liftEither $ Tree.accessOrEmpty m keyExtraContent treeList
   (_, antecedentTree) <- liftEither $ Tree.accessOrEmpty m keyAntecedent treeList
   (_, foreignDirListTree) <- liftEither $ Tree.accessOrEmpty m keyForeign treeList
   let moduleRootDir = parent moduleFilePath
+  releaseDir <- interpretDirPath releaseDirTree
   sourceDir <- interpretDirPath sourceDirTree
   target <- mapM interpretRelFilePath entryPointTree
   dependency <- interpretDependencyDict dependencyTree
@@ -70,6 +72,7 @@ fromFilePath moduleID moduleFilePath = do
   return
     Module
       { moduleID = moduleID,
+        moduleReleaseDir = releaseDir,
         moduleSourceDir = sourceDir,
         moduleTarget = Map.mapKeys Target target,
         moduleDependency = dependency,

--- a/src/Scene/Module/Reflect.hs
+++ b/src/Scene/Module/Reflect.hs
@@ -65,7 +65,7 @@ fromFilePath moduleID moduleFilePath = do
   dependency <- interpretDependencyDict dependencyTree
   extraContents <- mapM (interpretExtraPath moduleRootDir) extraContentTree
   antecedents <- mapM interpretAntecedent antecedentTree
-  foreignDirList <- mapM (interpretForeign moduleRootDir) foreignDirListTree
+  foreignDirList <- mapM (interpretDirPath moduleRootDir) foreignDirListTree
   return
     Module
       { moduleID = moduleID,
@@ -129,8 +129,8 @@ interpretAntecedent ens = do
   (_, digestText) <- liftEither $ Tree.toString ens
   return $ ModuleDigest digestText
 
-interpretForeign :: Path Abs Dir -> Tree.Tree -> App (Path Abs Dir)
-interpretForeign moduleRootDir ens = do
+interpretDirPath :: Path Abs Dir -> Tree.Tree -> App (Path Abs Dir)
+interpretDirPath moduleRootDir ens = do
   (_, pathText) <- liftEither $ Tree.toString ens
   Path.resolveDir moduleRootDir $ T.unpack pathText
 

--- a/src/Scene/Module/Reflect.hs
+++ b/src/Scene/Module/Reflect.hs
@@ -56,6 +56,7 @@ fromFilePath moduleID moduleFilePath = do
   (m, treeList) <- Tree.reflect moduleFilePath
   sourceDirTree <- liftEither $ Tree.extractValueByKey m keySource treeList
   archiveDirTree <- liftEither $ Tree.extractValueByKey m keyArchive treeList
+  buildDirTree <- liftEither $ Tree.extractValueByKey m keyBuild treeList
   (_, entryPointTree) <- liftEither $ Tree.accessOrEmpty m keyTarget treeList >>= mapM Tree.toDictionary
   dependencyTree <- liftEither $ Tree.accessOrEmpty m keyDependency treeList >>= mapM Tree.toDictionary
   (_, extraContentTree) <- liftEither $ Tree.accessOrEmpty m keyExtraContent treeList
@@ -63,6 +64,7 @@ fromFilePath moduleID moduleFilePath = do
   (_, foreignDirListTree) <- liftEither $ Tree.accessOrEmpty m keyForeign treeList
   let moduleRootDir = parent moduleFilePath
   archiveDir <- interpretDirPath archiveDirTree
+  buildDir <- interpretDirPath buildDirTree
   sourceDir <- interpretDirPath sourceDirTree
   target <- mapM interpretRelFilePath entryPointTree
   dependency <- interpretDependencyDict dependencyTree
@@ -73,6 +75,7 @@ fromFilePath moduleID moduleFilePath = do
     Module
       { moduleID = moduleID,
         moduleArchiveDir = archiveDir,
+        moduleBuildDir = buildDir,
         moduleSourceDir = sourceDir,
         moduleTarget = Map.mapKeys Target target,
         moduleDependency = dependency,

--- a/src/Scene/Module/Reflect.hs
+++ b/src/Scene/Module/Reflect.hs
@@ -55,14 +55,14 @@ fromFilePath :: MID.ModuleID -> Path Abs File -> App Module
 fromFilePath moduleID moduleFilePath = do
   (m, treeList) <- Tree.reflect moduleFilePath
   sourceDirTree <- liftEither $ Tree.accessOrEmpty m keySource treeList >>= Tree.extract
-  releaseDirTree <- liftEither $ Tree.accessOrEmpty m keyRelease treeList >>= Tree.extract
+  archiveDirTree <- liftEither $ Tree.accessOrEmpty m keyArchive treeList >>= Tree.extract
   (_, entryPointTree) <- liftEither $ Tree.accessOrEmpty m keyTarget treeList >>= mapM Tree.toDictionary
   dependencyTree <- liftEither $ Tree.accessOrEmpty m keyDependency treeList >>= mapM Tree.toDictionary
   (_, extraContentTree) <- liftEither $ Tree.accessOrEmpty m keyExtraContent treeList
   (_, antecedentTree) <- liftEither $ Tree.accessOrEmpty m keyAntecedent treeList
   (_, foreignDirListTree) <- liftEither $ Tree.accessOrEmpty m keyForeign treeList
   let moduleRootDir = parent moduleFilePath
-  releaseDir <- interpretDirPath releaseDirTree
+  archiveDir <- interpretDirPath archiveDirTree
   sourceDir <- interpretDirPath sourceDirTree
   target <- mapM interpretRelFilePath entryPointTree
   dependency <- interpretDependencyDict dependencyTree
@@ -72,7 +72,7 @@ fromFilePath moduleID moduleFilePath = do
   return
     Module
       { moduleID = moduleID,
-        moduleReleaseDir = releaseDir,
+        moduleArchiveDir = archiveDir,
         moduleSourceDir = sourceDir,
         moduleTarget = Map.mapKeys Target target,
         moduleDependency = dependency,

--- a/src/Scene/Module/Reflect.hs
+++ b/src/Scene/Module/Reflect.hs
@@ -55,12 +55,14 @@ getModule m moduleID locatorText = do
 fromFilePath :: MID.ModuleID -> Path Abs File -> App Module
 fromFilePath moduleID moduleFilePath = do
   (m, treeList) <- Tree.reflect moduleFilePath
+  sourceDirTree <- liftEither $ Tree.accessOrEmpty m keySource treeList >>= Tree.extract
   (_, entryPointTree) <- liftEither $ Tree.accessOrEmpty m keyTarget treeList >>= mapM Tree.toDictionary
   dependencyTree <- liftEither $ Tree.accessOrEmpty m keyDependency treeList >>= mapM Tree.toDictionary
   (_, extraContentTree) <- liftEither $ Tree.accessOrEmpty m keyExtraContent treeList
   (_, antecedentTree) <- liftEither $ Tree.accessOrEmpty m keyAntecedent treeList
   (_, foreignDirListTree) <- liftEither $ Tree.accessOrEmpty m keyForeign treeList
   let moduleRootDir = parent moduleFilePath
+  sourceDir <- interpretDirPath sourceDirTree
   target <- mapM (interpretRelFilePath moduleID) entryPointTree
   dependency <- interpretDependencyDict dependencyTree
   extraContents <- mapM (interpretExtraPath moduleRootDir) extraContentTree
@@ -69,6 +71,7 @@ fromFilePath moduleID moduleFilePath = do
   return
     Module
       { moduleID = moduleID,
+        moduleSourceDir = sourceDir,
         moduleTarget = Map.mapKeys Target target,
         moduleDependency = dependency,
         moduleExtraContents = extraContents,

--- a/src/Scene/Module/Reflect.hs
+++ b/src/Scene/Module/Reflect.hs
@@ -54,8 +54,8 @@ getModule m moduleID locatorText = do
 fromFilePath :: MID.ModuleID -> Path Abs File -> App Module
 fromFilePath moduleID moduleFilePath = do
   (m, treeList) <- Tree.reflect moduleFilePath
-  sourceDirTree <- liftEither $ Tree.accessOrEmpty m keySource treeList >>= Tree.extract
-  archiveDirTree <- liftEither $ Tree.accessOrEmpty m keyArchive treeList >>= Tree.extract
+  sourceDirTree <- liftEither $ Tree.extractValueByKey m keySource treeList
+  archiveDirTree <- liftEither $ Tree.extractValueByKey m keyArchive treeList
   (_, entryPointTree) <- liftEither $ Tree.accessOrEmpty m keyTarget treeList >>= mapM Tree.toDictionary
   dependencyTree <- liftEither $ Tree.accessOrEmpty m keyDependency treeList >>= mapM Tree.toDictionary
   (_, extraContentTree) <- liftEither $ Tree.accessOrEmpty m keyExtraContent treeList
@@ -108,7 +108,7 @@ interpretDependencyDict (m, dep) = do
           <> "` cannot be used as an alias of a module"
     (_, urlTreeList) <- liftEither $ Tree.access mDep "mirror" depTree
     urlList <- liftEither $ mapM (Tree.toString >=> return . snd) urlTreeList
-    (_, digest) <- liftEither $ Tree.access mDep "digest" depTree >>= Tree.extract >>= Tree.toString
+    (_, digest) <- liftEither $ Tree.extractValueByKey mDep "digest" depTree >>= Tree.toString
     return (ModuleAlias k', (map ModuleURL urlList, ModuleDigest digest))
   return $ Map.fromList items
 

--- a/src/Scene/Module/UpdateAntecedents.hs
+++ b/src/Scene/Module/UpdateAntecedents.hs
@@ -27,9 +27,9 @@ updateAntecedents newVersion targetModule = do
 
 getPackagePath :: Module -> PV.PackageVersion -> App (Path Abs File)
 getPackagePath targetModule ver = do
-  let releaseDir = getReleaseDir targetModule
-  let releaseName = PV.reify ver
-  Path.resolveFile releaseDir $ T.unpack $ releaseName <> packageFileExtension
+  let archiveDir = getArchiveDir targetModule
+  let archiveName = PV.reify ver
+  Path.resolveFile archiveDir $ T.unpack $ archiveName <> packageFileExtension
 
 getDigest :: Module -> PV.PackageVersion -> App ModuleDigest
 getDigest targetModule ver = do

--- a/src/Scene/New.hs
+++ b/src/Scene/New.hs
@@ -39,6 +39,7 @@ constructDefaultModule name = do
   return $
     Module
       { moduleID = MID.Main,
+        moduleSourceDir = sourceRelDir,
         moduleTarget =
           Map.fromList
             [ ( Target name,

--- a/src/Scene/New.hs
+++ b/src/Scene/New.hs
@@ -38,7 +38,7 @@ constructDefaultModule name = do
   return $
     Module
       { moduleID = MID.Main,
-        moduleReleaseDir = releaseRelDir,
+        moduleArchiveDir = archiveRelDir,
         moduleSourceDir = sourceRelDir,
         moduleTarget =
           Map.fromList

--- a/src/Scene/New.hs
+++ b/src/Scene/New.hs
@@ -16,7 +16,6 @@ import Entity.Const
 import Entity.Module
 import Entity.ModuleID qualified as MID
 import Entity.SourceLocator qualified as SL
-import Entity.StrictGlobalLocator qualified as SGL
 import Entity.Target
 import Path (parent, (</>))
 
@@ -43,10 +42,7 @@ constructDefaultModule name = do
         moduleTarget =
           Map.fromList
             [ ( Target name,
-                SGL.StrictGlobalLocator
-                  { SGL.moduleID = MID.Main,
-                    SGL.sourceLocator = SL.SourceLocator mainFile
-                  }
+                SL.SourceLocator mainFile
               )
             ],
         moduleDependency = Map.empty,
@@ -68,6 +64,5 @@ createMainFile :: App ()
 createMainFile = do
   newModule <- Module.getMainModule
   Path.ensureDir $ getSourceDir newModule
-  forM_ (Map.elems $ moduleTarget newModule) $ \sgl -> do
-    mainFilePath <- Module.getSourcePath sgl
+  forM_ (getTargetPathList newModule) $ \mainFilePath -> do
     Path.writeText mainFilePath "define main(): unit {\n  print(\"Hello, world!\\n\")\n}\n"

--- a/src/Scene/New.hs
+++ b/src/Scene/New.hs
@@ -39,6 +39,7 @@ constructDefaultModule name = do
     Module
       { moduleID = MID.Main,
         moduleArchiveDir = archiveRelDir,
+        moduleBuildDir = buildRelDir,
         moduleSourceDir = sourceRelDir,
         moduleTarget =
           Map.fromList

--- a/src/Scene/New.hs
+++ b/src/Scene/New.hs
@@ -38,6 +38,7 @@ constructDefaultModule name = do
   return $
     Module
       { moduleID = MID.Main,
+        moduleReleaseDir = releaseRelDir,
         moduleSourceDir = sourceRelDir,
         moduleTarget =
           Map.fromList

--- a/test/meta/module.ens
+++ b/test/meta/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (meta "meta.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/adder/module.ens
+++ b/test/misc/adder/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (adder "adder.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/args/module.ens
+++ b/test/misc/args/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (args "args.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/calc/module.ens
+++ b/test/misc/calc/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (calc "calc.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/check/module.ens
+++ b/test/misc/check/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (check "check.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/codata-basic/module.ens
+++ b/test/misc/codata-basic/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (codata-basic "codata-basic.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/complex-cancel/module.ens
+++ b/test/misc/complex-cancel/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (complex-cancel "complex-cancel.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/ex-falso/module.ens
+++ b/test/misc/ex-falso/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (ex-falso "ex-falso.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/fact/module.ens
+++ b/test/misc/fact/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (fact "fact.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/file/module.ens
+++ b/test/misc/file/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (file "file.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/fix-and-free-vars/module.ens
+++ b/test/misc/fix-and-free-vars/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (fix-and-free-vars "fix-and-free-vars.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/fold-tails/module.ens
+++ b/test/misc/fold-tails/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (fold-tails "fold-tails.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/foreign/module.ens
+++ b/test/misc/foreign/module.ens
@@ -1,7 +1,10 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (foreign "foreign.nt"))
-(foreign "foreign")
+(foreign "foreign/")
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/hello/module.ens
+++ b/test/misc/hello/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (hello "hello.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/lambda-list/module.ens
+++ b/test/misc/lambda-list/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (lambda-list "lambda-list.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/mutable/module.ens
+++ b/test/misc/mutable/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (mutable "mutable.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/nat-fact/module.ens
+++ b/test/misc/nat-fact/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (nat-fact "nat-fact.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/nat-list/module.ens
+++ b/test/misc/nat-list/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (nat-list "nat-list.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/nested-wildcard/module.ens
+++ b/test/misc/nested-wildcard/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (nested-wildcard "nested-wildcard.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/misc/print-float/module.ens
+++ b/test/misc/print-float/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (print-float "print-float.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/pfds/binary-search-tree/module.ens
+++ b/test/pfds/binary-search-tree/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (binary-search-tree "binary-search-tree.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/pfds/binomial-heap/module.ens
+++ b/test/pfds/binomial-heap/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (binomial-heap "binomial-heap.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/pfds/custom-stack/module.ens
+++ b/test/pfds/custom-stack/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (custom-stack "custom-stack.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/pfds/finite-map/module.ens
+++ b/test/pfds/finite-map/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (finite-map "finite-map.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/pfds/leftist-heap/module.ens
+++ b/test/pfds/leftist-heap/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (leftist-heap "leftist-heap.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/pfds/naive-queue/module.ens
+++ b/test/pfds/naive-queue/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (naive-queue "naive-queue.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/pfds/pairing-heap/module.ens
+++ b/test/pfds/pairing-heap/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (pairing-heap "pairing-heap.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/pfds/random-access-list/module.ens
+++ b/test/pfds/random-access-list/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (random-access-list "random-access-list.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/pfds/red-black-tree/module.ens
+++ b/test/pfds/red-black-tree/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (red-black-tree "red-black-tree.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/pfds/splay-heap/module.ens
+++ b/test/pfds/splay-heap/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (splay-heap "splay-heap.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/pfds/stack/module.ens
+++ b/test/pfds/stack/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (stack "stack.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/pfds/stream/module.ens
+++ b/test/pfds/stream/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (stream "stream.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/statement/define/module.ens
+++ b/test/statement/define/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (define "define.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/statement/empty-import-export/module.ens
+++ b/test/statement/empty-import-export/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (empty-import-export "empty-import-export.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/statement/import-names/module.ens
+++ b/test/statement/import-names/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (import-names "import-names.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/statement/resource-basic/module.ens
+++ b/test/statement/resource-basic/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (resource-basic "resource-basic.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/statement/variant-struct/module.ens
+++ b/test/statement/variant-struct/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (variant-struct "variant-struct.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/term/flow/module.ens
+++ b/test/term/flow/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (flow "flow.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/term/noema/module.ens
+++ b/test/term/noema/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (noema "noema.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/term/pi/module.ens
+++ b/test/term/pi/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (pi "pi.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/term/prim/module.ens
+++ b/test/term/prim/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (prim "prim.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/term/tau/module.ens
+++ b/test/term/tau/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (tau "tau.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/term/unitary/module.ens
+++ b/test/term/unitary/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (unitary "unitary.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/term/var/module.ens
+++ b/test/term/var/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (var "var.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/term/variant/module.ens
+++ b/test/term/variant/module.ens
@@ -1,6 +1,9 @@
+(archive "archive/")
+(build "build/")
+(source "source/")
 (target
   (variant "variant.nt"))
 (dependency
   (core
-    (digest "1H8FxjtehDdL-ZWEypx1gU5Ocag5p-QU_I-Rkdo6ePo=")
-    (mirror "https://github.com/vekatze/neut-core/raw/main/release/0-2-10.tar.zst")))
+    (digest "IhcsnZ0Di0GLjZdhKYORuu7HruStyZA1u9xuq57Ugj4=")
+    (mirror "https://github.com/vekatze/neut-core/raw/main/archive/0-2-11.tar.zst")))

--- a/test/test-darwin.sh
+++ b/test/test-darwin.sh
@@ -25,7 +25,7 @@ for target_dir in "$@"; do
       NEUT_TARGET_ARCH=$TARGET_ARCH $NEUT clean
       NEUT_TARGET_ARCH=$TARGET_ARCH NEUT_CLANG=$CLANG_PATH $NEUT build --clang-option $clang_option
       # https://stackoverflow.com/questions/64126942
-      output=$(MallocNanoZone=0 ASAN_OPTIONS=detect_leaks=1 LSAN_OPTIONS=suppressions=$LSAN_FILE ./.build/$TARGET_ARCH-darwin/compiler-$COMPILER_VERSION/build-option-$digest/executable/$(basename $i) 2>&1 > actual)
+      output=$(MallocNanoZone=0 ASAN_OPTIONS=detect_leaks=1 LSAN_OPTIONS=suppressions=$LSAN_FILE ./build/$TARGET_ARCH-darwin/compiler-$COMPILER_VERSION/build-option-$digest/executable/$(basename $i) 2>&1 > actual)
       last_exit_code=$?
       if [ $last_exit_code -ne 0 ]; then
         echo "\033[1;31merror:\033[0m a test failed: $(basename $i)\n$output"

--- a/test/test-linux.sh
+++ b/test/test-linux.sh
@@ -23,7 +23,7 @@ for target_dir in "$@"; do
       exit_code=0
       NEUT_TARGET_ARCH=$TARGET_ARCH $NEUT clean
       NEUT_TARGET_ARCH=$TARGET_ARCH $NEUT build --clang-option $clang_option
-      output=$(ASAN_OPTIONS=detect_leaks=1 ./.build/$TARGET_ARCH-linux/compiler-$COMPILER_VERSION/build-option-$digest/executable/$(basename $i) 2>&1 > actual)
+      output=$(ASAN_OPTIONS=detect_leaks=1 ./build/$TARGET_ARCH-linux/compiler-$COMPILER_VERSION/build-option-$digest/executable/$(basename $i) 2>&1 > actual)
       last_exit_code=$?
       if [ $last_exit_code -ne 0 ]; then
         printf "\033[1;31merror:\033[0m a test failed: $(basename $i)\n$output\n"

--- a/test/update-core.sh
+++ b/test/update-core.sh
@@ -9,7 +9,7 @@ for target_dir in "$@"; do
   for i in $(find . -d 1 -type d | sort); do
     cd $i
     echo $(basename $i)
-    neut add core https://github.com/vekatze/neut-core/raw/main/release/${NEW_VERSION}.tar.zst
+    neut add core https://github.com/vekatze/neut-core/raw/main/archive/${NEW_VERSION}.tar.zst
     cd ..
   done
 done


### PR DESCRIPTION
This PR parameterizes module-related directories (`source/`, `archive/`, and `build/`). These directories must be specified in `module.ens` as follows:

```
...
(archive "archive/")
(build "build/")
(source "source/")
...
```

The paths of these directories are relative to the root of the module.