### PR TITLE
Reimplement `Entity.WeakTerm.ToText` for the new syntax

### DIFF
--- a/src/Entity/WeakTerm/ToText.hs
+++ b/src/Entity/WeakTerm/ToText.hs
@@ -10,7 +10,6 @@ import Entity.Binder
 import Entity.DecisionTree qualified as DT
 import Entity.DefiniteDescription qualified as DD
 import Entity.Discriminant qualified as D
-import Entity.Hint
 import Entity.HoleID qualified as HID
 import Entity.Ident
 import Entity.Ident.Reify qualified as Ident
@@ -31,70 +30,72 @@ toText term =
       showVariable x
     _ :< WT.VarGlobal _ x ->
       showGlobalVariable x
-    _ :< WT.Pi xts cod ->
-      showCons ["Π", inParen $ showTypeArgs xts, toText cod]
+    _ :< WT.Pi xts cod -> do
+      case xts of
+        [(_, x, dom)]
+          | isHole x ->
+              toText dom <> " -> " <> toText cod
+        _ ->
+          inParen (showDomArgList xts) <> " -> " <> toText cod
     _ :< WT.PiIntro kind xts e -> do
       case kind of
         LK.Fix (_, x, _) -> do
-          let argStr = inParen $ showItems $ map showArg xts
-          showCons ["fix", showVariable x, argStr, toText e]
+          "mu " <> showVariable x <> inParen (showDomArgList xts) <> " " <> inBrace (toText e)
         LK.Normal -> do
-          let argStr = inParen $ showItems $ map showArg xts
-          showCons ["λ", argStr, toText e]
-    _ :< WT.PiElim e es ->
+          inParen (showDomArgList xts) <> " => " <> inBrace (toText e)
+    _ :< WT.PiElim e es -> do
       case e of
         _ :< WT.VarGlobal attr _
           | AttrVG.isConstLike attr ->
               toText e
-        _ ->
-          showCons $ map toText $ e : es
+        _ -> do
+          showApp (toText e) (map toText es)
     _ :< WT.Data (AttrD.Attr {..}) name es -> do
       if isConstLike
-        then "{data}" <> showGlobalVariable name
-        else showCons $ "{data}" <> showGlobalVariable name : map toText es
+        then showGlobalVariable name
+        else showApp (showGlobalVariable name) (map toText es)
     _ :< WT.DataIntro (AttrDI.Attr {..}) consName _ consArgs -> do
       if isConstLike
-        then "{data}" <> showGlobalVariable consName
-        else showCons ("{data-intro}" <> showGlobalVariable consName : map toText consArgs)
+        then showGlobalVariable consName
+        else showApp (showGlobalVariable consName) (map toText consArgs)
     _ :< WT.DataElim isNoetic xets tree -> do
       if isNoetic
-        then showCons ["match*", showMatchArgs xets, showDecisionTree tree]
-        else showCons ["match", showMatchArgs xets, showDecisionTree tree]
+        then "&match " <> showMatchArgs xets <> " " <> inBrace (showDecisionTree tree)
+        else "match " <> showMatchArgs xets <> " " <> inBrace (showDecisionTree tree)
     _ :< WT.Noema t ->
-      showCons ["noema", toText t]
+      "&" <> toText t
     _ :< WT.Embody _ e ->
       "*" <> toText e
-    _ :< WT.Let opacity (_, x, t) e1 e2 -> do
-      case opacity of
-        WT.Transparent ->
-          showCons ["let", showVariable x, toText t, toText e1, toText e2]
-        _ ->
-          showCons ["let-opaque", showVariable x, toText t, toText e1, toText e2]
+    _ :< WT.Let _ (_, x, t) e1 e2 -> do
+      "let " <> showVariable x <> ": " <> toText t <> " = " <> toText e1 <> " in " <> toText e2
     _ :< WT.Prim prim ->
       showPrim prim
     _ :< WT.Hole i es ->
-      showCons $ "?M" <> T.pack (show (HID.reify i)) : map toText es
+      showApp ("?M" <> T.pack (show (HID.reify i))) (map toText es)
     _ :< WT.ResourceType name ->
       showGlobalVariable name
-    _ :< WT.Magic m -> do
-      let a = fmap toText m
-      showCons [T.pack $ show a]
+    _ :< WT.Magic _ -> do
+      "<magic>"
     _ :< WT.Annotation _ _ e ->
       toText e
     _ :< WT.Flow _ t -> do
-      showCons ["flow", toText t]
+      showApp "flow" [toText t]
     _ :< WT.FlowIntro _ _ (e, _) -> do
-      showCons ["run", toText e]
+      showApp "detach" [toText e]
     _ :< WT.FlowElim _ _ (e, _) -> do
-      showCons ["wait", toText e]
+      showApp "attach" [toText e]
 
 inParen :: T.Text -> T.Text
 inParen s =
   "(" <> s <> ")"
 
-showArg :: (Hint, Ident, WT.WeakTerm) -> T.Text
-showArg (_, x, t) =
-  inParen $ showVariable x <> " " <> toText t
+inBrace :: T.Text -> T.Text
+inBrace s =
+  "{ " <> s <> " }"
+
+inBracket :: T.Text -> T.Text
+inBracket s =
+  "[" <> s <> "]"
 
 showTypeArgs :: [BinderF WT.WeakTerm] -> T.Text
 showTypeArgs args =
@@ -108,17 +109,27 @@ showTypeArgs args =
       let s2 = showTypeArgs xts
       s1 <> " " <> s2
 
+showDomArg :: BinderF WT.WeakTerm -> T.Text
+showDomArg (_, x, t) =
+  showVariable x <> ": " <> toText t
+
+showDomArgList :: [BinderF WT.WeakTerm] -> T.Text
+showDomArgList mxts =
+  T.intercalate ", " $ map showDomArg mxts
+
+showApp :: T.Text -> [T.Text] -> T.Text
+showApp e es =
+  e <> inParen (T.intercalate ", " es)
+
 showVariable :: Ident -> T.Text
-showVariable =
-  Ident.toText'
+showVariable x =
+  if isHole x
+    then "_"
+    else Ident.toText' x
 
 showGlobalVariable :: DD.DefiniteDescription -> T.Text
 showGlobalVariable dd =
   BN.reify $ LL.baseName $ DD.localLocator dd
-
-showItems :: [T.Text] -> T.Text
-showItems =
-  T.intercalate " "
 
 showPrim :: WP.WeakPrim WT.WeakTerm -> T.Text
 showPrim prim =
@@ -127,55 +138,53 @@ showPrim prim =
       PT.toText t
     WP.Value primValue ->
       case primValue of
-        WPV.Int t v ->
-          "{" <> toText t <> "}" <> T.pack (show v)
+        WPV.Int _ v ->
+          T.pack (show v)
         WPV.Float _ v ->
           T.pack (show v)
         WPV.Op op ->
           case op of
             PO.PrimUnaryOp name _ _ ->
-              showCons [T.pack (show name)]
+              T.pack (show name)
             PO.PrimBinaryOp name _ _ ->
-              showCons [T.pack (show name)]
+              T.pack (show name)
             PO.PrimCmpOp name _ _ ->
-              showCons [T.pack (show name)]
+              T.pack (show name)
             PO.PrimConvOp name _ _ ->
-              showCons [T.pack (show name)]
+              T.pack (show name)
         WPV.StaticText _ text ->
           T.pack $ show text
 
-showCons :: [T.Text] -> T.Text
-showCons =
-  inParen . T.intercalate " "
-
 showMatchArgs :: [(Ident, WT.WeakTerm, WT.WeakTerm)] -> T.Text
 showMatchArgs xets = do
-  showCons $ map showMatchArg xets
+  inParen $ T.intercalate ", " (map showMatchArg xets)
 
 showMatchArg :: (Ident, WT.WeakTerm, WT.WeakTerm) -> T.Text
 showMatchArg (x, e, t) = do
-  showCons [showVariable x, toText e, toText t]
+  showVariable x <> ": " <> toText t <> " = " <> toText e
 
 showDecisionTree :: DT.DecisionTree WT.WeakTerm -> T.Text
 showDecisionTree tree =
   case tree of
-    DT.Leaf xs cont ->
-      showCons ["leaf", showCons (map showVariable xs), toText cont]
+    DT.Leaf xs cont -> do
+      showApp "leaf" [inBracket (T.intercalate ", " (map showVariable xs)), toText cont]
     DT.Unreachable ->
       "UNREACHABLE"
     DT.Switch (cursor, cursorType) (fallbackClause, clauseList) -> do
-      showCons $
-        "switch"
-          : showCons [showCons [showVariable cursor, toText cursorType]]
-          : showDecisionTree fallbackClause
-          : map showClauseList clauseList
+      "switch"
+        <> inParen
+          ( showVariable cursor
+              <> ": "
+              <> toText cursorType
+          )
+        <> inBrace (T.intercalate ", " (map showClauseList clauseList ++ [showDecisionTree fallbackClause]))
 
 showClauseList :: DT.Case WT.WeakTerm -> T.Text
 showClauseList decisionCase = do
-  showCons
-    [ showGlobalVariable (DT.consDD decisionCase),
-      T.pack (show (D.reify (DT.disc decisionCase))),
-      showCons $ map (\(e, t) -> showCons [toText e, toText t]) (DT.dataArgs decisionCase),
+  showApp
+    (showGlobalVariable (DT.consDD decisionCase))
+    [ T.pack (show (D.reify (DT.disc decisionCase))),
+      inParen $ T.intercalate ", " $ map (\(e, t) -> toText e <> ": " <> toText t) (DT.dataArgs decisionCase),
       inParen $ showTypeArgs (DT.consArgs decisionCase),
       showDecisionTree (DT.cont decisionCase)
     ]

--- a/src/Entity/WeakTerm/ToText.hs
+++ b/src/Entity/WeakTerm/ToText.hs
@@ -10,7 +10,6 @@ import Entity.Binder
 import Entity.DecisionTree qualified as DT
 import Entity.DefiniteDescription qualified as DD
 import Entity.Discriminant qualified as D
-import Entity.HoleID qualified as HID
 import Entity.Ident
 import Entity.Ident.Reify qualified as Ident
 import Entity.LamKind qualified as LK
@@ -70,8 +69,8 @@ toText term =
       "let " <> showVariable x <> ": " <> toText t <> " = " <> toText e1 <> " in " <> toText e2
     _ :< WT.Prim prim ->
       showPrim prim
-    _ :< WT.Hole i es ->
-      showApp ("?M" <> T.pack (show (HID.reify i))) (map toText es)
+    _ :< WT.Hole {} ->
+      "_"
     _ :< WT.ResourceType name ->
       showGlobalVariable name
     _ :< WT.Magic _ -> do
@@ -125,7 +124,7 @@ showVariable :: Ident -> T.Text
 showVariable x =
   if isHole x
     then "_"
-    else Ident.toText' x
+    else Ident.toText x
 
 showGlobalVariable :: DD.DefiniteDescription -> T.Text
 showGlobalVariable dd =


### PR DESCRIPTION
(And say goodbye to the vestige of the old S-Expression syntax)