### PR TITLE
Support implicit arguments

### DIFF
--- a/book/src/ADTs-and-lambdas.md
+++ b/book/src/ADTs-and-lambdas.md
@@ -261,6 +261,13 @@ for-each(list(int), list(bool), xss, (xs) => {
 })
 ```
 
+You can also write `@foo` to pass implicit arguments explicitly (as in Coq and Lean):
+
+```neut
+let bool-list = @for-each(int, bool, int-list, int-to-bool-func) in
+cont
+```
+
 ### Keyword Arguments
 
 The arguments of a function can be supplied using their names:

--- a/book/src/ADTs-and-lambdas.md
+++ b/book/src/ADTs-and-lambdas.md
@@ -183,18 +183,17 @@ In practice, one may think of `mu` as a nested `define`.
 
 ## Some Useful Notations
 
-### Holes
+### Holes and Implicit Arguments
 
-A hole in Neut is written as `_`. The content of a hole is inferred by the type system at compile time. This can be useful when we, for example, call a polymorphic function. Suppose we have the following `map` function:
+A hole in Neut is written as `_`. The content of a hole is inferred by the type system at compile time. This can be useful when we, for example, call a polymorphic function. Suppose we have the following `for-each` function:
 
 ```neut
-// the usual one
-define map(a: tau, b: tau, f: a -> b, xs: list(a)): list(b) {
+define for-each(a: tau, b: tau, xs: list(a), f: a -> b): list(b) {
   match xs {
   - [] =>
     []
   - y :: ys =>
-    f(y) :: map(a, b, f, ys)
+    f(y) :: for-each(a, b, ys, f)
   }
 }
 ```
@@ -202,52 +201,62 @@ define map(a: tau, b: tau, f: a -> b, xs: list(a)): list(b) {
 If it were not for holes, we'd have to call this function as follows:
 
 ```neut
-let bool-list = map(int, bool, int-to-bool, int-list) in
+let bool-list = for-each(int, bool, int-list, int-to-bool-func) in
 cont
 ```
 
 Using holes, the function can be called without specifying its type arguments explicitly:
 
 ```neut
-let bool-list = map(_, _, int-to-bool-func, int-list) in
+let bool-list = for-each(_, _, int-list, int-to-bool-func) in
 cont
 ```
 
 ### Supplying Holes
 
-You can write:
+When defining a function, you can specify some of its arguments to be implicit:
 
 ```neut
-some-func/2(x, y)
+// `a: tau` and `b: tau` are implicit
+define for-each[a: tau, b: tau](xs: list(a), f: a -> b): list(b) {
+  ..
+}
 ```
 
-instead of:
+Or even shorter:
 
 ```neut
-some-func(_, _, x, y)
+define for-each[a, b](xs: list(a), f: a -> b): list(b) {
+  ..
+}
 ```
 
-The `i` in `some-func/i` specifies the number of supplied holes. Using this notation, the `map` above can now be called as follows:
+You can call this `for-each` as if it were a binary function:
 
 ```neut
-let bool-list = map/2(int-to-bool-func, int-list) in
+let bool-list = for-each(int-list, int-to-bool-func) in
+cont
+
+// ↓ (automatically translated to)
+
+let bool-list = for-each(_, _, int-list, int-to-bool-func) in
 cont
 ```
 
 This can be useful when achieving better readability (YMMV):
 
 ```neut
-// with the notation
-for-each/1(xss, (xs) => {
-  for-each/1(xs, (x) => {
-    some-func/1(x)
+// with implicit arguments
+for-each(xss, (xs) => {
+  for-each(xs, (x) => {
+    int-to-bool(x)
   })
 })
 
-// without the notation
-for-each(list(list(int)), xss, (xs) => {
-  for-each(list(int), xs, (x) => {
-    do-something(int, x)
+// without implicit arguments
+for-each(list(int), list(bool), xss, (xs) => {
+  for-each(int, bool, xs, (x) => {
+    int-to-bool(x)
   })
 })
 ```

--- a/src/Entity/Attr/Var.hs
+++ b/src/Entity/Attr/Var.hs
@@ -1,0 +1,12 @@
+module Entity.Attr.Var (Attr (..)) where
+
+import Data.Binary
+import Entity.IsExplicit
+import GHC.Generics (Generic)
+
+newtype Attr = Attr
+  { isExplicit :: IsExplicit
+  }
+  deriving (Show, Generic)
+
+instance Binary Attr

--- a/src/Entity/Attr/VarGlobal.hs
+++ b/src/Entity/Attr/VarGlobal.hs
@@ -7,7 +7,8 @@ import GHC.Generics (Generic)
 
 data Attr = Attr
   { argNum :: ArgNum,
-    isConstLike :: IsConstLike
+    isConstLike :: IsConstLike,
+    isExplicit :: Bool
   }
   deriving (Show, Generic)
 
@@ -15,4 +16,4 @@ instance Binary Attr
 
 new :: ArgNum -> Attr
 new argNum =
-  Attr {argNum = argNum, isConstLike = False}
+  Attr {argNum = argNum, isConstLike = False, isExplicit = False}

--- a/src/Entity/IsExplicit.hs
+++ b/src/Entity/IsExplicit.hs
@@ -1,0 +1,4 @@
+module Entity.IsExplicit where
+
+type IsExplicit =
+  Bool

--- a/src/Entity/RawTerm.hs
+++ b/src/Entity/RawTerm.hs
@@ -62,4 +62,4 @@ type DefInfo =
   ((Hint, T.Text), [RawBinder RawTerm], RawTerm, RawTerm)
 
 type TopDefInfo =
-  ((Hint, BN.BaseName), [RawBinder RawTerm], RawTerm, RawTerm)
+  ((Hint, BN.BaseName), [RawBinder RawTerm], [RawBinder RawTerm], RawTerm, RawTerm)

--- a/src/Entity/RawTerm.hs
+++ b/src/Entity/RawTerm.hs
@@ -11,6 +11,7 @@ import Data.Text qualified as T
 import Entity.Annotation qualified as Annot
 import Entity.Attr.Data qualified as AttrD
 import Entity.Attr.DataIntro qualified as AttrDI
+import Entity.Attr.Var qualified as AttrV
 import Entity.BaseName qualified as BN
 import Entity.DefiniteDescription qualified as DD
 import Entity.Hint
@@ -31,11 +32,11 @@ type RawTerm = Cofree RawTermF Hint
 
 data RawTermF a
   = Tau
-  | Var Name
+  | Var AttrV.Attr Name
   | Pi [RawBinder a] a
   | PiIntro (RawLamKind a) [RawBinder a] a
   | PiElim a [a]
-  | PiElimByKey Name [a] [(Hint, Key, a)] -- auxiliary syntax for key-call
+  | PiElimByKey AttrV.Attr Name [a] [(Hint, Key, a)] -- auxiliary syntax for key-call
   | Data AttrD.Attr DD.DefiniteDescription [a]
   | DataIntro AttrDI.Attr DD.DefiniteDescription [a] [a] -- (attr, consName, dataArgs, consArgs)
   | DataElim N.IsNoetic [a] (RP.RawPatternMatrix a)

--- a/src/Scene/Elaborate.hs
+++ b/src/Scene/Elaborate.hs
@@ -85,7 +85,7 @@ analyzeDefList defList = do
 -- viewStmt stmt = do
 --   case stmt of
 --     WeakStmtDefine _ _ m x _ xts codType e ->
---       Remark.printNote m $ DD.reify x <> "\n" <> toText (m :< WT.Pi xts codType) <> "\n" <> toText (m :< WT.PiIntro (LK.Normal O.Transparent) xts e)
+--       Remark.printNote m $ DD.reify x <> "\n" <> toText (m :< WT.Pi xts codType) <> "\n" <> toText (m :< WT.PiIntro LK.Normal xts e)
 --     WeakStmtDefineResource m name discarder copier ->
 --       Remark.printNote m $ "define-resource" <> DD.reify name <> "\n" <> toText discarder <> toText copier
 

--- a/src/Scene/Elaborate/Infer.hs
+++ b/src/Scene/Elaborate/Infer.hs
@@ -90,7 +90,7 @@ getUnitType :: Hint -> App WT.WeakTerm
 getUnitType m = do
   locator <- Throw.liftEither $ DD.getLocatorPair m coreUnit
   (unitDD, _) <- N.resolveName m (N.Locator locator)
-  let attr = AttrVG.Attr {argNum = AN.fromInt 0, isConstLike = True}
+  let attr = AttrVG.Attr {argNum = AN.fromInt 0, isConstLike = True, isExplicit = False}
   return $ m :< WT.PiElim (m :< WT.VarGlobal attr unitDD) []
 
 infer' :: BoundVarEnv -> WT.WeakTerm -> App (WT.WeakTerm, WT.WeakTerm)
@@ -386,7 +386,7 @@ inferClause varEnv cursorType decisionCase@(DT.Case {..}) = do
   (consArgs', extendedVarEnv) <- inferBinder' varEnv consArgs
   (cont', tCont) <- inferDecisionTree m extendedVarEnv cont
   let argNum = AN.fromInt $ length dataArgs + length consArgs
-  let attr = AttrVG.Attr {argNum = argNum, isConstLike = isConstLike}
+  let attr = AttrVG.Attr {isExplicit = False, ..}
   consTerm <- infer' varEnv $ m :< WT.VarGlobal attr consDD
   (_, tPat) <- inferPiElim varEnv m consTerm $ typedDataArgs' ++ map (\(mx, x, t) -> (mx :< WT.Var x, t)) consArgs'
   insConstraintEnv cursorType tPat

--- a/src/Scene/Elaborate/Reveal.hs
+++ b/src/Scene/Elaborate/Reveal.hs
@@ -67,7 +67,8 @@ reveal' varEnv term =
       mImpArgNum <- Implicit.lookup name
       case mImpArgNum of
         Just impArgNum
-          | AN.reify impArgNum > 0 -> do
+          | AN.reify impArgNum > 0,
+            not isExplicit -> do
               suppliedHoles <- mapM (const $ newHole m varEnv) [1 .. AN.reify impArgNum]
               args <- mapM (const $ Gensym.newIdentFromText "arg") [1 .. AN.reify argNum - AN.reify impArgNum]
               let enrichedArgs = map (,m) args

--- a/src/Scene/Parse.hs
+++ b/src/Scene/Parse.hs
@@ -164,9 +164,10 @@ parseDefine opacity = do
       O.Transparent ->
         P.keyword "inline"
   m <- P.getCurrentHint
-  ((_, name), expArgs, codType, e) <- parseTopDefInfo
+  ((_, name), impArgs, expArgs, codType, e) <- parseTopDefInfo
   name' <- lift $ Locator.attachCurrentLocator name
-  lift $ defineFunction (SK.Normal opacity) m name' (AN.fromInt 0) expArgs codType e
+  let impArgNum = AN.fromInt $ length impArgs
+  lift $ defineFunction (SK.Normal opacity) m name' impArgNum (impArgs ++ expArgs) codType e
 
 defineFunction ::
   SK.RawStmtKind ->

--- a/src/Scene/Parse.hs
+++ b/src/Scene/Parse.hs
@@ -24,6 +24,7 @@ import Data.Text qualified as T
 import Entity.ArgNum qualified as AN
 import Entity.Attr.Data qualified as AttrD
 import Entity.Attr.DataIntro qualified as AttrDI
+import Entity.Attr.Var qualified as AttrV
 import Entity.BaseName qualified as BN
 import Entity.Cache qualified as Cache
 import Entity.Decl qualified as DE
@@ -336,11 +337,11 @@ parseDefineResource = do
 
 identPlusToVar :: RawBinder RT.RawTerm -> RT.RawTerm
 identPlusToVar (m, x, _) =
-  m :< RT.Var (Var x)
+  m :< RT.Var (AttrV.Attr {isExplicit = False}) (Var x)
 
 adjustConsArg :: (RawBinder RT.RawTerm, Maybe Name) -> (RT.RawTerm, (RawIdent, Maybe Name))
 adjustConsArg ((m, x, _), mName) =
-  (m :< RT.Var (Var x), (x, mName))
+  (m :< RT.Var (AttrV.Attr {isExplicit = False}) (Var x), (x, mName))
 
 registerTopLevelNames :: [RawStmt] -> App ()
 registerTopLevelNames stmtList =

--- a/test/meta/module.ens
+++ b/test/meta/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/adder/module.ens
+++ b/test/misc/adder/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/args/module.ens
+++ b/test/misc/args/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/calc/module.ens
+++ b/test/misc/calc/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/check/module.ens
+++ b/test/misc/check/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/codata-basic/module.ens
+++ b/test/misc/codata-basic/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/complex-cancel/module.ens
+++ b/test/misc/complex-cancel/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/ex-falso/module.ens
+++ b/test/misc/ex-falso/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/fact/module.ens
+++ b/test/misc/fact/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/file/module.ens
+++ b/test/misc/file/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/fix-and-free-vars/module.ens
+++ b/test/misc/fix-and-free-vars/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/fold-tails/module.ens
+++ b/test/misc/fold-tails/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/fold-tails/source/fold-tails.nt
+++ b/test/misc/fold-tails/source/fold-tails.nt
@@ -78,7 +78,7 @@ define main(): unit {
   let yss = tails(_, xs) in // [[26, ...], [25, ...], ..., [1, ...]]
   let _ = yss in
   let _ = yss in
-  let zs = map(_, _, (l) => { head(l) }, yss) in // [26, ..., 1]
+  let zs = map((l) => { head(l) }, yss) in // [26, ..., 1]
   let _ = zs in
   let _ = zs in
   let _ = zs in

--- a/test/misc/foreign/module.ens
+++ b/test/misc/foreign/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/hello/module.ens
+++ b/test/misc/hello/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/lambda-list/module.ens
+++ b/test/misc/lambda-list/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/mutable/module.ens
+++ b/test/misc/mutable/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/mutable/source/mutable.nt
+++ b/test/misc/mutable/source/mutable.nt
@@ -18,7 +18,7 @@ define my-length(xs: &list(int)): int {
 }
 
 define bar(xs-cell: &cell(list(int))): unit {
-  borrow(_, xs-cell, (xs) => {
+  borrow(xs-cell, (xs) => {
     let len = my-length(xs) in
     print-int(len);
     print("\n")
@@ -27,17 +27,17 @@ define bar(xs-cell: &cell(list(int))): unit {
 
 define main(): unit {
   let xs: list(int) = Cons(1, Cons(2, Nil())) in
-  let xs-cell = new-cell(_, xs) in
+  let xs-cell = new-cell(xs) in
   let _ on xs-cell =
     let _ = bar(xs-cell) in
-    mutate(_, xs-cell, (xs) => {
+    mutate(xs-cell, (xs) => {
       Cons(4, xs)
     });
     let _ = bar(xs-cell) in
-    mutate(_, xs-cell, (_) => {
+    mutate(xs-cell, (_) => {
       Nil()
     });
-    mutate(_, xs-cell, (xs) => {
+    mutate(xs-cell, (xs) => {
       Cons(4, xs)
     });
     bar(xs-cell)

--- a/test/misc/nat-fact/module.ens
+++ b/test/misc/nat-fact/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/nat-list/module.ens
+++ b/test/misc/nat-list/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/nested-wildcard/module.ens
+++ b/test/misc/nested-wildcard/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/misc/print-float/module.ens
+++ b/test/misc/print-float/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/pfds/binary-search-tree/module.ens
+++ b/test/pfds/binary-search-tree/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/pfds/binomial-heap/module.ens
+++ b/test/pfds/binomial-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/pfds/binomial-heap/source/binomial-heap.nt
+++ b/test/pfds/binomial-heap/source/binomial-heap.nt
@@ -129,7 +129,7 @@ define remove-min-tree(a: tau, cmp: (a, a) -> order, h: heap(a)): ?tuple(tree(a)
 
 define delete-min(a: tau, cmp: (a, a) -> order, h: heap(a)): ?heap(a) {
   let? Tuple(Node(_, _, ts1), ts2): tuple(tree(a), heap(a)) = remove-min-tree(a, cmp, h) in
-  Some(merge(a, cmp, reverse(tree(a), ts1), ts2))
+  Some(merge(a, cmp, reverse(ts1), ts2))
 }
 
 define compare-int(x: int, y: int): order {

--- a/test/pfds/custom-stack/module.ens
+++ b/test/pfds/custom-stack/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/pfds/finite-map/module.ens
+++ b/test/pfds/finite-map/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/pfds/leftist-heap/module.ens
+++ b/test/pfds/leftist-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/pfds/naive-queue/module.ens
+++ b/test/pfds/naive-queue/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/pfds/naive-queue/source/naive-queue.nt
+++ b/test/pfds/naive-queue/source/naive-queue.nt
@@ -24,7 +24,7 @@ define head(a: tau, q: &queue(a)): ?a {
 inline sanitize(a: tau, q: queue(a)): queue(a) {
   match q {
   - Tuple([], ys) =>
-    Tuple(reverse(_, ys), [])
+    Tuple(reverse(ys), [])
   - q =>
     q
   }

--- a/test/pfds/pairing-heap/module.ens
+++ b/test/pfds/pairing-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/pfds/random-access-list/module.ens
+++ b/test/pfds/random-access-list/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/pfds/red-black-tree/module.ens
+++ b/test/pfds/red-black-tree/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/pfds/splay-heap/module.ens
+++ b/test/pfds/splay-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/pfds/stack/module.ens
+++ b/test/pfds/stack/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/pfds/stream/module.ens
+++ b/test/pfds/stream/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/statement/define/module.ens
+++ b/test/statement/define/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/statement/define/source/define.nt
+++ b/test/statement/define/source/define.nt
@@ -102,5 +102,8 @@ define main(): unit {
   let _ = implicit-0(&text, "hello") in
   let _ = implicit-1("hello") in
   let _ = implicit-2("hello", tau) in
+  let _ = @implicit-0(&text, "hello") in
+  let _ = @implicit-1(&text, "hello") in
+  let _ = @implicit-2(&text, tau, "hello", tau) in
   Unit
 }

--- a/test/statement/define/source/define.nt
+++ b/test/statement/define/source/define.nt
@@ -63,7 +63,7 @@ define multiple-argument-list(x: int)(y: int, z: bool, w: int -> int): int {
   }
 }
 
-define imp-multiple(a: tau, x: a)(y: int, z: bool, w: a -> int): int {
+define dependent-multiple(a: tau, x: a)(y: int, z: bool, w: a -> int): int {
   if eq-int(1, y) {
     10
   } else-if z {
@@ -71,6 +71,18 @@ define imp-multiple(a: tau, x: a)(y: int, z: bool, w: a -> int): int {
   } else {
     3
   }
+}
+
+define implicit-0[](a : tau, x: a): a {
+  x
+}
+
+define implicit-1[a](x: a): a {
+  x
+}
+
+define implicit-2[a, b](x: a, y: b): tuple(a, b) {
+  Tuple(x, y)
 }
 
 define multi(a: tau, x: a)(y: int)(z: bool)(w: a -> int): int {
@@ -86,6 +98,9 @@ define multi(a: tau, x: a)(y: int)(z: bool)(w: a -> int): int {
 define main(): unit {
   let _ = is-even(12345) in
   let _ = multiple-argument-list(10)(20, True, (x) => { add-int(x, 1) }) in
-  let _ = imp-multiple(tau, tau)(10, False, (_) => { 20 }) in
+  let _ = dependent-multiple(tau, tau)(10, False, (_) => { 20 }) in
+  let _ = implicit-0(&text, "hello") in
+  let _ = implicit-1("hello") in
+  let _ = implicit-2("hello", tau) in
   Unit
 }

--- a/test/statement/empty-import-export/module.ens
+++ b/test/statement/empty-import-export/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/statement/import-names/module.ens
+++ b/test/statement/import-names/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/statement/resource-basic/module.ens
+++ b/test/statement/resource-basic/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/statement/variant-struct/module.ens
+++ b/test/statement/variant-struct/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/term/flow/module.ens
+++ b/test/term/flow/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/term/flow/source/flow.nt
+++ b/test/term/flow/source/flow.nt
@@ -52,7 +52,7 @@ define some-list(len: int, acc: list(int)): list(int) {
 
 define detach-send(x: int, ch: &channel(int)): flow(unit) {
   detach {
-    send(int, ch, x)
+    send(ch, x)
   }
 }
 
@@ -72,7 +72,7 @@ define receive-one-by-one(xs: list(flow(unit)), ch: &channel(int)): unit {
     Unit
   - fl :: rest =>
     let _ = attach fl in
-    let _ = receive(int, ch) in
+    let _ = receive(ch) in
     receive-one-by-one(rest, ch)
   }
 }
@@ -89,14 +89,14 @@ define receive-all-at-once(xs: list(flow(unit)), ch: &channel(int)): unit {
       }
     }
   in
-  let size on xs = length(flow(unit), xs) in
+  let size on xs = length(xs) in
   wait-all(xs);
   let receive-all =
     mu receive-all(count: int) {
       if eq-int(count, 0) {
         Unit
       } else {
-        let _ = receive(_, ch) in
+        let _ = receive(ch) in
         receive-all(sub-int(count, 1))
       }
     }
@@ -105,7 +105,7 @@ define receive-all-at-once(xs: list(flow(unit)), ch: &channel(int)): unit {
 }
 
 define test-behavior(): unit {
-  let ch = new-channel(int) in
+  let ch = new-channel() in
   let _ on ch =
     let fl1 =
       detach {
@@ -128,29 +128,29 @@ define test-behavior(): unit {
   in
   let _ = ch in
 
-  let ch = new-channel(() -> int) in
+  let ch = new-channel() in
   let ch: channel(() -> int) = ch in
   let _ = ch in
-  let _ on ch = send(_, ch, () => {1}) in
+  let _ on ch = send(ch, () => {1}) in
   let ch = ch in
   let ch-clone = ch in
-  let _ on ch-clone = send(_, ch-clone, () => {1}) in
+  let _ on ch-clone = send(ch-clone, () => {1}) in
   let tmp on ch-clone =
     let f =
       detach {
         ext.sleep(1);
-        send(_, ch-clone, () => {3})
+        send(ch-clone, () => {3})
       }
     in
     let g =
       detach {
         ext.sleep(1);
-        send(() -> int, ch-clone, () => {4})
+        send(ch-clone, () => {4})
       }
     in
-    let _ = receive(_, ch-clone) in
-    let _ = receive(_, ch-clone) in
-    let _ = receive(_, ch-clone) in
+    let _ = receive(ch-clone) in
+    let _ = receive(ch-clone) in
+    let _ = receive(ch-clone) in
     attach f;
     attach g
   in

--- a/test/term/noema/module.ens
+++ b/test/term/noema/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/term/noema/source/noema.nt
+++ b/test/term/noema/source/noema.nt
@@ -5,11 +5,11 @@ define test-syntax(): unit {
   let xs: list(int) = [1, 2, 3] in
   let _ on xs =
     let _ on xs =
-      let l1 = length(int, !xs) in
-      let l2 = length(int, !xs) in
+      let l1 = length(!xs) in
+      let l2 = length(!xs) in
       add-int(l1, l2)
     in
-    let _ = length(int, xs) in
+    let _ = length(xs) in
     let xs-copy = !xs in
     let _ = xs in
     let _ = xs in
@@ -19,18 +19,18 @@ define test-syntax(): unit {
     let _ = xs-copy in
     &match xs {
     - [] =>
-      length(int, xs)
+      length(xs)
     - _ :: ys =>
-      length(int, ys)
+      length(ys)
     }
   in
   let _ = xs in
   let ys = xs in
   let zs = xs in
   let _ on xs, ys, zs =
-    let v1 = length(int, xs) in
-    let v2 = length(int, ys) in
-    let v3 = length(int, zs) in
+    let v1 = length(xs) in
+    let v2 = length(ys) in
+    let v3 = length(zs) in
     add-int(v1, add-int(v2, v3))
   in
   let _ = xs in
@@ -148,12 +148,12 @@ data ctx {
 
 define with-ctx(c: &ctx): unit {
   &let Ctx(counter) = c in
-  let current-value = clone(int, counter) in
+  let current-value = clone(counter) in
   if eq-int(current-value, 0) {
     print("stop\n")
   } else {
     print("loop\n");
-    mutate(int, counter, (x) => { sub-int(x, 1) });
+    mutate(counter, (x) => { sub-int(x, 1) });
     with-ctx(c)
   }
 }
@@ -175,7 +175,7 @@ define test-resource(): unit {
   let _ = t2 in
   let _ = t3 in
   let _ = t4 in
-  let c = Ctx(new-cell(_, 5)) in
+  let c = Ctx(new-cell(5)) in
   let _ on c = with-ctx(c) in
   let _ = c in
   Unit

--- a/test/term/pi/module.ens
+++ b/test/term/pi/module.ens
@@ -1,15 +1,15 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }
   prefix {
-    term "this.pi-term"
     keyword "this.pi-keyword"
+    term "this.pi-term"
   }
   target {
     pi "pi.nt"

--- a/test/term/prim/module.ens
+++ b/test/term/prim/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/term/tau/module.ens
+++ b/test/term/tau/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/term/unitary/module.ens
+++ b/test/term/unitary/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/term/unitary/source/unitary.nt
+++ b/test/term/unitary/source/unitary.nt
@@ -31,14 +31,14 @@ define test-item1(): unit {
 define use-item1(x: item1): list(int) {
   match x {
   - Item1(value) =>
-    trace-list/1(value)
+    trace-list(value)
   }
 }
 
 define use-item1-noetic(x: &item1): list(int) {
   &match x {
   - Item1(value) =>
-    trace-list/1(!value)
+    trace-list(!value)
   }
 }
 
@@ -115,23 +115,23 @@ define test-item4(): unit {
 define use-item4(x: item4(int, list(int))): list(int) {
   match x {
   - Item4(Tuple(v, xs)) =>
-    trace-list/1(v :: xs)
+    trace-list(v :: xs)
   }
 }
 
 define use-item4-noetic(x: &item4(int, list(int))): list(int) {
   &match x {
   - Item4(Tuple(v, xs)) =>
-    trace-list/1(!v :: !xs)
+    trace-list(!v :: !xs)
   }
 }
 
-define trace-list(a: tau, xs: list(a)): list(a) {
+define trace-list[a](xs: list(a)): list(a) {
   match xs {
   - [] =>
     []
   - y :: ys =>
-    y :: trace-list(a, ys)
+    y :: trace-list(ys)
   }
 }
 

--- a/test/term/var/module.ens
+++ b/test/term/var/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/term/variant/module.ens
+++ b/test/term/variant/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "fYFSK71KIBclMuPuvJ2X4zTUNRQm5bR28oYafGP149g="
+      digest "UINiz9QyUuBZqC8H2Le8DJu0o71UrvPRlKAMW3fZPLc="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-4-0.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-6.tar.zst"
       ]
     }
   }

--- a/test/term/variant/source/variant.nt
+++ b/test/term/variant/source/variant.nt
@@ -220,7 +220,7 @@ data monoid(a) {
 inline list-monoid(a: tau): monoid(list(a)) {
   Monoid of {
   - m-op =>
-    (xs, ys) => { core.list.append(a, xs, ys) }
+    (xs, ys) => { core.list.append(xs, ys) }
   - m-empty =>
     []
   }


### PR DESCRIPTION
This PR allows the followings:

- defining/using top-level functions with implicit arguments
- pass implicit arguments explicitly by writing `@foo(bar, buz)` as in Coq or Lean

Example:

```neut
// top-level function `length` with an implicit argument `a`
define length[a](xs: list(a)): int {
  ..
}

// using top-level function `length`
define foo(): unit {
  let xs = [bar, buz] in

  // use `length` by inferring `a`
  let _ = length(xs) in 

  // implicit arguments can also be passed explicitly by writing `@foo(bar, buz)`
  let _ = @length(some-type, xs) in

  Unit
}
```