### PR TITLE
Add a notation for (not necessarily) monadic bind

### DIFF
--- a/book/src/other-built-in-utilities.md
+++ b/book/src/other-built-in-utilities.md
@@ -170,6 +170,51 @@ define use-my-int(x: my-int()) {
 
 which relieves code cluttering.
 
+### A Notation for (Not Necessarily) Monadic Binds
+
+You can use Neut's `with` notation as something like the `do` notation in other languages:
+
+```neut
+// play with the `with` notation
+define test(): except(&text, int) {
+  with except-bind {
+    bind x: bool = Pass(True) in   // x == True
+    bind y: tau = Fail("error") in // returns `Fail("error"): except(&text, int)`
+    Pass(10) // not executed
+  }
+}
+```
+
+where the `except-bind` is the bind operator of the except monad:
+
+```neut
+// monadic bind
+define except-bind[e, a, b](x: except(e, a), k: a -> except(e, b)): except(e, b) {
+  match x {
+  - Fail(err) => Fail(err)
+  - Pass(value) => k(value)
+  }
+}
+```
+
+Although the `binder` in `with binder { .. }` is a monadic bind in the case above, it can be any term as long as it typechecks.
+
+Let's take a look at a slightly more complex example:
+
+```neut
+define test(): except(&text, int) {
+  with except-bind {
+    let _ = tau in   // `let` can be used in `with` as usual
+    print("hey");    // `e1; e2` can also be used in `with` as usual
+    bind _: bool =
+      bind _: bool = Pass(True) in // `bind` is nestable
+      Fail("hello")
+    in
+    Pass(10)
+  }
+}
+```
+
 ### Tail Call Optimization
 
 Neut optimizes all the tail calls. Thus, for example, the following function is optimized into a loop:

--- a/book/theme/book.js
+++ b/book/theme/book.js
@@ -19,11 +19,12 @@ hljs.registerLanguage("neut", function (hljs) {
       keyword: [
         "alias",
         "attach",
+        "bind",
         "by",
         "case",
         "data",
-        "default",
         "declare",
+        "default",
         "define",
         "detach",
         "else",

--- a/test/term/with/module.ens
+++ b/test/term/with/module.ens
@@ -1,0 +1,13 @@
+{
+  dependency {
+    core {
+      digest "wCcmGSKo6JFVJh7ZNg3SOskZjRttwzpP_96_HC4DGYs="
+      mirror [
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-7.tar.zst"
+      ]
+    }
+  }
+  target {
+    with "with.nt"
+  }
+}

--- a/test/term/with/source/with.nt
+++ b/test/term/with/source/with.nt
@@ -21,7 +21,8 @@ define test(): except(&text, int) {
       bind _: bool = Pass(True) in
       nop();
       let _ = tau in
-      Fail("hello") in
+      Fail("hello")
+    in
     bind _: bool = Fail("hello") in
     bind _: bool = Fail("hello") in
     nop();

--- a/test/term/with/source/with.nt
+++ b/test/term/with/source/with.nt
@@ -1,0 +1,35 @@
+define nop(): unit {
+  Unit
+}
+
+define except-bind[e, a, b](x: except(e, a), k: a -> except(e, b)): except(e, b) {
+  match x {
+  - Fail(err) => Fail(err)
+  - Pass(value) => k(value)
+  }
+}
+
+define test(): except(&text, int) {
+  with except-bind {
+    bind _: bool = Fail("hello") in
+    let _ = tau in
+    bind _: bool = Fail("hello") in
+    let _ = tau in
+    bind _: bool = Pass(True) in
+    nop();
+    bind _: bool =
+      bind _: bool = Pass(True) in
+      nop();
+      let _ = tau in
+      Fail("hello") in
+    bind _: bool = Fail("hello") in
+    bind _: bool = Fail("hello") in
+    nop();
+    bind _: tau = Pass(int) in
+    Pass(10)
+  }
+}
+
+define main(): unit {
+  print("Hello, world!\n")
+}


### PR DESCRIPTION
This PR adds the following notation:

```
// base case

with binder {
  e
}

↓

e

// step case (for let)

with binder {
  let x = e in
  cont
}

↓

let x = e in
with binder { cont }

// step case (for seq)

with binder {
  e;
  cont
}

↓

e;
with binder { cont }

// step case (for bind)

with binder {
  bind x = e in
  cont
}

↓

binder(with binder { e }, (x) => {
  with binder { cont }
})
```

Example:

```neut
// binder (the bind operator of the except monad)
define except-bind[e, a, b](x: except(e, a), k: a -> except(e, b)): except(e, b) {
  match x {
  - Fail(err) => Fail(err)
  - Pass(value) => k(value)
  }
}

// try the `with` notation
define test(): except(&text, int) {
  with except-bind {
    bind _: bool = Fail("hello") in
    let _ = tau in
    bind _: bool =
      bind _: bool = Pass(True) in // with-notation is nestable
      Fail("hello")
    in
    Pass(10)
  }
}
```