### PR TITLE
Introduce module-based way of defining/using import prefixes

### DIFF
--- a/book/src/basics-of-modules.md
+++ b/book/src/basics-of-modules.md
@@ -22,7 +22,7 @@ When running compilation, every module is marked as "main" or "library". The mai
 A module can use other modules. Such module dependencies can be added using `neut add`:
 
 ```sh
-neut add core https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst
+neut add core https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst
 ```
 
 By running the code above, the specified tarball is downloaded into `~/.cache/neut/library`:
@@ -30,20 +30,20 @@ By running the code above, the specified tarball is downloaded into `~/.cache/ne
 ```sh
 ls ~/.cache/neut/library
 # => ...
-#    DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo=
+#    fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g=
 #    ...
 ```
 
-where the `DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo=` is the digest of the module. Also, the module information is added to the current module's `module.ens`:
+where the `fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g=` is the digest of the module. Also, the module information is added to the current module's `module.ens`:
 
 ```ens
 {
   // ...
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/book/src/importing-names.md
+++ b/book/src/importing-names.md
@@ -119,31 +119,38 @@ core.text.io.get-line
 DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo=.text.io.get-line
 ```
 
-## Qualified Import
+## Module-Based Qualified Import
 
-Names in other files can be qualified as follows:
+Names can also be imported via "prefixes". You can define prefixes in your `module.ens`:
+
+```ens
+{
+  // ...
+  prefix {
+    hey "this.foo.yo" // `hey` is a prefix of `this.foo.yo`
+    hoo "this.bar"    // `hoo` is a prefix of `this.bar`
+  }
+}
+```
+
+These prefixes can then be used in source files of your module:
 
 ```neut
 import {
-- this.foo.yo => i // create an alias `i ~> this.foo.yo`
-- this.bar [f] => bar // import `f` from `this.bar` and create an alias `bar ~> this.bar`
+- hey // "hey.*" ~> "this.foo.yo.*"
+- hoo // "hoo.*" ~> "this.bar.*"
 }
 
 define main(): int {
-  i.some-func() // resolve: `i.some-func()` ~> `this.foo.yo.some-func()`
+  let _ = hey.func1() in  // `hey.func1()` ~> `this.foo.yo.func1()`
+  let _ = hoo.func2() in  // `hoo.func2()` ~> `this.bar.func2()`
+  ..
 }
 ```
 
-Overlapping aliases are prohibited:
+This module-based approach forces us to use prefixes in a consistent manner within a module.
 
-```neut
-import {
-- this.foo.item => abc
-// the below results in an error since the alias `abc` is already defined
-- this.bar.buz => abc
-}
-
-```
+---
 
 By the way, when you define an ADT, I recommend you *not* to prefix constructors like the below:
 
@@ -167,9 +174,18 @@ data term {
 
 and use them via qualified import:
 
+```ens
+{
+  // ...
+  prefix {
+    term "this.foo.bar.term"
+  }
+}
+```
+
 ```neut
 import {
-- this.foo.bar.term => term
+- term
 }
 
 define buz() {

--- a/book/src/importing-names.md
+++ b/book/src/importing-names.md
@@ -77,9 +77,9 @@ Suppose that you have added a library module to your module:
   // ...
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }
@@ -106,7 +106,7 @@ Here, the module alias of `core.text.io` is `core`, and the relative path is `te
 ```sh
 core => DIGEST_OF_THE_LIBRARY
 
-# core => DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo=
+# core => fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g=
 ```
 
 and do the following name resolution:
@@ -116,7 +116,7 @@ core.text.io.get-line
 
 ↓
 
-DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo=.text.io.get-line
+fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g=.text.io.get-line
 ```
 
 ## Module-Based Qualified Import

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -32,8 +32,8 @@ We also need to register the URL and the digest of the core module (standard lib
 
 ```sh
 # add the below to your bashrc, zshrc, etc.
-export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
-export NEUT_CORE_MODULE_DIGEST="DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+export NEUT_CORE_MODULE_DIGEST="fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
 ```
 
 Now, let's create a sample project and build it to check if your installation is correct:

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -65,8 +65,8 @@ An example scenario:
 
 ```sh
 # setting up the core module (i.e. standard library)
-export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
-export NEUT_CORE_MODULE_DIGEST="DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+export NEUT_CORE_MODULE_DIGEST="fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
 
 # get the compiler (choose one)
 curl -L -o ~/.local/bin/neut https://github.com/vekatze/neut/releases/latest/download/neut-arm64-darwin

--- a/src/Scene/New.hs
+++ b/src/Scene/New.hs
@@ -51,7 +51,8 @@ constructDefaultModule name = do
         moduleExtraContents = [],
         moduleAntecedents = [],
         moduleLocation = moduleRootDir </> moduleFile,
-        moduleForeignDirList = []
+        moduleForeignDirList = [],
+        modulePrefixMap = Map.empty
       }
 
 createModuleFile :: App ()

--- a/test/meta/module.ens
+++ b/test/meta/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/adder/module.ens
+++ b/test/misc/adder/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/args/module.ens
+++ b/test/misc/args/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/calc/module.ens
+++ b/test/misc/calc/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/check/module.ens
+++ b/test/misc/check/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/codata-basic/module.ens
+++ b/test/misc/codata-basic/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/complex-cancel/module.ens
+++ b/test/misc/complex-cancel/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/ex-falso/module.ens
+++ b/test/misc/ex-falso/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/fact/module.ens
+++ b/test/misc/fact/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/file/module.ens
+++ b/test/misc/file/module.ens
@@ -1,11 +1,15 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
+  }
+  prefix {
+    FF "core.file.flag"
+    FM "core.file.mode"
   }
   target {
     file "file.nt"

--- a/test/misc/file/source/file.nt
+++ b/test/misc/file/source/file.nt
@@ -1,6 +1,6 @@
 import {
-- core.file.flag => FF
-- core.file.mode => FM
+- FF
+- FM
 }
 
 define main(): unit {

--- a/test/misc/fix-and-free-vars/module.ens
+++ b/test/misc/fix-and-free-vars/module.ens
@@ -1,11 +1,15 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
+  }
+  prefix {
+    L "core.list"
+    V "core.data.vector"
   }
   target {
     fix-and-free-vars "fix-and-free-vars.nt"

--- a/test/misc/fix-and-free-vars/source/fix-and-free-vars.nt
+++ b/test/misc/fix-and-free-vars/source/fix-and-free-vars.nt
@@ -1,7 +1,7 @@
 import {
 - core.bool
-- core.list => L
-- core.data.vector => V
+- L
+- V
 }
 
 data list() {

--- a/test/misc/fold-tails/module.ens
+++ b/test/misc/fold-tails/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/foreign/module.ens
+++ b/test/misc/foreign/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/hello/module.ens
+++ b/test/misc/hello/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/lambda-list/module.ens
+++ b/test/misc/lambda-list/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/mutable/module.ens
+++ b/test/misc/mutable/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/mutable/source/mutable.nt
+++ b/test/misc/mutable/source/mutable.nt
@@ -1,6 +1,6 @@
 import {
-- core.list => L
-- core.data.vector => V
+- core.list
+- core.data.vector
 }
 
 data list(a: tau) {

--- a/test/misc/nat-fact/module.ens
+++ b/test/misc/nat-fact/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/nat-list/module.ens
+++ b/test/misc/nat-list/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/misc/nested-wildcard/module.ens
+++ b/test/misc/nested-wildcard/module.ens
@@ -1,11 +1,16 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
+  }
+  prefix {
+    a "this.arith"
+    c "this.compare"
+    d "this.double"
   }
   target {
     nested-wildcard "nested-wildcard.nt"

--- a/test/misc/nested-wildcard/source/double.nt
+++ b/test/misc/nested-wildcard/source/double.nt
@@ -1,8 +1,8 @@
 import {
 - core.data.semigroup [semigroup, Semigroup]
 - core.data.monoid [monoid, Monoid]
-- this.arith => a
-- this.compare => c
+- a
+- c
 }
 
 alias double { float64 }

--- a/test/misc/nested-wildcard/source/nested-wildcard.nt
+++ b/test/misc/nested-wildcard/source/nested-wildcard.nt
@@ -1,5 +1,5 @@
 import {
-- this.double => d
+- d
 - core.data.monoid [Monoid]
 - this.arith [Arith]
 }

--- a/test/misc/print-float/module.ens
+++ b/test/misc/print-float/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/pfds/binary-search-tree/module.ens
+++ b/test/pfds/binary-search-tree/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/pfds/binary-search-tree/source/binary-search-tree.nt
+++ b/test/pfds/binary-search-tree/source/binary-search-tree.nt
@@ -1,5 +1,5 @@
 import {
-- core.text => T
+- core.text
 }
 
 data order {

--- a/test/pfds/binomial-heap/module.ens
+++ b/test/pfds/binomial-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/pfds/custom-stack/module.ens
+++ b/test/pfds/custom-stack/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/pfds/custom-stack/source/custom-stack.nt
+++ b/test/pfds/custom-stack/source/custom-stack.nt
@@ -1,6 +1,6 @@
 import {
-- core.list => L
-- core.text => T
+- core.list
+- core.text
 }
 
 data custom-stack(a) {

--- a/test/pfds/finite-map/module.ens
+++ b/test/pfds/finite-map/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/pfds/finite-map/source/finite-map.nt
+++ b/test/pfds/finite-map/source/finite-map.nt
@@ -1,5 +1,5 @@
 import {
-- core.text => T
+- core.text
 }
 
 data order {

--- a/test/pfds/leftist-heap/module.ens
+++ b/test/pfds/leftist-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/pfds/leftist-heap/source/leftist-heap.nt
+++ b/test/pfds/leftist-heap/source/leftist-heap.nt
@@ -1,5 +1,5 @@
 import {
-- core.text => T
+- core.text
 }
 
 data order {

--- a/test/pfds/naive-queue/module.ens
+++ b/test/pfds/naive-queue/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/pfds/naive-queue/source/naive-queue.nt
+++ b/test/pfds/naive-queue/source/naive-queue.nt
@@ -1,6 +1,6 @@
 import {
-- core.except => S
-- core.text => T
+- core.except
+- core.text
 - core.list [list, reverse]
 }
 

--- a/test/pfds/pairing-heap/module.ens
+++ b/test/pfds/pairing-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/pfds/random-access-list/module.ens
+++ b/test/pfds/random-access-list/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/pfds/red-black-tree/module.ens
+++ b/test/pfds/red-black-tree/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/pfds/splay-heap/module.ens
+++ b/test/pfds/splay-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/pfds/stack/module.ens
+++ b/test/pfds/stack/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/pfds/stack/source/stack.nt
+++ b/test/pfds/stack/source/stack.nt
@@ -1,6 +1,6 @@
 import {
-- core.list => L
-- core.text => T
+- core.list
+- core.text
 }
 
 data stack(a) {

--- a/test/pfds/stream/module.ens
+++ b/test/pfds/stream/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/pfds/stream/source/stream.nt
+++ b/test/pfds/stream/source/stream.nt
@@ -1,7 +1,7 @@
 import {
 - core.bool
-- core.list => L
-- core.text => T
+- core.list
+- core.text
 }
 
 data stream-cell(a) {

--- a/test/statement/define/module.ens
+++ b/test/statement/define/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/statement/empty-import-export/module.ens
+++ b/test/statement/empty-import-export/module.ens
@@ -1,11 +1,14 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
+  }
+  prefix {
+    B "this.bar"
   }
   target {
     empty-import-export "empty-import-export.nt"

--- a/test/statement/empty-import-export/source/empty-import-export.nt
+++ b/test/statement/empty-import-export/source/empty-import-export.nt
@@ -1,6 +1,6 @@
 import {
 - this.foo
-- this.bar => B
+- B
 }
 
 define main(): unit {

--- a/test/statement/import-names/module.ens
+++ b/test/statement/import-names/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/statement/resource-basic/module.ens
+++ b/test/statement/resource-basic/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/statement/variant-struct/module.ens
+++ b/test/statement/variant-struct/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/term/flow/module.ens
+++ b/test/term/flow/module.ens
@@ -1,11 +1,14 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
+  }
+  prefix {
+    ext "core.external"
   }
   target {
     flow "flow.nt"

--- a/test/term/flow/source/flow.nt
+++ b/test/term/flow/source/flow.nt
@@ -1,5 +1,5 @@
 import {
-- core.external => ext
+- ext
 }
 
 define test-syntax(): unit {

--- a/test/term/noema/module.ens
+++ b/test/term/noema/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/term/pi/module.ens
+++ b/test/term/pi/module.ens
@@ -1,11 +1,15 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
+  }
+  prefix {
+    term "this.pi-term"
+    keyword "this.pi-keyword"
   }
   target {
     pi "pi.nt"

--- a/test/term/pi/source/pi.nt
+++ b/test/term/pi/source/pi.nt
@@ -1,6 +1,6 @@
 import {
-- this.pi-term => term
-- this.pi-keyword => keyword
+- keyword
+- term
 }
 
 define test-syntax(): unit {

--- a/test/term/prim/module.ens
+++ b/test/term/prim/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/term/tau/module.ens
+++ b/test/term/tau/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/term/unitary/module.ens
+++ b/test/term/unitary/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }

--- a/test/term/var/module.ens
+++ b/test/term/var/module.ens
@@ -1,11 +1,14 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
+  }
+  prefix {
+    v "core.data.vector"
   }
   target {
     var "var.nt"

--- a/test/term/var/source/var.nt
+++ b/test/term/var/source/var.nt
@@ -1,5 +1,5 @@
 import {
-- core.data.vector => v
+- v
 }
 
 define identity(a: tau, x: a): a {

--- a/test/term/variant/module.ens
+++ b/test/term/variant/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "DNqh8NLdXliNwdwqRiWBh5T3rkt6tkw3o39c8olclPo="
+      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-3-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
       ]
     }
   }


### PR DESCRIPTION
This PR introduces a module-based way of defining/using import prefixes. Prefixes are now defined in `module.ens`:

```ens
{
  // ...
  prefix {
    tio "core.text.io"
  }
}
```

and used in source files as follows:

```neut
import {
- tio
}

define foo(): unit {
  tio.print("hello, world")
}
```

This change forces us (me) to define/use prefixes in a consistent manner within a module.

(I've always wanted something like this when writing Haskell)

---

This PR also deprecates the old, file-based way of qualified import:

```neut
// deprecated
import {
- core.text.io => tio 
}
```