### PR TITLE
Display constant-like terms as constants

### DIFF
--- a/src/Entity/Attr/Data.hs
+++ b/src/Entity/Attr/Data.hs
@@ -1,0 +1,14 @@
+module Entity.Attr.Data where
+
+import Data.Binary
+import Entity.DefiniteDescription qualified as DD
+import Entity.IsConstLike
+import GHC.Generics (Generic)
+
+data Attr = Attr
+  { consNameList :: [DD.DefiniteDescription],
+    isConstLike :: IsConstLike
+  }
+  deriving (Show, Generic)
+
+instance Binary Attr

--- a/src/Entity/Attr/DataIntro.hs
+++ b/src/Entity/Attr/DataIntro.hs
@@ -1,0 +1,17 @@
+module Entity.Attr.DataIntro where
+
+import Data.Binary
+import Entity.DefiniteDescription qualified as DD
+import Entity.Discriminant qualified as D
+import Entity.IsConstLike
+import GHC.Generics (Generic)
+
+data Attr = Attr
+  { dataName :: DD.DefiniteDescription,
+    consNameList :: [DD.DefiniteDescription],
+    discriminant :: D.Discriminant,
+    isConstLike :: IsConstLike
+  }
+  deriving (Show, Generic)
+
+instance Binary Attr

--- a/src/Entity/Attr/VarGlobal.hs
+++ b/src/Entity/Attr/VarGlobal.hs
@@ -1,0 +1,18 @@
+module Entity.Attr.VarGlobal (Attr (..), new) where
+
+import Data.Binary
+import Entity.ArgNum
+import Entity.IsConstLike
+import GHC.Generics (Generic)
+
+data Attr = Attr
+  { argNum :: ArgNum,
+    isConstLike :: IsConstLike
+  }
+  deriving (Show, Generic)
+
+instance Binary Attr
+
+new :: ArgNum -> Attr
+new argNum =
+  Attr {argNum = argNum, isConstLike = False}

--- a/src/Entity/DecisionTree.hs
+++ b/src/Entity/DecisionTree.hs
@@ -14,6 +14,7 @@ import Entity.DefiniteDescription qualified as DD
 import Entity.Discriminant qualified as D
 import Entity.Hint
 import Entity.Ident
+import Entity.IsConstLike
 import GHC.Generics (Generic)
 
 data DecisionTree a
@@ -27,6 +28,7 @@ type CaseList a = (DecisionTree a, [Case a])
 data Case a = Case
   { mCons :: Hint,
     consDD :: DD.DefiniteDescription,
+    isConstLike :: IsConstLike,
     disc :: D.Discriminant,
     dataArgs :: [(a, a)],
     consArgs :: [BinderF a],

--- a/src/Entity/OptimizableData.hs
+++ b/src/Entity/OptimizableData.hs
@@ -2,5 +2,4 @@ module Entity.OptimizableData (OptimizableData (..)) where
 
 data OptimizableData
   = Enum
-  | Nat
   | Unitary -- for newtype-ish optimization

--- a/src/Entity/Pattern.hs
+++ b/src/Entity/Pattern.hs
@@ -25,6 +25,7 @@ import Entity.Discriminant qualified as D
 import Entity.Error
 import Entity.Hint hiding (new)
 import Entity.Ident
+import Entity.IsConstLike
 
 data Pattern
   = Var Ident
@@ -34,6 +35,7 @@ data Pattern
 
 data ConsInfo = ConsInfo
   { consDD :: DD.DefiniteDescription,
+    isConstLike :: IsConstLike,
     disc :: D.Discriminant,
     dataArgNum :: AN.ArgNum,
     consArgNum :: AN.ArgNum,

--- a/src/Entity/RawTerm.hs
+++ b/src/Entity/RawTerm.hs
@@ -9,9 +9,10 @@ where
 import Control.Comonad.Cofree
 import Data.Text qualified as T
 import Entity.Annotation qualified as Annot
+import Entity.Attr.Data qualified as AttrD
+import Entity.Attr.DataIntro qualified as AttrDI
 import Entity.BaseName qualified as BN
 import Entity.DefiniteDescription qualified as DD
-import Entity.Discriminant qualified as D
 import Entity.Hint
 import Entity.HoleID
 import Entity.Key
@@ -35,14 +36,8 @@ data RawTermF a
   | PiIntro (RawLamKind a) [RawBinder a] a
   | PiElim a [a]
   | PiElimByKey Name [a] [(Hint, Key, a)] -- auxiliary syntax for key-call
-  | Data DD.DefiniteDescription [DD.DefiniteDescription] [a]
-  | DataIntro
-      DD.DefiniteDescription
-      DD.DefiniteDescription
-      [DD.DefiniteDescription]
-      D.Discriminant
-      [a]
-      [a]
+  | Data AttrD.Attr DD.DefiniteDescription [a]
+  | DataIntro AttrDI.Attr DD.DefiniteDescription [a] [a] -- (attr, consName, dataArgs, consArgs)
   | DataElim N.IsNoetic [a] (RP.RawPatternMatrix a)
   | Noema a
   | Embody a

--- a/src/Entity/Stuck.hs
+++ b/src/Entity/Stuck.hs
@@ -31,7 +31,7 @@ asStuckedTerm term =
   case term of
     m :< WT.Var x ->
       Just (VarLocal x, m :< Base)
-    m :< WT.VarGlobal g _ ->
+    m :< WT.VarGlobal _ g ->
       Just (VarGlobal g, m :< Base)
     m :< WT.Hole h es ->
       Just (Hole h es, m :< Base)

--- a/src/Entity/Term.hs
+++ b/src/Entity/Term.hs
@@ -3,7 +3,7 @@ module Entity.Term where
 import Control.Comonad.Cofree
 import Data.Binary
 import Data.IntMap qualified as IntMap
-import Entity.ArgNum
+import Entity.Attr.VarGlobal qualified as VG
 import Entity.Binder
 import Entity.DecisionTree qualified as DT
 import Entity.DefiniteDescription qualified as DD
@@ -23,7 +23,7 @@ type Term = Cofree TermF Hint
 data TermF a
   = Tau
   | Var Ident
-  | VarGlobal DD.DefiniteDescription ArgNum
+  | VarGlobal VG.Attr DD.DefiniteDescription
   | Pi [BinderF a] a
   | PiIntro (LamKindF a) [BinderF a] a
   | PiElim a [a]

--- a/src/Entity/Term.hs
+++ b/src/Entity/Term.hs
@@ -3,11 +3,12 @@ module Entity.Term where
 import Control.Comonad.Cofree
 import Data.Binary
 import Data.IntMap qualified as IntMap
-import Entity.Attr.VarGlobal qualified as VG
+import Entity.Attr.Data qualified as AttrD
+import Entity.Attr.DataIntro qualified as AttrDI
+import Entity.Attr.VarGlobal qualified as AttrVG
 import Entity.Binder
 import Entity.DecisionTree qualified as DT
 import Entity.DefiniteDescription qualified as DD
-import Entity.Discriminant qualified as D
 import Entity.Hint
 import Entity.Ident
 import Entity.Ident.Reify
@@ -23,12 +24,12 @@ type Term = Cofree TermF Hint
 data TermF a
   = Tau
   | Var Ident
-  | VarGlobal VG.Attr DD.DefiniteDescription
+  | VarGlobal AttrVG.Attr DD.DefiniteDescription
   | Pi [BinderF a] a
   | PiIntro (LamKindF a) [BinderF a] a
   | PiElim a [a]
-  | Data DD.DefiniteDescription [DD.DefiniteDescription] [a]
-  | DataIntro DD.DefiniteDescription DD.DefiniteDescription [DD.DefiniteDescription] D.Discriminant [a] [a]
+  | Data AttrD.Attr DD.DefiniteDescription [a]
+  | DataIntro AttrDI.Attr DD.DefiniteDescription [a] [a] -- (consName, dataArgs, consArgs)
   | DataElim N.IsNoetic [(Ident, a, a)] (DT.DecisionTree a)
   | Noema a
   | Embody a a
@@ -75,7 +76,7 @@ isValue term =
       True
     _ :< Data {} ->
       True
-    _ :< DataIntro _ _ _ _ dataArgs consArgs ->
+    _ :< DataIntro _ _ dataArgs consArgs ->
       all isValue $ dataArgs ++ consArgs
     _ :< Noema {} ->
       True

--- a/src/Entity/Term/Chain.hs
+++ b/src/Entity/Term/Chain.hs
@@ -111,13 +111,11 @@ chainOfCaseList tenv m (fallbackClause, clauseList) = do
 
 chainOfCase :: TM.TypeEnv -> Hint -> DT.Case TM.Term -> [BinderF TM.Term]
 chainOfCase tenv m decisionCase = do
-  case decisionCase of
-    DT.Cons _ _ _ dataArgs consArgs tree -> do
-      let (dataTerms, dataTypes) = unzip dataArgs
-      let xs1 = concatMap (chainOf' tenv) dataTerms
-      let xs2 = concatMap (chainOf' tenv) dataTypes
-      let xs3 = chainOfDecisionTree' tenv m consArgs tree
-      xs1 ++ xs2 ++ xs3
+  let (dataTerms, dataTypes) = unzip $ DT.dataArgs decisionCase
+  let xs1 = concatMap (chainOf' tenv) dataTerms
+  let xs2 = concatMap (chainOf' tenv) dataTypes
+  let xs3 = chainOfDecisionTree' tenv m (DT.consArgs decisionCase) (DT.cont decisionCase)
+  xs1 ++ xs2 ++ xs3
 
 nubFreeVariables :: [BinderF TM.Term] -> [BinderF TM.Term]
 nubFreeVariables =

--- a/src/Entity/Term/Chain.hs
+++ b/src/Entity/Term/Chain.hs
@@ -43,7 +43,7 @@ chainOf' tenv term =
       xs1 ++ xs2
     _ :< TM.Data _ _ es ->
       concatMap (chainOf' tenv) es
-    _ :< TM.DataIntro _ _ _ _ dataArgs consArgs ->
+    _ :< TM.DataIntro _ _ dataArgs consArgs ->
       concatMap (chainOf' tenv) $ dataArgs ++ consArgs
     m :< TM.DataElim _ xets tree -> do
       let (xs, es, ts) = unzip3 xets

--- a/src/Entity/Term/Weaken.hs
+++ b/src/Entity/Term/Weaken.hs
@@ -140,13 +140,15 @@ weakenCaseList (fallbackClause, clauseList) = do
   (fallbackClause', clauseList')
 
 weakenCase :: DT.Case TM.Term -> DT.Case WT.WeakTerm
-weakenCase decisonCase = do
-  case decisonCase of
-    DT.Cons m dd disc dataArgs consArgs tree -> do
-      let dataArgs' = map (bimap weaken weaken) dataArgs
-      let consArgs' = map weakenBinder consArgs
-      let tree' = weakenDecisionTree tree
-      DT.Cons m dd disc dataArgs' consArgs' tree'
+weakenCase decisionCase = do
+  let dataArgs' = map (bimap weaken weaken) $ DT.dataArgs decisionCase
+  let consArgs' = map weakenBinder $ DT.consArgs decisionCase
+  let cont' = weakenDecisionTree $ DT.cont decisionCase
+  decisionCase
+    { DT.dataArgs = dataArgs',
+      DT.consArgs = consArgs',
+      DT.cont = cont'
+    }
 
 weakenStmtKind :: StmtKind TM.Term -> StmtKind WT.WeakTerm
 weakenStmtKind stmtKind =

--- a/src/Entity/Term/Weaken.hs
+++ b/src/Entity/Term/Weaken.hs
@@ -59,13 +59,13 @@ weaken term =
       let e' = weaken e
       let es' = map weaken es
       m :< WT.PiElim e' es'
-    m :< TM.Data name consNameList es -> do
+    m :< TM.Data attr name es -> do
       let es' = map weaken es
-      m :< WT.Data name consNameList es'
-    m :< TM.DataIntro dataName consName consNameList disc dataArgs consArgs -> do
+      m :< WT.Data attr name es'
+    m :< TM.DataIntro attr consName dataArgs consArgs -> do
       let dataArgs' = map weaken dataArgs
       let consArgs' = map weaken consArgs
-      m :< WT.DataIntro dataName consName consNameList disc dataArgs' consArgs'
+      m :< WT.DataIntro attr consName dataArgs' consArgs'
     m :< TM.DataElim isNoetic oets tree -> do
       let (os, es, ts) = unzip3 oets
       let es' = map weaken es

--- a/src/Entity/WeakTerm.hs
+++ b/src/Entity/WeakTerm.hs
@@ -3,11 +3,12 @@ module Entity.WeakTerm where
 import Control.Comonad.Cofree
 import Data.IntMap qualified as IntMap
 import Entity.Annotation qualified as AN
+import Entity.Attr.Data qualified as AttrD
+import Entity.Attr.DataIntro qualified as AttrDI
 import Entity.Attr.VarGlobal qualified as AttrVG
 import Entity.Binder
 import Entity.DecisionTree qualified as DT
 import Entity.DefiniteDescription qualified as DD
-import Entity.Discriminant qualified as D
 import Entity.Hint
 import Entity.HoleID
 import Entity.Ident
@@ -29,8 +30,8 @@ data WeakTermF a
   | Pi [BinderF a] a
   | PiIntro (LamKindF a) [BinderF a] a
   | PiElim a [a]
-  | Data DD.DefiniteDescription [DD.DefiniteDescription] [a]
-  | DataIntro DD.DefiniteDescription DD.DefiniteDescription [DD.DefiniteDescription] D.Discriminant [a] [a]
+  | Data AttrD.Attr DD.DefiniteDescription [a]
+  | DataIntro AttrDI.Attr DD.DefiniteDescription [a] [a] -- (consName, dataArgs, consArgs)
   | DataElim N.IsNoetic [(Ident, a, a)] (DT.DecisionTree a)
   | Noema a
   | Embody a a

--- a/src/Entity/WeakTerm.hs
+++ b/src/Entity/WeakTerm.hs
@@ -3,7 +3,7 @@ module Entity.WeakTerm where
 import Control.Comonad.Cofree
 import Data.IntMap qualified as IntMap
 import Entity.Annotation qualified as AN
-import Entity.ArgNum
+import Entity.Attr.VarGlobal qualified as AttrVG
 import Entity.Binder
 import Entity.DecisionTree qualified as DT
 import Entity.DefiniteDescription qualified as DD
@@ -25,7 +25,7 @@ type WeakTerm = Cofree WeakTermF Hint
 data WeakTermF a
   = Tau
   | Var Ident
-  | VarGlobal DD.DefiniteDescription ArgNum
+  | VarGlobal AttrVG.Attr DD.DefiniteDescription
   | Pi [BinderF a] a
   | PiIntro (LamKindF a) [BinderF a] a
   | PiElim a [a]

--- a/src/Entity/WeakTerm/FreeVars.hs
+++ b/src/Entity/WeakTerm/FreeVars.hs
@@ -29,7 +29,7 @@ freeVars term =
       S.union xs ys
     _ :< WT.Data _ _ es ->
       S.unions $ map freeVars es
-    _ :< WT.DataIntro _ _ _ _ dataArgs consArgs -> do
+    _ :< WT.DataIntro _ _ dataArgs consArgs -> do
       S.unions $ map freeVars $ dataArgs ++ consArgs
     m :< WT.DataElim _ oets decisionTree -> do
       let (os, es, ts) = unzip3 oets

--- a/src/Entity/WeakTerm/FreeVars.hs
+++ b/src/Entity/WeakTerm/FreeVars.hs
@@ -98,7 +98,5 @@ freeVarsCaseList (fallbackClause, clauseList) = do
 
 freeVarsCase :: DT.Case WT.WeakTerm -> S.Set Ident
 freeVarsCase decisionCase = do
-  case decisionCase of
-    DT.Cons _ _ _ dataArgs consArgs tree -> do
-      let (dataTerms, dataTypes) = unzip dataArgs
-      S.unions $ freeVars' consArgs (freeVarsDecisionTree tree) : map freeVars dataTerms ++ map freeVars dataTypes
+  let (dataTerms, dataTypes) = unzip $ DT.dataArgs decisionCase
+  S.unions $ freeVars' (DT.consArgs decisionCase) (freeVarsDecisionTree (DT.cont decisionCase)) : map freeVars dataTerms ++ map freeVars dataTypes

--- a/src/Entity/WeakTerm/Holes.hs
+++ b/src/Entity/WeakTerm/Holes.hs
@@ -93,8 +93,6 @@ holesCaseList (fallbackClause, clauseList) = do
   S.union xs1 xs2
 
 holesCase :: DT.Case WT.WeakTerm -> S.Set HoleID
-holesCase decisionCase =
-  case decisionCase of
-    DT.Cons _ _ _ dataArgs consArgs tree -> do
-      let (dataTerms, dataTypes) = unzip dataArgs
-      S.unions $ holes' consArgs (holesDecisionTree tree) : map holes dataTerms ++ map holes dataTypes
+holesCase decisionCase = do
+  let (dataTerms, dataTypes) = unzip (DT.dataArgs decisionCase)
+  S.unions $ holes' (DT.consArgs decisionCase) (holesDecisionTree (DT.cont decisionCase)) : map holes dataTerms ++ map holes dataTypes

--- a/src/Entity/WeakTerm/Holes.hs
+++ b/src/Entity/WeakTerm/Holes.hs
@@ -25,7 +25,7 @@ holes term =
       S.unions $ map holes $ e : es
     _ :< WT.Data _ _ es ->
       S.unions $ map holes es
-    _ :< WT.DataIntro _ _ _ _ dataArgs consArgs -> do
+    _ :< WT.DataIntro _ _ dataArgs consArgs -> do
       S.unions $ map holes $ dataArgs ++ consArgs
     m :< WT.DataElim _ oets decisionTree -> do
       let (os, es, ts) = unzip3 oets

--- a/src/Entity/WeakTerm/ToText.hs
+++ b/src/Entity/WeakTerm/ToText.hs
@@ -2,6 +2,7 @@ module Entity.WeakTerm.ToText (toText, showDecisionTree, showGlobalVariable) whe
 
 import Control.Comonad.Cofree
 import Data.Text qualified as T
+import Entity.Attr.VarGlobal qualified as AttrVG
 import Entity.BaseName qualified as BN
 import Entity.Binder
 import Entity.DecisionTree qualified as DT
@@ -26,7 +27,7 @@ toText term =
       "tau"
     _ :< WT.Var x ->
       showVariable x
-    _ :< WT.VarGlobal x _ ->
+    _ :< WT.VarGlobal _ x ->
       showGlobalVariable x
     _ :< WT.Pi xts cod ->
       showCons ["Π", inParen $ showTypeArgs xts, toText cod]
@@ -39,7 +40,12 @@ toText term =
           let argStr = inParen $ showItems $ map showArg xts
           showCons ["λ", argStr, toText e]
     _ :< WT.PiElim e es ->
-      showCons $ map toText $ e : es
+      case e of
+        _ :< WT.VarGlobal attr _
+          | AttrVG.isConstLike attr ->
+              toText e
+        _ ->
+          showCons $ map toText $ e : es
     _ :< WT.Data name _ es -> do
       showCons $ "{data}" <> showGlobalVariable name : map toText es
     _ :< WT.DataIntro _ consName _ _ _ consArgs -> do

--- a/src/Entity/WeakTerm/ToText.hs
+++ b/src/Entity/WeakTerm/ToText.hs
@@ -2,6 +2,8 @@ module Entity.WeakTerm.ToText (toText, showDecisionTree, showGlobalVariable) whe
 
 import Control.Comonad.Cofree
 import Data.Text qualified as T
+import Entity.Attr.Data qualified as AttrD
+import Entity.Attr.DataIntro qualified as AttrDI
 import Entity.Attr.VarGlobal qualified as AttrVG
 import Entity.BaseName qualified as BN
 import Entity.Binder
@@ -46,10 +48,14 @@ toText term =
               toText e
         _ ->
           showCons $ map toText $ e : es
-    _ :< WT.Data name _ es -> do
-      showCons $ "{data}" <> showGlobalVariable name : map toText es
-    _ :< WT.DataIntro _ consName _ _ _ consArgs -> do
-      showCons ("{data-intro}" <> showGlobalVariable consName : map toText consArgs)
+    _ :< WT.Data (AttrD.Attr {..}) name es -> do
+      if isConstLike
+        then "{data}" <> showGlobalVariable name
+        else showCons $ "{data}" <> showGlobalVariable name : map toText es
+    _ :< WT.DataIntro (AttrDI.Attr {..}) consName _ consArgs -> do
+      if isConstLike
+        then "{data}" <> showGlobalVariable consName
+        else showCons ("{data-intro}" <> showGlobalVariable consName : map toText consArgs)
     _ :< WT.DataElim isNoetic xets tree -> do
       if isNoetic
         then showCons ["match*", showMatchArgs xets, showDecisionTree tree]

--- a/src/Entity/WeakTerm/ToText.hs
+++ b/src/Entity/WeakTerm/ToText.hs
@@ -160,12 +160,10 @@ showDecisionTree tree =
 
 showClauseList :: DT.Case WT.WeakTerm -> T.Text
 showClauseList decisionCase = do
-  case decisionCase of
-    DT.Cons _ consName d dataArgs consArgs cont -> do
-      showCons
-        [ showGlobalVariable consName,
-          T.pack (show (D.reify d)),
-          showCons $ map (\(e, t) -> showCons [toText e, toText t]) dataArgs,
-          inParen $ showTypeArgs consArgs,
-          showDecisionTree cont
-        ]
+  showCons
+    [ showGlobalVariable (DT.consDD decisionCase),
+      T.pack (show (D.reify (DT.disc decisionCase))),
+      showCons $ map (\(e, t) -> showCons [toText e, toText t]) (DT.dataArgs decisionCase),
+      inParen $ showTypeArgs (DT.consArgs decisionCase),
+      showDecisionTree (DT.cont decisionCase)
+    ]

--- a/src/Scene/Elaborate.hs
+++ b/src/Scene/Elaborate.hs
@@ -399,7 +399,7 @@ reduceWeakType e = do
   case e' of
     m :< WT.Hole h es ->
       fillHole m h es >>= reduceWeakType
-    m :< WT.PiElim (_ :< WT.VarGlobal name _) args -> do
+    m :< WT.PiElim (_ :< WT.VarGlobal _ name) args -> do
       mLam <- WeakDefinition.lookup name
       case mLam of
         Just lam ->

--- a/src/Scene/Elaborate.hs
+++ b/src/Scene/Elaborate.hs
@@ -373,14 +373,17 @@ elaborateDecisionTree m tree =
 
 elaborateClause :: DT.Case WT.WeakTerm -> App (DT.Case TM.Term)
 elaborateClause decisionCase = do
-  case decisionCase of
-    DT.Cons mCons consName disc dataArgs consArgs cont -> do
-      let (dataTerms, dataTypes) = unzip dataArgs
-      dataTerms' <- mapM elaborate' dataTerms
-      dataTypes' <- mapM elaborate' dataTypes
-      consArgs' <- mapM elaborateWeakBinder consArgs
-      cont' <- elaborateDecisionTree mCons cont
-      return $ DT.Cons mCons consName disc (zip dataTerms' dataTypes') consArgs' cont'
+  let (dataTerms, dataTypes) = unzip $ DT.dataArgs decisionCase
+  dataTerms' <- mapM elaborate' dataTerms
+  dataTypes' <- mapM elaborate' dataTypes
+  consArgs' <- mapM elaborateWeakBinder $ DT.consArgs decisionCase
+  cont' <- elaborateDecisionTree (DT.mCons decisionCase) (DT.cont decisionCase)
+  return $
+    decisionCase
+      { DT.dataArgs = zip dataTerms' dataTypes',
+        DT.consArgs = consArgs',
+        DT.cont = cont'
+      }
 
 raiseNonExhaustivePatternMatching :: Hint -> App a
 raiseNonExhaustivePatternMatching m =

--- a/src/Scene/Elaborate.hs
+++ b/src/Scene/Elaborate.hs
@@ -21,6 +21,7 @@ import Data.List
 import Data.Set qualified as S
 import Data.Text qualified as T
 import Entity.Annotation qualified as AN
+import Entity.Attr.Data qualified as AttrD
 import Entity.Binder
 import Entity.Cache qualified as Cache
 import Entity.DecisionTree qualified as DT
@@ -203,13 +204,13 @@ elaborate' term =
       e' <- elaborate' e
       es' <- mapM elaborate' es
       return $ m :< TM.PiElim e' es'
-    m :< WT.Data name consNameList es -> do
+    m :< WT.Data attr name es -> do
       es' <- mapM elaborate' es
-      return $ m :< TM.Data name consNameList es'
-    m :< WT.DataIntro dataName consName consNameList disc dataArgs consArgs -> do
+      return $ m :< TM.Data attr name es'
+    m :< WT.DataIntro attr consName dataArgs consArgs -> do
       dataArgs' <- mapM elaborate' dataArgs
       consArgs' <- mapM elaborate' consArgs
-      return $ m :< TM.DataIntro dataName consName consNameList disc dataArgs' consArgs'
+      return $ m :< TM.DataIntro attr consName dataArgs' consArgs'
     m :< WT.DataElim isNoetic oets tree -> do
       let (os, es, ts) = unzip3 oets
       es' <- mapM elaborate' es
@@ -412,7 +413,7 @@ reduceWeakType e = do
 extractConstructorList :: Hint -> TM.Term -> App [DD.DefiniteDescription]
 extractConstructorList m cursorType = do
   case cursorType of
-    _ :< TM.Data _ consNameList _ -> do
+    _ :< TM.Data (AttrD.Attr {..}) _ _ -> do
       return consNameList
     _ ->
       Throw.raiseError m $ "the type of this term is expected to be an ADT, but it's not:\n" <> toText (weaken cursorType)

--- a/src/Scene/Elaborate/Infer.hs
+++ b/src/Scene/Elaborate/Infer.hs
@@ -12,6 +12,8 @@ import Data.IntMap qualified as IntMap
 import Data.Text qualified as T
 import Entity.Annotation qualified as Annotation
 import Entity.ArgNum qualified as AN
+import Entity.Attr.Data qualified as AttrD
+import Entity.Attr.DataIntro qualified as AttrDI
 import Entity.Attr.VarGlobal qualified as AttrVG
 import Entity.Binder
 import Entity.Const
@@ -124,14 +126,14 @@ infer' varEnv term =
       etls <- mapM (infer' varEnv) es
       etl <- infer' varEnv e
       inferPiElim varEnv m etl etls
-    m :< WT.Data name consNameList es -> do
+    m :< WT.Data attr name es -> do
       (es', _) <- mapAndUnzipM (infer' varEnv) es
-      return (m :< WT.Data name consNameList es', m :< WT.Tau)
-    m :< WT.DataIntro dataName consName consNameList disc dataArgs consArgs -> do
+      return (m :< WT.Data attr name es', m :< WT.Tau)
+    m :< WT.DataIntro attr@(AttrDI.Attr {..}) consName dataArgs consArgs -> do
       (dataArgs', _) <- mapAndUnzipM (infer' varEnv) dataArgs
       (consArgs', _) <- mapAndUnzipM (infer' varEnv) consArgs
-      let dataType = m :< WT.Data dataName consNameList dataArgs'
-      return (m :< WT.DataIntro dataName consName consNameList disc dataArgs' consArgs', dataType)
+      let dataType = m :< WT.Data (AttrD.Attr {..}) dataName dataArgs'
+      return (m :< WT.DataIntro attr consName dataArgs' consArgs', dataType)
     m :< WT.DataElim isNoetic oets tree -> do
       let (os, es, _) = unzip3 oets
       (es', ts') <- mapAndUnzipM (infer' varEnv) es

--- a/src/Scene/Elaborate/Reveal.hs
+++ b/src/Scene/Elaborate/Reveal.hs
@@ -92,13 +92,13 @@ reveal' varEnv term =
       es' <- mapM (reveal' varEnv) es
       e' <- reveal' varEnv e
       return $ m :< WT.PiElim e' es'
-    m :< WT.Data name consNameList es -> do
+    m :< WT.Data attr name es -> do
       es' <- mapM (reveal' varEnv) es
-      return $ m :< WT.Data name consNameList es'
-    m :< WT.DataIntro dataName consName consNameList disc dataArgs consArgs -> do
+      return $ m :< WT.Data attr name es'
+    m :< WT.DataIntro attr consName dataArgs consArgs -> do
       dataArgs' <- mapM (reveal' varEnv) dataArgs
       consArgs' <- mapM (reveal' varEnv) consArgs
-      return $ m :< WT.DataIntro dataName consName consNameList disc dataArgs' consArgs'
+      return $ m :< WT.DataIntro attr consName dataArgs' consArgs'
     m :< WT.DataElim isNoetic oets tree -> do
       let (os, es, ts) = unzip3 oets
       es' <- mapM (reveal' varEnv) es

--- a/src/Scene/Elaborate/Reveal.hs
+++ b/src/Scene/Elaborate/Reveal.hs
@@ -11,6 +11,7 @@ import Control.Comonad.Cofree
 import Control.Monad
 import Entity.Annotation qualified as AN
 import Entity.ArgNum qualified as AN
+import Entity.Attr.VarGlobal qualified as AttrVG
 import Entity.Binder
 import Entity.DecisionTree qualified as DT
 import Entity.HoleID qualified as HID
@@ -62,7 +63,7 @@ reveal' varEnv term =
       return term
     _ :< WT.Var {} ->
       return term
-    m :< WT.VarGlobal name argNum -> do
+    m :< WT.VarGlobal (AttrVG.Attr {..}) name -> do
       mImpArgNum <- Implicit.lookup name
       case mImpArgNum of
         Just impArgNum

--- a/src/Scene/Elaborate/Reveal.hs
+++ b/src/Scene/Elaborate/Reveal.hs
@@ -255,11 +255,14 @@ revealClause ::
   DT.Case WT.WeakTerm ->
   App (DT.Case WT.WeakTerm)
 revealClause varEnv decisionCase = do
-  case decisionCase of
-    DT.Cons mCons consName disc dataArgs consArgs body -> do
-      let (dataTerms, dataTypeTerms) = unzip dataArgs
-      dataTerms' <- mapM (reveal' varEnv) dataTerms
-      dataTypeTerms' <- mapM (reveal' varEnv) dataTypeTerms
-      (consArgs', body') <- revealBinder' varEnv consArgs $ \extendedVarEnv ->
-        revealDecisionTree extendedVarEnv body
-      return (DT.Cons mCons consName disc (zip dataTerms' dataTypeTerms') consArgs' body')
+  let (dataTerms, dataTypes) = unzip $ DT.dataArgs decisionCase
+  dataTerms' <- mapM (reveal' varEnv) dataTerms
+  dataTypes' <- mapM (reveal' varEnv) dataTypes
+  (consArgs', cont') <- revealBinder' varEnv (DT.consArgs decisionCase) $ \extendedVarEnv ->
+    revealDecisionTree extendedVarEnv (DT.cont decisionCase)
+  return $
+    decisionCase
+      { DT.dataArgs = zip dataTerms' dataTypes',
+        DT.consArgs = consArgs',
+        DT.cont = cont'
+      }

--- a/src/Scene/Elaborate/Unify.hs
+++ b/src/Scene/Elaborate/Unify.hs
@@ -13,6 +13,7 @@ import Data.IntMap qualified as IntMap
 import Data.PQueue.Min qualified as Q
 import Data.Set qualified as S
 import Data.Text qualified as T
+import Entity.Attr.Data qualified as AttrD
 import Entity.Binder
 import Entity.Constraint qualified as C
 import Entity.DefiniteDescription qualified as DD
@@ -135,14 +136,13 @@ simplify constraintList =
               xt2 <- asWeakBinder m2 e2
               cs' <- simplifyBinder orig (xts1 ++ [xt1]) (xts2 ++ [xt2])
               simplify $ cs' ++ cs
-        (_ :< WT.Data name1 _ es1, _ :< WT.Data name2 _ es2)
+        (_ :< WT.Data _ name1 es1, _ :< WT.Data _ name2 es2)
           | name1 == name2,
             length es1 == length es2 -> do
               let cs' = map (,orig) (zipWith C.Eq es1 es2)
               simplify $ cs' ++ cs
-        (_ :< WT.DataIntro dataName1 consName1 _ _ dataArgs1 consArgs1, _ :< WT.DataIntro dataName2 consName2 _ _ dataArgs2 consArgs2)
-          | dataName1 == dataName2,
-            consName1 == consName2,
+        (_ :< WT.DataIntro _ consName1 dataArgs1 consArgs1, _ :< WT.DataIntro _ consName2 dataArgs2 consArgs2)
+          | consName1 == consName2,
             length dataArgs1 == length dataArgs2,
             length consArgs1 == length consArgs2 -> do
               let es1 = dataArgs1 ++ consArgs1
@@ -346,7 +346,7 @@ simplifyActual m dataNameSet t orig = do
   case t' of
     _ :< WT.Tau ->
       return ()
-    _ :< WT.Data dataName consNameList dataArgs -> do
+    _ :< WT.Data (AttrD.Attr {..}) dataName dataArgs -> do
       let dataNameSet' = S.insert dataName dataNameSet
       forM_ dataArgs $ \dataArg ->
         simplifyActual m dataNameSet' dataArg orig

--- a/src/Scene/Elaborate/Unify.hs
+++ b/src/Scene/Elaborate/Unify.hs
@@ -110,7 +110,7 @@ simplify constraintList =
         (_ :< WT.Var x1, _ :< WT.Var x2)
           | x1 == x2 ->
               simplify cs
-        (_ :< WT.VarGlobal g1 _, _ :< WT.VarGlobal g2 _)
+        (_ :< WT.VarGlobal _ g1, _ :< WT.VarGlobal _ g2)
           | g1 == g2 ->
               simplify cs
         (m1 :< WT.Pi xts1 cod1, m2 :< WT.Pi xts2 cod2)

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -157,10 +157,10 @@ discern nenv term =
     m :< RT.Data name consNameList es -> do
       es' <- mapM (discern nenv) es
       return $ m :< WT.Data name consNameList es'
-    m :< RT.DataIntro dataName consName consNameList disc dataArgs consArgs -> do
+    m :< RT.DataIntro attr consName dataArgs consArgs -> do
       dataArgs' <- mapM (discern nenv) dataArgs
       consArgs' <- mapM (discern nenv) consArgs
-      return $ m :< WT.DataIntro dataName consName consNameList disc dataArgs' consArgs'
+      return $ m :< WT.DataIntro attr consName dataArgs' consArgs'
     m :< RT.DataElim isNoetic es patternMatrix -> do
       os <- mapM (const $ Gensym.newIdentFromText "match") es -- os: occurrences
       es' <- mapM (discern nenv >=> castFromNoemaIfNecessary isNoetic) es

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -19,6 +19,7 @@ import Data.Set qualified as S
 import Data.Text qualified as T
 import Data.Vector qualified as V
 import Entity.Annotation qualified as AN
+import Entity.Attr.VarGlobal qualified as AttrVG
 import Entity.Binder
 import Entity.DefiniteDescription qualified as DD
 import Entity.Error qualified as E
@@ -152,7 +153,7 @@ discern nenv term =
       let keyList' = drop (length impArgs) keyList
       expArgs <- reorderArgs m keyList' $ Map.fromList $ zip ks vs'
       impArgs' <- mapM (discern nenv) impArgs
-      return $ m :< WT.PiElim (m :< WT.VarGlobal dd argNum) (impArgs' ++ expArgs)
+      return $ m :< WT.PiElim (m :< WT.VarGlobal (AttrVG.new argNum) dd) (impArgs' ++ expArgs)
     m :< RT.Data name consNameList es -> do
       es' <- mapM (discern nenv) es
       return $ m :< WT.Data name consNameList es'

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -363,6 +363,7 @@ discernPattern (m, pat) =
                   let consInfo =
                         PAT.ConsInfo
                           { consDD = consName,
+                            isConstLike = isConstLike,
                             disc = disc,
                             dataArgNum = dataArgNum,
                             consArgNum = consArgNum,
@@ -372,10 +373,11 @@ discernPattern (m, pat) =
         Locator l -> do
           (dd, gn) <- resolveName m $ Locator l
           case gn of
-            (_, GN.DataIntro dataArgNum consArgNum disc _) -> do
+            (_, GN.DataIntro dataArgNum consArgNum disc isConstLike) -> do
               let consInfo =
                     PAT.ConsInfo
                       { consDD = dd,
+                        isConstLike = isConstLike,
                         disc = disc,
                         dataArgNum = dataArgNum,
                         consArgNum = consArgNum,
@@ -388,10 +390,11 @@ discernPattern (m, pat) =
         DefiniteDescription dd -> do
           (_, gn) <- resolveName m $ DefiniteDescription dd
           case gn of
-            (_, GN.DataIntro dataArgNum consArgNum disc _) -> do
+            (_, GN.DataIntro dataArgNum consArgNum disc isConstLike) -> do
               let consInfo =
                     PAT.ConsInfo
                       { consDD = dd,
+                        isConstLike = isConstLike,
                         disc = disc,
                         dataArgNum = dataArgNum,
                         consArgNum = consArgNum,
@@ -412,6 +415,7 @@ discernPattern (m, pat) =
           let consInfo =
                 PAT.ConsInfo
                   { consDD = consName,
+                    isConstLike = isConstLike,
                     disc = disc,
                     dataArgNum = dataArgNum,
                     consArgNum = consArgNum,
@@ -428,6 +432,7 @@ discernPattern (m, pat) =
           let consInfo =
                 PAT.ConsInfo
                   { consDD = consName,
+                    isConstLike = isConstLike,
                     disc = disc,
                     dataArgNum = dataArgNum,
                     consArgNum = consArgNum,

--- a/src/Scene/Parse/Discern/Name.hs
+++ b/src/Scene/Parse/Discern/Name.hs
@@ -18,6 +18,7 @@ import Control.Comonad.Cofree hiding (section)
 import Data.Maybe qualified as Maybe
 import Data.Text qualified as T
 import Entity.ArgNum qualified as AN
+import Entity.Attr.VarGlobal qualified as AttrVG
 import Entity.Const qualified as C
 import Entity.DefiniteDescription qualified as DD
 import Entity.Discriminant qualified as D
@@ -128,7 +129,7 @@ interpretGlobalName m dd gn = do
     GN.Data argNum _ isConstLike ->
       interpretTopLevelFunc m dd argNum isConstLike
     GN.DataIntro dataArgNum consArgNum _ isConstLike -> do
-      let e = m :< WT.VarGlobal dd (AN.add dataArgNum consArgNum)
+      let e = m :< WT.VarGlobal (AttrVG.new (AN.add dataArgNum consArgNum)) dd
       if isConstLike
         then return $ m :< WT.PiElim e []
         else return e
@@ -150,9 +151,10 @@ interpretTopLevelFunc ::
   Bool ->
   App WT.WeakTerm
 interpretTopLevelFunc m dd argNum isConstLike = do
+  let attr = AttrVG.Attr {argNum = argNum, isConstLike = isConstLike}
   if isConstLike
-    then return $ m :< WT.PiElim (m :< WT.VarGlobal dd argNum) []
-    else return $ m :< WT.VarGlobal dd argNum
+    then return $ m :< WT.PiElim (m :< WT.VarGlobal attr dd) []
+    else return $ m :< WT.VarGlobal attr dd
 
 castFromIntToBool :: WT.WeakTerm -> App WT.WeakTerm
 castFromIntToBool e@(m :< _) = do

--- a/src/Scene/Parse/Discern/PatternMatrix.hs
+++ b/src/Scene/Parse/Discern/PatternMatrix.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedRecordDot #-}
-
 module Scene.Parse.Discern.PatternMatrix
   ( compilePatternMatrix,
     ensurePatternMatrixSanity,
@@ -57,22 +55,22 @@ compilePatternMatrix nenv isNoetic m occurrences mat =
             else do
               let headConstructors = PAT.getHeadConstructors mat
               let cursor = V.head occurrences
-              clauseList <- forM headConstructors $ \(mPat, consInfo) -> do
-                dataHoles <- mapM (const $ Gensym.newHole mPat []) [1 .. AN.reify consInfo.dataArgNum]
-                dataTypeHoles <- mapM (const $ Gensym.newHole mPat []) [1 .. AN.reify consInfo.dataArgNum]
-                consVars <- mapM (const $ Gensym.newIdentFromText "cvar") [1 .. AN.reify consInfo.consArgNum]
-                let ms = map fst consInfo.args
+              clauseList <- forM headConstructors $ \(mPat, PAT.ConsInfo {..}) -> do
+                dataHoles <- mapM (const $ Gensym.newHole mPat []) [1 .. AN.reify dataArgNum]
+                dataTypeHoles <- mapM (const $ Gensym.newHole mPat []) [1 .. AN.reify dataArgNum]
+                consVars <- mapM (const $ Gensym.newIdentFromText "cvar") [1 .. AN.reify consArgNum]
+                let ms = map fst args
                 (consArgs', nenv') <- alignConsArgs nenv $ zip ms consVars
                 let occurrences' = V.fromList consVars <> V.tail occurrences
-                specialMatrix <- PATS.specialize isNoetic cursor (consInfo.consDD, consInfo.consArgNum) mat
+                specialMatrix <- PATS.specialize isNoetic cursor (consDD, consArgNum) mat
                 specialDecisionTree <- compilePatternMatrix nenv' isNoetic mPat occurrences' specialMatrix
                 let dataArgs' = zip dataHoles dataTypeHoles
                 return $
                   DT.Case
                     { mCons = mPat,
-                      consDD = consInfo.consDD,
-                      isConstLike = consInfo.isConstLike,
-                      disc = consInfo.disc,
+                      consDD = consDD,
+                      isConstLike = isConstLike,
+                      disc = disc,
                       dataArgs = dataArgs',
                       consArgs = consArgs',
                       cont = specialDecisionTree

--- a/src/Scene/Parse/Discern/PatternMatrix.hs
+++ b/src/Scene/Parse/Discern/PatternMatrix.hs
@@ -67,7 +67,15 @@ compilePatternMatrix nenv isNoetic m occurrences mat =
                 specialMatrix <- PATS.specialize isNoetic cursor (consInfo.consDD, consInfo.consArgNum) mat
                 specialDecisionTree <- compilePatternMatrix nenv' isNoetic mPat occurrences' specialMatrix
                 let dataArgs' = zip dataHoles dataTypeHoles
-                return (DT.Cons mPat consInfo.consDD consInfo.disc dataArgs' consArgs' specialDecisionTree)
+                return $
+                  DT.Case
+                    { mCons = mPat,
+                      consDD = consInfo.consDD,
+                      disc = consInfo.disc,
+                      dataArgs = dataArgs',
+                      consArgs = consArgs',
+                      cont = specialDecisionTree
+                    }
               fallbackMatrix <- PATF.getFallbackMatrix isNoetic cursor mat
               fallbackClause <- compilePatternMatrix nenv isNoetic mCol (V.tail occurrences) fallbackMatrix
               t <- Gensym.newHole mCol []

--- a/src/Scene/Parse/Discern/PatternMatrix.hs
+++ b/src/Scene/Parse/Discern/PatternMatrix.hs
@@ -71,6 +71,7 @@ compilePatternMatrix nenv isNoetic m occurrences mat =
                   DT.Case
                     { mCons = mPat,
                       consDD = consInfo.consDD,
+                      isConstLike = consInfo.isConstLike,
                       disc = consInfo.disc,
                       dataArgs = dataArgs',
                       consArgs = consArgs',

--- a/src/Scene/Parse/Discern/PatternMatrix.hs
+++ b/src/Scene/Parse/Discern/PatternMatrix.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
 module Scene.Parse.Discern.PatternMatrix
   ( compilePatternMatrix,
     ensurePatternMatrixSanity,
@@ -55,16 +57,17 @@ compilePatternMatrix nenv isNoetic m occurrences mat =
             else do
               let headConstructors = PAT.getHeadConstructors mat
               let cursor = V.head occurrences
-              clauseList <- forM headConstructors $ \(mPat, (cons, disc, dataArgNum, consArgNum, args)) -> do
-                dataHoles <- mapM (const $ Gensym.newHole mPat []) [1 .. AN.reify dataArgNum]
-                dataTypeHoles <- mapM (const $ Gensym.newHole mPat []) [1 .. AN.reify dataArgNum]
-                consVars <- mapM (const $ Gensym.newIdentFromText "cvar") [1 .. AN.reify consArgNum]
-                let ms = map fst args
+              clauseList <- forM headConstructors $ \(mPat, consInfo) -> do
+                dataHoles <- mapM (const $ Gensym.newHole mPat []) [1 .. AN.reify consInfo.dataArgNum]
+                dataTypeHoles <- mapM (const $ Gensym.newHole mPat []) [1 .. AN.reify consInfo.dataArgNum]
+                consVars <- mapM (const $ Gensym.newIdentFromText "cvar") [1 .. AN.reify consInfo.consArgNum]
+                let ms = map fst consInfo.args
                 (consArgs', nenv') <- alignConsArgs nenv $ zip ms consVars
                 let occurrences' = V.fromList consVars <> V.tail occurrences
-                specialMatrix <- PATS.specialize isNoetic cursor (cons, consArgNum) mat
+                specialMatrix <- PATS.specialize isNoetic cursor (consInfo.consDD, consInfo.consArgNum) mat
                 specialDecisionTree <- compilePatternMatrix nenv' isNoetic mPat occurrences' specialMatrix
-                return (DT.Cons mPat cons disc (zip dataHoles dataTypeHoles) consArgs' specialDecisionTree)
+                let dataArgs' = zip dataHoles dataTypeHoles
+                return (DT.Cons mPat consInfo.consDD consInfo.disc dataArgs' consArgs' specialDecisionTree)
               fallbackMatrix <- PATF.getFallbackMatrix isNoetic cursor mat
               fallbackClause <- compilePatternMatrix nenv isNoetic mCol (V.tail occurrences) fallbackMatrix
               t <- Gensym.newHole mCol []
@@ -119,15 +122,15 @@ ensurePatternSanity (m, pat) =
       return ()
     PAT.WildcardVar {} ->
       return ()
-    PAT.Cons cons _ _ consArgNum args -> do
-      let argNum = length args
-      when (argNum /= AN.reify consArgNum) $
+    PAT.Cons consInfo -> do
+      let argNum = length (PAT.args consInfo)
+      when (argNum /= AN.reify (PAT.consArgNum consInfo)) $
         Throw.raiseError m $
           "the constructor `"
-            <> DD.reify cons
+            <> DD.reify (PAT.consDD consInfo)
             <> "` expects "
-            <> T.pack (show (AN.reify consArgNum))
+            <> T.pack (show (AN.reify (PAT.consArgNum consInfo)))
             <> " arguments, but found "
             <> T.pack (show argNum)
             <> "."
-      mapM_ ensurePatternSanity args
+      mapM_ ensurePatternSanity (PAT.args consInfo)

--- a/src/Scene/Parse/Discern/Specialize.hs
+++ b/src/Scene/Parse/Discern/Specialize.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
 module Scene.Parse.Discern.Specialize (specialize) where
 
 import Context.App
@@ -44,15 +46,15 @@ specializeRow isNoetic cursor (dd, argNum) (patternVector, (freedVars, body@(mBo
       adjustedCursor <- castToNoemaIfNecessary isNoetic (mBody :< WT.Var cursor)
       let body' = mBody :< WT.Let WT.Transparent (mBody, x, h) adjustedCursor body
       return $ Just (V.concat [wildcards, rest], (freedVars, body'))
-    Just ((_, Cons dd' _ _ _ args), rest) ->
-      if dd == dd'
+    Just ((_, Cons consInfo), rest) ->
+      if dd == consDD consInfo
         then do
-          od <- OptimizableData.lookup dd'
+          od <- OptimizableData.lookup consInfo.consDD
           case od of
             Just OD.Enum ->
-              return $ Just (V.concat [V.fromList args, rest], (freedVars, body))
+              return $ Just (V.concat [V.fromList consInfo.args, rest], (freedVars, body))
             Just OD.Unitary ->
-              return $ Just (V.concat [V.fromList args, rest], (freedVars, body))
+              return $ Just (V.concat [V.fromList consInfo.args, rest], (freedVars, body))
             _ ->
-              return $ Just (V.concat [V.fromList args, rest], (cursor : freedVars, body))
+              return $ Just (V.concat [V.fromList consInfo.args, rest], (cursor : freedVars, body))
         else return Nothing

--- a/src/Scene/Parse/Discern/Specialize.hs
+++ b/src/Scene/Parse/Discern/Specialize.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedRecordDot #-}
-
 module Scene.Parse.Discern.Specialize (specialize) where
 
 import Context.App
@@ -46,15 +44,15 @@ specializeRow isNoetic cursor (dd, argNum) (patternVector, (freedVars, body@(mBo
       adjustedCursor <- castToNoemaIfNecessary isNoetic (mBody :< WT.Var cursor)
       let body' = mBody :< WT.Let WT.Transparent (mBody, x, h) adjustedCursor body
       return $ Just (V.concat [wildcards, rest], (freedVars, body'))
-    Just ((_, Cons consInfo), rest) ->
-      if dd == consDD consInfo
+    Just ((_, Cons (ConsInfo {..})), rest) ->
+      if dd == consDD
         then do
-          od <- OptimizableData.lookup consInfo.consDD
+          od <- OptimizableData.lookup consDD
           case od of
             Just OD.Enum ->
-              return $ Just (V.concat [V.fromList consInfo.args, rest], (freedVars, body))
+              return $ Just (V.concat [V.fromList args, rest], (freedVars, body))
             Just OD.Unitary ->
-              return $ Just (V.concat [V.fromList consInfo.args, rest], (freedVars, body))
+              return $ Just (V.concat [V.fromList args, rest], (freedVars, body))
             _ ->
-              return $ Just (V.concat [V.fromList consInfo.args, rest], (cursor : freedVars, body))
+              return $ Just (V.concat [V.fromList args, rest], (cursor : freedVars, body))
         else return Nothing

--- a/src/Scene/Term/Inline.hs
+++ b/src/Scene/Term/Inline.hs
@@ -44,7 +44,7 @@ inline term =
               let xs = map (\(_, x, _) -> Ident.toInt x) xts
               let sub = IntMap.fromList $ zip xs (map Right es')
               Subst.subst sub (m :< body) >>= inline
-        (_ :< TM.VarGlobal dd _)
+        (_ :< TM.VarGlobal _ dd)
           | Just (xts, _ :< body) <- Map.lookup dd dmap,
             all TM.isValue es' -> do
               let xs = map (\(_, x, _) -> Ident.toInt x) xts

--- a/src/Scene/Term/Reduce.hs
+++ b/src/Scene/Term/Reduce.hs
@@ -40,13 +40,13 @@ reduce term =
               Subst.subst sub (m :< body) >>= reduce
         _ ->
           return (m :< TM.PiElim e' es')
-    m :< TM.Data name consNameList es -> do
+    m :< TM.Data attr name es -> do
       es' <- mapM reduce es
-      return $ m :< TM.Data name consNameList es'
-    m :< TM.DataIntro dataName consName consNameList disc dataArgs consArgs -> do
+      return $ m :< TM.Data attr name es'
+    m :< TM.DataIntro attr consName dataArgs consArgs -> do
       dataArgs' <- mapM reduce dataArgs
       consArgs' <- mapM reduce consArgs
-      return $ m :< TM.DataIntro dataName consName consNameList disc dataArgs' consArgs'
+      return $ m :< TM.DataIntro attr consName dataArgs' consArgs'
     m :< TM.DataElim isNoetic oets decisionTree -> do
       let (os, es, ts) = unzip3 oets
       es' <- mapM reduce es

--- a/src/Scene/Term/Reduce.hs
+++ b/src/Scene/Term/Reduce.hs
@@ -97,12 +97,15 @@ reduceCase ::
   DT.Case TM.Term ->
   App (DT.Case TM.Term)
 reduceCase decisionCase = do
-  case decisionCase of
-    DT.Cons m dd disc dataArgs consArgs tree -> do
-      let (dataTerms, dataTypes) = unzip dataArgs
-      dataTerms' <- mapM reduce dataTerms
-      dataTypes' <- mapM reduce dataTypes
-      let (ms, xs, ts) = unzip3 consArgs
-      ts' <- mapM reduce ts
-      tree' <- reduceDecisionTree tree
-      return $ DT.Cons m dd disc (zip dataTerms' dataTypes') (zip3 ms xs ts') tree'
+  let (dataTerms, dataTypes) = unzip $ DT.dataArgs decisionCase
+  dataTerms' <- mapM reduce dataTerms
+  dataTypes' <- mapM reduce dataTypes
+  let (ms, xs, ts) = unzip3 $ DT.consArgs decisionCase
+  ts' <- mapM reduce ts
+  cont' <- reduceDecisionTree $ DT.cont decisionCase
+  return $
+    decisionCase
+      { DT.dataArgs = zip dataTerms' dataTypes',
+        DT.consArgs = zip3 ms xs ts',
+        DT.cont = cont'
+      }

--- a/src/Scene/Term/Subst.hs
+++ b/src/Scene/Term/Subst.hs
@@ -156,13 +156,16 @@ substCase ::
   DT.Case TM.Term ->
   App (DT.Case TM.Term)
 substCase sub decisionCase = do
-  case decisionCase of
-    DT.Cons m dd disc dataArgs consArgs tree -> do
-      let (dataTerms, dataTypes) = unzip dataArgs
-      dataTerms' <- mapM (subst sub) dataTerms
-      dataTypes' <- mapM (subst sub) dataTypes
-      (consArgs', tree') <- subst'' sub consArgs tree
-      return $ DT.Cons m dd disc (zip dataTerms' dataTypes') consArgs' tree'
+  let (dataTerms, dataTypes) = unzip $ DT.dataArgs decisionCase
+  dataTerms' <- mapM (subst sub) dataTerms
+  dataTypes' <- mapM (subst sub) dataTypes
+  (consArgs', cont') <- subst'' sub (DT.consArgs decisionCase) (DT.cont decisionCase)
+  return $
+    decisionCase
+      { DT.dataArgs = zip dataTerms' dataTypes',
+        DT.consArgs = consArgs',
+        DT.cont = cont'
+      }
 
 substLeafVar :: SubstTerm -> Ident -> Maybe Ident
 substLeafVar sub leafVar =

--- a/src/Scene/Term/Subst.hs
+++ b/src/Scene/Term/Subst.hs
@@ -46,13 +46,13 @@ subst sub term =
       e' <- subst sub e
       es' <- mapM (subst sub) es
       return (m :< TM.PiElim e' es')
-    m :< TM.Data name consNameList es -> do
+    m :< TM.Data attr name es -> do
       es' <- mapM (subst sub) es
-      return $ m :< TM.Data name consNameList es'
-    m :< TM.DataIntro dataName consName consNameList disc dataArgs consArgs -> do
+      return $ m :< TM.Data attr name es'
+    m :< TM.DataIntro attr consName dataArgs consArgs -> do
       dataArgs' <- mapM (subst sub) dataArgs
       consArgs' <- mapM (subst sub) consArgs
-      return $ m :< TM.DataIntro dataName consName consNameList disc dataArgs' consArgs'
+      return $ m :< TM.DataIntro attr consName dataArgs' consArgs'
     m :< TM.DataElim isNoetic oets decisionTree -> do
       let (os, es, ts) = unzip3 oets
       es' <- mapM (subst sub) es

--- a/src/Scene/WeakTerm/Fill.hs
+++ b/src/Scene/WeakTerm/Fill.hs
@@ -176,10 +176,13 @@ fillCase ::
   DT.Case WT.WeakTerm ->
   App (DT.Case WT.WeakTerm)
 fillCase sub decisionCase = do
-  case decisionCase of
-    DT.Cons m dd disc dataArgs consArgs tree -> do
-      let (dataTerms, dataTypes) = unzip dataArgs
-      dataTerms' <- mapM (fill sub) dataTerms
-      dataTypes' <- mapM (fill sub) dataTypes
-      (consArgs', tree') <- fill''' sub consArgs tree
-      return $ DT.Cons m dd disc (zip dataTerms' dataTypes') consArgs' tree'
+  let (dataTerms, dataTypes) = unzip $ DT.dataArgs decisionCase
+  dataTerms' <- mapM (fill sub) dataTerms
+  dataTypes' <- mapM (fill sub) dataTypes
+  (consArgs', cont') <- fill''' sub (DT.consArgs decisionCase) (DT.cont decisionCase)
+  return $
+    decisionCase
+      { DT.dataArgs = zip dataTerms' dataTypes',
+        DT.consArgs = consArgs',
+        DT.cont = cont'
+      }

--- a/src/Scene/WeakTerm/Fill.hs
+++ b/src/Scene/WeakTerm/Fill.hs
@@ -46,10 +46,10 @@ fill sub term =
     m :< WT.Data name consNameList es -> do
       es' <- mapM (fill sub) es
       return $ m :< WT.Data name consNameList es'
-    m :< WT.DataIntro dataName consName consNameList disc dataArgs consArgs -> do
+    m :< WT.DataIntro attr consName dataArgs consArgs -> do
       dataArgs' <- mapM (fill sub) dataArgs
       consArgs' <- mapM (fill sub) consArgs
-      return $ m :< WT.DataIntro dataName consName consNameList disc dataArgs' consArgs'
+      return $ m :< WT.DataIntro attr consName dataArgs' consArgs'
     m :< WT.DataElim isNoetic oets decisionTree -> do
       let (os, es, ts) = unzip3 oets
       es' <- mapM (fill sub) es

--- a/src/Scene/WeakTerm/Reduce.hs
+++ b/src/Scene/WeakTerm/Reduce.hs
@@ -3,6 +3,7 @@ module Scene.WeakTerm.Reduce (reduce) where
 import Context.App
 import Control.Comonad.Cofree
 import Data.IntMap qualified as IntMap
+import Entity.Attr.DataIntro qualified as AttrDI
 import Entity.DecisionTree qualified as DT
 import Entity.Discriminant
 import Entity.Ident
@@ -63,13 +64,13 @@ reduce term =
               return $ m :< WT.Prim (WP.Value (WPV.Int intType (op' value1 value2)))
         _ ->
           return $ m :< WT.PiElim e' es'
-    m :< WT.Data name consNameList es -> do
+    m :< WT.Data attr name es -> do
       es' <- mapM reduce es
-      return $ m :< WT.Data name consNameList es'
-    m :< WT.DataIntro dataName consName consNameList disc dataArgs consArgs -> do
+      return $ m :< WT.Data attr name es'
+    m :< WT.DataIntro attr consName dataArgs consArgs -> do
       dataArgs' <- mapM reduce dataArgs
       consArgs' <- mapM reduce consArgs
-      return $ m :< WT.DataIntro dataName consName consNameList disc dataArgs' consArgs'
+      return $ m :< WT.DataIntro attr consName dataArgs' consArgs'
     m :< WT.DataElim isNoetic oets decisionTree -> do
       let (os, es, ts) = unzip3 oets
       es' <- mapM reduce es
@@ -88,8 +89,8 @@ reduce term =
               return $ m :< WT.DataElim isNoetic oets' DT.Unreachable
             DT.Switch (cursor, _) (fallbackTree, caseList) -> do
               case lookupSplit cursor oets' of
-                Just (e@(_ :< WT.DataIntro _ _ _ disc _ consArgs), oets'')
-                  | (newBaseCursorList, cont) <- findClause disc fallbackTree caseList -> do
+                Just (e@(_ :< WT.DataIntro (AttrDI.Attr {..}) _ _ consArgs), oets'')
+                  | (newBaseCursorList, cont) <- findClause discriminant fallbackTree caseList -> do
                       let newCursorList = zipWith (\(o, t) arg -> (o, arg, t)) newBaseCursorList consArgs
                       let sub = IntMap.singleton (Ident.toInt cursor) (Right e)
                       cont' <- Subst.substDecisionTree sub cont

--- a/src/Scene/WeakTerm/Subst.hs
+++ b/src/Scene/WeakTerm/Subst.hs
@@ -177,13 +177,16 @@ substCase ::
   DT.Case WT.WeakTerm ->
   App (DT.Case WT.WeakTerm)
 substCase sub decisionCase = do
-  case decisionCase of
-    DT.Cons m dd disc dataArgs consArgs tree -> do
-      let (dataTerms, dataTypes) = unzip dataArgs
-      dataTerms' <- mapM (subst sub) dataTerms
-      dataTypes' <- mapM (subst sub) dataTypes
-      (consArgs', tree') <- subst''' sub consArgs tree
-      return $ DT.Cons m dd disc (zip dataTerms' dataTypes') consArgs' tree'
+  let (dataTerms, dataTypes) = unzip $ DT.dataArgs decisionCase
+  dataTerms' <- mapM (subst sub) dataTerms
+  dataTypes' <- mapM (subst sub) dataTypes
+  (consArgs', cont') <- subst''' sub (DT.consArgs decisionCase) (DT.cont decisionCase)
+  return $
+    decisionCase
+      { DT.dataArgs = zip dataTerms' dataTypes',
+        DT.consArgs = consArgs',
+        DT.cont = cont'
+      }
 
 substLeafVar :: WT.SubstWeakTerm -> Ident -> Maybe Ident
 substLeafVar sub leafVar =

--- a/src/Scene/WeakTerm/Subst.hs
+++ b/src/Scene/WeakTerm/Subst.hs
@@ -47,10 +47,10 @@ subst sub term =
     m :< WT.Data name consNameList es -> do
       es' <- mapM (subst sub) es
       return $ m :< WT.Data name consNameList es'
-    m :< WT.DataIntro dataName consName consNameList disc dataArgs consArgs -> do
+    m :< WT.DataIntro attr consName dataArgs consArgs -> do
       dataArgs' <- mapM (subst sub) dataArgs
       consArgs' <- mapM (subst sub) consArgs
-      return $ m :< WT.DataIntro dataName consName consNameList disc dataArgs' consArgs'
+      return $ m :< WT.DataIntro attr consName dataArgs' consArgs'
     m :< WT.DataElim isNoetic oets decisionTree -> do
       let (os, es, ts) = unzip3 oets
       es' <- mapM (subst sub) es


### PR DESCRIPTION
This PR is for better error messages. Consider the code below:

```
data Nat {
- Zero
- Succ(Nat)
}

define foo(): tau {
  Zero // ← (causes a type error)
}
```

Before this PR, the code should result in the following error (conceptually):

```
type mismatch:
- Nat()
- tau
```

OTOH, after this PR, the error message becomes:

```
type mismatch:
- Nat
- tau
```

i.e. After this PR one can think about types like `Nat` in `data Nat {..}` as if they weren't functions.