### PR TITLE
Reorganize keywords and remove some notations

### DIFF
--- a/book/src/basics-of-modules.md
+++ b/book/src/basics-of-modules.md
@@ -22,7 +22,7 @@ When running compilation, every module is marked as "main" or "library". The mai
 A module can use other modules. Such module dependencies can be added using `neut add`:
 
 ```sh
-neut add core https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst
+neut add core https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst
 ```
 
 By running the code above, the specified tarball is downloaded into `~/.cache/neut/library`:
@@ -30,20 +30,20 @@ By running the code above, the specified tarball is downloaded into `~/.cache/ne
 ```sh
 ls ~/.cache/neut/library
 # => ...
-#    ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ=
+#    tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g=
 #    ...
 ```
 
-where the `ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ=` is the digest of the module. Also, the module information is added to the current module's `module.ens`:
+where the `tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g=` is the digest of the module. Also, the module information is added to the current module's `module.ens`:
 
 ```ens
 {
   // ...
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/book/src/basics-of-modules.md
+++ b/book/src/basics-of-modules.md
@@ -22,7 +22,7 @@ When running compilation, every module is marked as "main" or "library". The mai
 A module can use other modules. Such module dependencies can be added using `neut add`:
 
 ```sh
-neut add core https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst
+neut add core https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst
 ```
 
 By running the code above, the specified tarball is downloaded into `~/.cache/neut/library`:
@@ -30,20 +30,20 @@ By running the code above, the specified tarball is downloaded into `~/.cache/ne
 ```sh
 ls ~/.cache/neut/library
 # => ...
-#    LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs=
+#    ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ=
 #    ...
 ```
 
-where the `LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs=` is the digest of the module. Also, the module information is added to the current module's `module.ens`:
+where the `ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ=` is the digest of the module. Also, the module information is added to the current module's `module.ens`:
 
 ```ens
 {
   // ...
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/book/src/importing-names.md
+++ b/book/src/importing-names.md
@@ -77,9 +77,9 @@ Suppose that you have added a library module to your module:
   // ...
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }
@@ -106,7 +106,7 @@ Here, the module alias of `core.text.io` is `core`, and the relative path is `te
 ```sh
 core => DIGEST_OF_THE_LIBRARY
 
-# core => ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ=
+# core => tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g=
 ```
 
 and do the following name resolution:
@@ -116,7 +116,7 @@ core.text.io.get-line
 
 ↓
 
-ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ=.text.io.get-line
+tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g=.text.io.get-line
 ```
 
 ## Module-Based Qualified Import

--- a/book/src/importing-names.md
+++ b/book/src/importing-names.md
@@ -77,9 +77,9 @@ Suppose that you have added a library module to your module:
   // ...
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }
@@ -106,7 +106,7 @@ Here, the module alias of `core.text.io` is `core`, and the relative path is `te
 ```sh
 core => DIGEST_OF_THE_LIBRARY
 
-# core => LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs=
+# core => ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ=
 ```
 
 and do the following name resolution:
@@ -116,7 +116,7 @@ core.text.io.get-line
 
 ↓
 
-LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs=.text.io.get-line
+ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ=.text.io.get-line
 ```
 
 ## Module-Based Qualified Import

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -32,8 +32,8 @@ We also need to register the URL and the digest of the core module (standard lib
 
 ```sh
 # add the below to your bashrc, zshrc, etc.
-export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
-export NEUT_CORE_MODULE_DIGEST="ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
+export NEUT_CORE_MODULE_DIGEST="tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
 ```
 
 Now, let's create a sample project and build it to check if your installation is correct:

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -32,8 +32,8 @@ We also need to register the URL and the digest of the core module (standard lib
 
 ```sh
 # add the below to your bashrc, zshrc, etc.
-export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
-export NEUT_CORE_MODULE_DIGEST="LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+export NEUT_CORE_MODULE_DIGEST="ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
 ```
 
 Now, let's create a sample project and build it to check if your installation is correct:

--- a/book/src/noetic-optimization.md
+++ b/book/src/noetic-optimization.md
@@ -66,7 +66,7 @@ Using a noema, for example, the length of a list can be obtained as follows:
 
 ```neut
 define length-noetic(a: tau, xs: &list(a)): int {
-  &match xs {
+  case xs {
   - [] =>
     0
   - y :: ys =>
@@ -75,13 +75,13 @@ define length-noetic(a: tau, xs: &list(a)): int {
 }
 ```
 
-Here, `&match` does the same as `match` except that:
+Here, `case` does the same as `match` except that:
 
 - it expects noetic ADTs like `&list(a)`, not ordinary ADTs like `list(a)`,
 - it doesn't call `free` against its arguments (the `xs` here), and that
 - the types of the constructor arguments are casted to be noetic.
 
-The last one means, for example, the type of `y` in the example above is not `a` but `&a`. Similarly, The type of `ys` is not `list(a)`, but `&list(a)`. This ensures that the internal content of `xs` is kept intact. In this sense, you can think of `&match` as a read-only variant of `match`.
+The last one means, for example, the type of `y` in the example above is not `a` but `&a`. Similarly, The type of `ys` is not `list(a)`, but `&list(a)`. This ensures that the internal content of `xs` is kept intact. In this sense, you can think of `case` as a read-only variant of `match`.
 
 Note that, although the `y: &a` is unused in the code above, since `&a` is a noetic type, this `y` isn't discarded, which is what we wanted.
 
@@ -91,7 +91,7 @@ Also, you can create a value of type `A` from a noema of type `&A`:
 
 ```neut
 define sum-of-list(xs: &list(int)): int {
-  &match xs {
+  case xs {
   - [] =>
     0
   - y :: ys =>
@@ -175,7 +175,7 @@ This restriction is checked at compile time by the type system of Neut.
 
 Some (including me) might find the above restriction rather ad-hoc. Indeed, there exists an alternative, more seemingly principled approach. The approach essentially uses [the ST monad](https://hackage.haskell.org/package/base-4.18.0.0/docs/Control-Monad-ST.html); Every noetic type is now of the form `noema(s, A)`, where the `s` corresponds to the `s` in `STRef s a`.
 
-In this approach, `let-on` would internally use `runST: (forall s. ST s a) -> a` to ensure that the result doesn't depend on noetic values. Also, in this approach, the whole language will be made pure so that we can track every use of `&e` and `&match`. This approach will be a variation of [Monadic State: Axiomatization and Type Safety](https://dl.acm.org/doi/abs/10.1145/258949.258970), or [Monadic Regions](https://dl.acm.org/doi/abs/10.1145/1016848.1016867).
+In this approach, `let-on` would internally use `runST: (forall s. ST s a) -> a` to ensure that the result doesn't depend on noetic values. Also, in this approach, the whole language will be made pure so that we can track every use of `&e` and `case`. This approach will be a variation of [Monadic State: Axiomatization and Type Safety](https://dl.acm.org/doi/abs/10.1145/258949.258970), or [Monadic Regions](https://dl.acm.org/doi/abs/10.1145/1016848.1016867).
 
 Then, why Neut didn't take this more "principled" approach? This is because the virtue of noetic types lies in making our experience with certain fragments of the language better. Indeed, we can already do the same thing without noetic stuff by using unsafe casts appropriately. Although we can make the language pure and change the formulation of noemata into `noema(s, A)`, pursuing local generality here by modifying the whole language will go against the purpose of noetic types; They are there to provide certain safe patterns of uses of unsafe casts.
 

--- a/book/src/noetic-optimization.md
+++ b/book/src/noetic-optimization.md
@@ -95,12 +95,12 @@ define sum-of-list(xs: &list(int)): int {
   - [] =>
     0
   - y :: ys =>
-    add-int(!y, sum-of-list(ys))
+    add-int(*y, sum-of-list(ys))
   }
 }
 ```
 
-`!e` copies the argument along its type, keeping the original noema intact. In the example above, a term of type `int` is obtained from a term `y: &int`, by writing `!y`.
+`*e` copies the argument along its type, keeping the original noema intact. In the example above, a term of type `int` is obtained from a term `y: &int`, by writing `*y`.
 
 ## Example: Get the Length of a List
 
@@ -165,7 +165,7 @@ let result on xs = HideX(xs) in // the type of `result` is `jokerX` (dubious)
 let _ = xs in                   // `xs` is discarded here
 match result {
 - HideX(xs) =>
-  !xs                           // CRASH: use-after-free!
+  *xs                           // CRASH: use-after-free!
 }
 ```
 

--- a/book/src/noetic-programming.md
+++ b/book/src/noetic-programming.md
@@ -72,11 +72,11 @@ By using a noema, we can perform something like "borrowing" in other languages.
 
 ## Using a Noema: Viewing Its Contents
 
-The content of a noema can be viewed using `&match`:
+The content of a noema can be viewed using `case`:
 
 ```neut
 define length(a: tau, xs: &list(a)): int {
-  &match xs {
+  case xs {
   - [] =>
     0
   - y :: ys =>
@@ -85,9 +85,9 @@ define length(a: tau, xs: &list(a)): int {
 }
 ```
 
-Here, the `&match` is the noetic variant of `match`; It does the same as `match` except that it doesn't free the outer tuple of the given value (`xs` in this &match).
+Here, the `case` is the noetic variant of `match`; It does the same as `match` except that it doesn't free the outer tuple of the given value (`xs` in this case).
 
-The variables that are bound by a `&match` are cast to be noetic. For example, the `y` in the example above is not of type `a`, but of type `&a`. The `ys` is not of type `list(a)`, but of type `&list(a)`. Since the type of `y` is noetic, `y` isn't discarded even though it isn't used.
+The variables that are bound by a `case` are cast to be noetic. For example, the `y` in the example above is not of type `a`, but of type `&a`. The `ys` is not of type `list(a)`, but of type `&list(a)`. Since the type of `y` is noetic, `y` isn't discarded even though it isn't used.
 
 ## Using a Noema: Incarnation
 
@@ -95,7 +95,7 @@ You can embody a noema using `*e`:
 
 ```neut
 define sum-of-list(xs: &list(int)): int {
-  &match xs {
+  case xs {
   - [] =>
     0
   - y :: ys =>

--- a/book/src/noetic-programming.md
+++ b/book/src/noetic-programming.md
@@ -91,7 +91,7 @@ The variables that are bound by a `&match` are cast to be noetic. For example, t
 
 ## Using a Noema: Incarnation
 
-You can embody a noema using `!e`:
+You can embody a noema using `*e`:
 
 ```neut
 define sum-of-list(xs: &list(int)): int {
@@ -99,12 +99,12 @@ define sum-of-list(xs: &list(int)): int {
   - [] =>
     0
   - y :: ys =>
-    add-int(!y, sum-of-list(ys)) // ← a use of `!e`
+    add-int(*y, sum-of-list(ys)) // ← a use of `*e`
   }
 }
 ```
 
-`!e` copies a noema along its inner type. For example, since the `y` above is of type `&int`, `!y: int` is a `y`'s new copy of type `int` (which is the same as `y` in this case, since `y` is an immediate).
+`*e` copies a noema along its inner type. For example, since the `y` above is of type `&int`, `*y: int` is a `y`'s new copy of type `int` (which is the same as `y` in this case, since `y` is an immediate).
 
 ## The Type of a Static Text
 

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -65,8 +65,8 @@ An example scenario:
 
 ```sh
 # setting up the core module (i.e. standard library)
-export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
-export NEUT_CORE_MODULE_DIGEST="LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+export NEUT_CORE_MODULE_DIGEST="ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
 
 # get the compiler (choose one)
 curl -L -o ~/.local/bin/neut https://github.com/vekatze/neut/releases/latest/download/neut-arm64-darwin

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -65,8 +65,8 @@ An example scenario:
 
 ```sh
 # setting up the core module (i.e. standard library)
-export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
-export NEUT_CORE_MODULE_DIGEST="ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
+export NEUT_CORE_MODULE_DIGEST="tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
 
 # get the compiler (choose one)
 curl -L -o ~/.local/bin/neut https://github.com/vekatze/neut/releases/latest/download/neut-arm64-darwin

--- a/src/Context/Definition.hs
+++ b/src/Context/Definition.hs
@@ -16,7 +16,7 @@ import Prelude hiding (lookup, read)
 
 insert :: O.Opacity -> DD.DefiniteDescription -> [BinderF TM.Term] -> TM.Term -> App ()
 insert opacity name xts e =
-  when (opacity == O.Transparent) $
+  when (opacity == O.Clear) $
     modifyRef' defMap $
       Map.insert name (xts, e)
 

--- a/src/Context/WeakDefinition.hs
+++ b/src/Context/WeakDefinition.hs
@@ -24,7 +24,7 @@ type DefMap =
 
 insert :: O.Opacity -> Hint -> DD.DefiniteDescription -> [BinderF WeakTerm] -> WeakTerm -> App ()
 insert opacity m name xts e =
-  when (opacity == O.Transparent) $
+  when (opacity == O.Clear) $
     modifyRef' weakDefMap $
       Map.insert name (m :< WT.PiIntro LK.Normal xts e)
 

--- a/src/Entity/Opacity.hs
+++ b/src/Entity/Opacity.hs
@@ -5,7 +5,7 @@ import GHC.Generics
 
 data Opacity
   = Opaque
-  | Transparent
+  | Clear
   deriving (Show, Eq, Generic)
 
 instance Binary Opacity

--- a/src/Entity/RawTerm.hs
+++ b/src/Entity/RawTerm.hs
@@ -35,7 +35,7 @@ data RawTermF a
   | Pi [RawBinder a] a
   | PiIntro (RawLamKind a) [RawBinder a] a
   | PiElim a [a]
-  | PiElimByKey AttrV.Attr Name [a] [(Hint, Key, a)] -- auxiliary syntax for key-call
+  | PiElimByKey AttrV.Attr Name [(Hint, Key, a)] -- auxiliary syntax for key-call
   | Data AttrD.Attr DD.DefiniteDescription [a]
   | DataIntro AttrDI.Attr DD.DefiniteDescription [a] [a] -- (attr, consName, dataArgs, consArgs)
   | DataElim N.IsNoetic [a] (RP.RawPatternMatrix a)

--- a/src/Entity/StmtKind.hs
+++ b/src/Entity/StmtKind.hs
@@ -41,7 +41,7 @@ toOpacity stmtKind =
     Normal opacity ->
       opacity
     _ ->
-      O.Transparent
+      O.Clear
 
 toLowOpacity :: BaseStmtKind x t -> O.Opacity
 toLowOpacity stmtKind =
@@ -51,4 +51,4 @@ toLowOpacity stmtKind =
     Data {} ->
       O.Opaque -- so as not to reduce recursive terms
     DataIntro {} ->
-      O.Transparent
+      O.Clear

--- a/src/Entity/WeakTerm.hs
+++ b/src/Entity/WeakTerm.hs
@@ -47,7 +47,7 @@ type SubstWeakTerm =
 
 data LetOpacity
   = Opaque
-  | Transparent
+  | Clear
   | Noetic
   deriving (Show, Eq)
 
@@ -56,18 +56,18 @@ reifyOpacity letOpacity =
   case letOpacity of
     Opaque ->
       O.Opaque
-    Transparent ->
-      O.Transparent
+    Clear ->
+      O.Clear
     Noetic ->
-      O.Transparent
+      O.Clear
 
 reflectOpacity :: O.Opacity -> LetOpacity
 reflectOpacity opacity =
   case opacity of
     O.Opaque ->
       Opaque
-    O.Transparent ->
-      Transparent
+    O.Clear ->
+      Clear
 
 toVar :: Hint -> Ident -> WeakTerm
 toVar m x =

--- a/src/Entity/WeakTerm/ToText.hs
+++ b/src/Entity/WeakTerm/ToText.hs
@@ -59,7 +59,7 @@ toText term =
         else showApp (showGlobalVariable consName) (map toText consArgs)
     _ :< WT.DataElim isNoetic xets tree -> do
       if isNoetic
-        then "&match " <> showMatchArgs xets <> " " <> inBrace (showDecisionTree tree)
+        then "case " <> showMatchArgs xets <> " " <> inBrace (showDecisionTree tree)
         else "match " <> showMatchArgs xets <> " " <> inBrace (showDecisionTree tree)
     _ :< WT.Noema t ->
       "&" <> toText t

--- a/src/Entity/WeakTerm/ToText.hs
+++ b/src/Entity/WeakTerm/ToText.hs
@@ -65,8 +65,12 @@ toText term =
       "&" <> toText t
     _ :< WT.Embody _ e ->
       "*" <> toText e
-    _ :< WT.Let _ (_, x, t) e1 e2 -> do
-      "let " <> showVariable x <> ": " <> toText t <> " = " <> toText e1 <> " in " <> toText e2
+    _ :< WT.Let opacity (_, x, t) e1 e2 -> do
+      case opacity of
+        WT.Noetic ->
+          "tie " <> showVariable x <> ": " <> toText t <> " = " <> toText e1 <> " in " <> toText e2
+        _ ->
+          "let " <> showVariable x <> ": " <> toText t <> " = " <> toText e1 <> " in " <> toText e2
     _ :< WT.Prim prim ->
       showPrim prim
     _ :< WT.Hole {} ->

--- a/src/Scene/Clarify/Sigma.hs
+++ b/src/Scene/Clarify/Sigma.hs
@@ -31,14 +31,14 @@ registerImmediateS4 :: App ()
 registerImmediateS4 = do
   let immediateT _ = return $ C.UpIntro $ C.SigmaIntro []
   let immediate4 arg = return $ C.UpIntro arg
-  registerSwitcher O.Transparent DD.imm immediateT immediate4
+  registerSwitcher O.Clear DD.imm immediateT immediate4
 
 registerClosureS4 :: App ()
 registerClosureS4 = do
   (env, envVar) <- Gensym.newValueVarLocalWith "env"
   registerSigmaS4
     DD.cls
-    O.Transparent
+    O.Clear
     [Right (env, returnImmediateS4), Left (C.UpIntro envVar), Left returnImmediateS4]
 
 returnImmediateS4 :: C.Comp
@@ -133,7 +133,7 @@ closureEnvS4 mxts =
     _ -> do
       i <- Gensym.newCount
       name <- Locator.attachCurrentLocator $ BN.sigmaName i
-      registerSwitcher O.Transparent name (sigmaT mxts) (sigma4 mxts)
+      registerSwitcher O.Clear name (sigmaT mxts) (sigma4 mxts)
       return $ C.VarGlobal name AN.argNumS4
 
 returnSigmaDataS4 ::
@@ -154,7 +154,7 @@ returnEnumS4 dataName = do
   let aff _ = return $ C.UpIntro $ C.SigmaIntro []
   let rel arg = return $ C.UpIntro arg
   let dataName' = DD.getFormDD dataName
-  registerSwitcher O.Transparent dataName' aff rel
+  registerSwitcher O.Clear dataName' aff rel
   return $ C.UpIntro $ C.VarGlobal dataName' AN.argNumS4
 
 sigmaData4 :: [(D.Discriminant, [(Ident, C.Comp)])] -> C.Value -> App C.Comp

--- a/src/Scene/Comp/Reduce.hs
+++ b/src/Scene/Comp/Reduce.hs
@@ -28,7 +28,7 @@ reduce term =
         C.VarGlobal x _ -> do
           mDefValue <- CompDefinition.lookup x
           case mDefValue of
-            Just (O.Transparent, xs, body) -> do
+            Just (O.Clear, xs, body) -> do
               let sub = IntMap.fromList (zip (map Ident.toInt xs) ds)
               subst sub body >>= reduce
             _ ->

--- a/src/Scene/Parse.hs
+++ b/src/Scene/Parse.hs
@@ -127,9 +127,9 @@ parseStmt = do
   choice
     [ parseDefineData,
       return <$> parseAliasOpaque,
-      return <$> parseAliasTransparent,
+      return <$> parseAliasClear,
       return <$> parseDefineResource,
-      return <$> parseDefine O.Transparent,
+      return <$> parseDefine O.Clear,
       return <$> parseDefine O.Opaque
     ]
 
@@ -155,7 +155,7 @@ parseDefine opacity = do
     case opacity of
       O.Opaque ->
         P.keyword "define"
-      O.Transparent ->
+      O.Clear ->
         P.keyword "inline"
   m <- P.getCurrentHint
   ((_, name), impArgs, expArgs, codType, e) <- parseTopDefInfo
@@ -289,9 +289,9 @@ parseDefineDataClauseArg = do
       typeWithoutIdent
     ]
 
-parseAliasTransparent :: P.Parser RawStmt
-parseAliasTransparent = do
-  parseType "alias" O.Transparent
+parseAliasClear :: P.Parser RawStmt
+parseAliasClear = do
+  parseType "alias" O.Clear
 
 parseAliasOpaque :: P.Parser RawStmt
 parseAliasOpaque = do

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -185,7 +185,7 @@ discernLet nenv m mxt mys e1 e2 = do
   e1' <- discern nenvLocal e1
   (mxt', _, e2') <- discernBinderWithBody' nenvCont mxt [] e2
   e2'' <- attachSuffix (zip ysCont ysLocal) e2'
-  let opacity = if null mys then WT.Transparent else WT.Noetic
+  let opacity = if null mys then WT.Clear else WT.Noetic
   attachPrefix (zip ysLocal ysActual) (m :< WT.Let opacity mxt' e1' e2'')
 
 discernBinder ::

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -114,17 +114,15 @@ discern nenv term =
       es' <- mapM (discern nenv) es
       e' <- discern nenv e
       return $ m :< WT.PiElim e' es'
-    m :< RT.PiElimByKey (AttrV.Attr {..}) name impArgs kvs -> do
+    m :< RT.PiElimByKey (AttrV.Attr {..}) name kvs -> do
       (dd, _) <- resolveName m name
       let (_, ks, vs) = unzip3 kvs
       ensureFieldLinearity m ks S.empty S.empty
       (argNum, keyList) <- KeyArg.lookup m dd
       vs' <- mapM (discern nenv) vs
-      let keyList' = drop (length impArgs) keyList
-      expArgs <- reorderArgs m keyList' $ Map.fromList $ zip ks vs'
-      impArgs' <- mapM (discern nenv) impArgs
+      args <- reorderArgs m keyList $ Map.fromList $ zip ks vs'
       let isConstLike = False
-      return $ m :< WT.PiElim (m :< WT.VarGlobal (AttrVG.Attr {..}) dd) (impArgs' ++ expArgs)
+      return $ m :< WT.PiElim (m :< WT.VarGlobal (AttrVG.Attr {..}) dd) args
     m :< RT.Data name consNameList es -> do
       es' <- mapM (discern nenv) es
       return $ m :< WT.Data name consNameList es'

--- a/src/Scene/Parse/Discern/Fallback.hs
+++ b/src/Scene/Parse/Discern/Fallback.hs
@@ -34,7 +34,7 @@ fallbackRow isNoetic cursor (patternVector, (freedVars, body@(mBody :< _))) =
     Just ((_, Var x), rest) -> do
       h <- Gensym.newHole mBody []
       adjustedCursor <- castToNoemaIfNecessary isNoetic (mBody :< WT.Var cursor)
-      let body' = mBody :< WT.Let WT.Transparent (mBody, x, h) adjustedCursor body
+      let body' = mBody :< WT.Let WT.Clear (mBody, x, h) adjustedCursor body
       return $ Just (rest, (freedVars, body'))
     Just ((_, Cons {}), _) ->
       return Nothing

--- a/src/Scene/Parse/Discern/PatternMatrix.hs
+++ b/src/Scene/Parse/Discern/PatternMatrix.hs
@@ -107,7 +107,7 @@ bindLet binder cont =
     (Just (m, from), to) : xes -> do
       h <- Gensym.newHole m []
       cont' <- bindLet xes cont
-      return $ m :< WT.Let WT.Transparent (m, from, h) to cont'
+      return $ m :< WT.Let WT.Clear (m, from, h) to cont'
 
 ensurePatternMatrixSanity :: PAT.PatternMatrix a -> App ()
 ensurePatternMatrixSanity mat =

--- a/src/Scene/Parse/Discern/Specialize.hs
+++ b/src/Scene/Parse/Discern/Specialize.hs
@@ -42,7 +42,7 @@ specializeRow isNoetic cursor (dd, argNum) (patternVector, (freedVars, body@(mBo
       let wildcards = V.fromList $ replicate (AN.reify argNum) (mBody, WildcardVar)
       h <- Gensym.newHole mBody []
       adjustedCursor <- castToNoemaIfNecessary isNoetic (mBody :< WT.Var cursor)
-      let body' = mBody :< WT.Let WT.Transparent (mBody, x, h) adjustedCursor body
+      let body' = mBody :< WT.Let WT.Clear (mBody, x, h) adjustedCursor body
       return $ Just (V.concat [wildcards, rest], (freedVars, body'))
     Just ((_, Cons (ConsInfo {..})), rest) ->
       if dd == consDD

--- a/src/Scene/Parse/RawTerm.hs
+++ b/src/Scene/Parse/RawTerm.hs
@@ -329,12 +329,9 @@ parseTopDefInfo = do
   impDomArgList <- parseImplicitArgs
   expDomArgList <- argSeqOrList preBinder
   lift $ ensureArgumentLinearity S.empty $ map (\(mx, x, _) -> (mx, x)) expDomArgList
-  argListList <- many $ argList preBinder
   codType <- parseDefInfoCod m
   e <- betweenBrace rawExpr
-  let e' = foldPiIntro m argListList e
-  let codType' = foldPi m argListList codType
-  return ((m, funcBaseName), impDomArgList, expDomArgList, codType', e')
+  return ((m, funcBaseName), impDomArgList, expDomArgList, codType, e)
 
 parseImplicitArgs :: Parser [RawBinder RT.RawTerm]
 parseImplicitArgs =
@@ -343,22 +340,6 @@ parseImplicitArgs =
         betweenBracket (commaList preBinder),
       return []
     ]
-
-foldPi :: Hint -> [[RawBinder RT.RawTerm]] -> RT.RawTerm -> RT.RawTerm
-foldPi m args t =
-  case args of
-    [] ->
-      t
-    binder : rest ->
-      m :< RT.Pi binder (foldPi m rest t)
-
-foldPiIntro :: Hint -> [[RawBinder RT.RawTerm]] -> RT.RawTerm -> RT.RawTerm
-foldPiIntro m args e =
-  case args of
-    [] ->
-      e
-    binder : rest ->
-      lam m binder (foldPiIntro m rest e)
 
 ensureArgumentLinearity :: S.Set RawIdent -> [(Hint, RawIdent)] -> App ()
 ensureArgumentLinearity foundVarSet vs =

--- a/src/Scene/Parse/RawTerm.hs
+++ b/src/Scene/Parse/RawTerm.hs
@@ -288,7 +288,7 @@ rawTermLetExcept = do
 rawTermEmbody :: Parser RT.RawTerm
 rawTermEmbody = do
   m <- getCurrentHint
-  delimiter "!"
+  delimiter "*"
   e <- rawTermBasic
   return $ m :< RT.Embody e
 

--- a/src/Scene/Parse/RawTerm.hs
+++ b/src/Scene/Parse/RawTerm.hs
@@ -257,7 +257,7 @@ rawTermNoeticVar = do
 
 rawTermLetExcept :: Parser (RT.RawTerm -> RT.RawTerm)
 rawTermLetExcept = do
-  keyword "let?"
+  keyword "try"
   pat@(mx, _) <- rawTermPattern
   rightType <- rawTermLetVarAscription mx
   delimiter "="

--- a/src/Scene/Parse/RawTerm.hs
+++ b/src/Scene/Parse/RawTerm.hs
@@ -186,7 +186,7 @@ rawTermKeyValuePair = do
 
 rawTermLetOrLetOn :: Hint -> Parser (RT.RawTerm -> RT.RawTerm)
 rawTermLetOrLetOn m = do
-  isNoetic <- choice [try (keyword "&let") >> return True, keyword "let" >> return False]
+  isNoetic <- choice [try (keyword "tie") >> return True, keyword "let" >> return False]
   pat@(mx, _) <- rawTermPattern
   (x, modifier) <- getContinuationModifier pat
   t <- rawTermLetVarAscription mx

--- a/src/Scene/Parse/RawTerm.hs
+++ b/src/Scene/Parse/RawTerm.hs
@@ -489,7 +489,7 @@ primType = do
 rawTermMatch :: Parser RT.RawTerm
 rawTermMatch = do
   m <- getCurrentHint
-  isNoetic <- choice [try (keyword "&match") >> return True, keyword "match" >> return False]
+  isNoetic <- choice [try (keyword "case") >> return True, keyword "match" >> return False]
   es <- commaList rawTermBasic
   patternRowList <- betweenBrace $ manyList $ rawTermPatternRow (length es)
   return $ m :< RT.DataElim isNoetic es (RP.new patternRowList)

--- a/src/Scene/Term/Inline.hs
+++ b/src/Scene/Term/Inline.hs
@@ -91,7 +91,7 @@ inline term =
     m :< TM.Let opacity (mx, x, t) e1 e2 -> do
       e1' <- inline e1
       case opacity of
-        O.Transparent
+        O.Clear
           | TM.isValue e1' -> do
               let sub = IntMap.fromList [(Ident.toInt x, Right e1')]
               Subst.subst sub e2 >>= inline

--- a/src/Scene/Term/Reduce.hs
+++ b/src/Scene/Term/Reduce.hs
@@ -56,7 +56,7 @@ reduce term =
     m :< TM.Let opacity (mx, x, t) e1 e2 -> do
       e1' <- reduce e1
       case opacity of
-        O.Transparent
+        O.Clear
           | TM.isValue e1' -> do
               let sub = IntMap.fromList [(Ident.toInt x, Right e1')]
               Subst.subst sub e2 >>= reduce

--- a/src/Scene/WeakTerm/Reduce.hs
+++ b/src/Scene/WeakTerm/Reduce.hs
@@ -108,7 +108,7 @@ reduce term =
     m :< WT.Let opacity mxt@(_, x, _) e1 e2 -> do
       e1' <- reduce e1
       case opacity of
-        WT.Transparent -> do
+        WT.Clear -> do
           let sub = IntMap.fromList [(Ident.toInt x, Right e1')]
           Subst.subst sub e2 >>= reduce
         _ -> do

--- a/test/meta/module.ens
+++ b/test/meta/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/meta/module.ens
+++ b/test/meta/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/adder/module.ens
+++ b/test/misc/adder/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/adder/module.ens
+++ b/test/misc/adder/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/args/module.ens
+++ b/test/misc/args/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/args/module.ens
+++ b/test/misc/args/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/calc/module.ens
+++ b/test/misc/calc/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/calc/module.ens
+++ b/test/misc/calc/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/check/module.ens
+++ b/test/misc/check/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/check/module.ens
+++ b/test/misc/check/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/codata-basic/module.ens
+++ b/test/misc/codata-basic/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/codata-basic/module.ens
+++ b/test/misc/codata-basic/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/codata-basic/source/codata-basic.nt
+++ b/test/misc/codata-basic/source/codata-basic.nt
@@ -53,8 +53,8 @@ define main(): unit {
   in
   // k = value-1 + value-1 + value-1 + value-3 = 3 + 3 + 3 + 10 = 19
   let k on config =
-    &let Foo of { value-1, value-3 } = config in
-    &let Bar of { value } = value-3 in
+    tie Foo of { value-1, value-3 } = config in
+    tie Bar of { value } = value-3 in
     add-int(*value-1, add-int(*value-1, add-int(*value-1, *value)))
   in
   let _ = config in

--- a/test/misc/codata-basic/source/codata-basic.nt
+++ b/test/misc/codata-basic/source/codata-basic.nt
@@ -55,7 +55,7 @@ define main(): unit {
   let k on config =
     &let Foo of { value-1, value-3 } = config in
     &let Bar of { value } = value-3 in
-    add-int(!value-1, add-int(!value-1, add-int(!value-1, !value)))
+    add-int(*value-1, add-int(*value-1, add-int(*value-1, *value)))
   in
   let _ = config in
   let some-stream = int-stream(3) in

--- a/test/misc/complex-cancel/module.ens
+++ b/test/misc/complex-cancel/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/complex-cancel/module.ens
+++ b/test/misc/complex-cancel/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/ex-falso/module.ens
+++ b/test/misc/ex-falso/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/ex-falso/module.ens
+++ b/test/misc/ex-falso/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/fact/module.ens
+++ b/test/misc/fact/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/fact/module.ens
+++ b/test/misc/fact/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/file/module.ens
+++ b/test/misc/file/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/file/module.ens
+++ b/test/misc/file/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/fix-and-free-vars/module.ens
+++ b/test/misc/fix-and-free-vars/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/fix-and-free-vars/module.ens
+++ b/test/misc/fix-and-free-vars/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/fold-tails/module.ens
+++ b/test/misc/fold-tails/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/fold-tails/module.ens
+++ b/test/misc/fold-tails/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/foreign/module.ens
+++ b/test/misc/foreign/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/foreign/module.ens
+++ b/test/misc/foreign/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/hello/module.ens
+++ b/test/misc/hello/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/hello/module.ens
+++ b/test/misc/hello/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/lambda-list/module.ens
+++ b/test/misc/lambda-list/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/lambda-list/module.ens
+++ b/test/misc/lambda-list/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/mutable/module.ens
+++ b/test/misc/mutable/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/mutable/module.ens
+++ b/test/misc/mutable/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/mutable/source/mutable.nt
+++ b/test/misc/mutable/source/mutable.nt
@@ -9,7 +9,7 @@ data list(a: tau) {
 }
 
 define my-length(xs: &list(int)): int {
-  &match xs {
+  case xs {
   - Nil() =>
     0
   - Cons(_, ys) =>

--- a/test/misc/nat-fact/module.ens
+++ b/test/misc/nat-fact/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/nat-fact/module.ens
+++ b/test/misc/nat-fact/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/nat-list/module.ens
+++ b/test/misc/nat-list/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/nat-list/module.ens
+++ b/test/misc/nat-list/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/misc/print-float/module.ens
+++ b/test/misc/print-float/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/misc/print-float/module.ens
+++ b/test/misc/print-float/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/pfds/binary-search-tree/module.ens
+++ b/test/pfds/binary-search-tree/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/pfds/binary-search-tree/module.ens
+++ b/test/pfds/binary-search-tree/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/pfds/binary-search-tree/source/binary-search-tree.nt
+++ b/test/pfds/binary-search-tree/source/binary-search-tree.nt
@@ -43,7 +43,7 @@ define make-set-signature(a: tau, compare: (a, a) -> order): set-signature(a) {
     }
   - member =>
     mu member(needle: a, haystack: &set(a)) {
-      &match haystack {
+      case haystack {
       - Leaf =>
         False
       - Node(left, x, right) =>

--- a/test/pfds/binary-search-tree/source/binary-search-tree.nt
+++ b/test/pfds/binary-search-tree/source/binary-search-tree.nt
@@ -47,7 +47,7 @@ define make-set-signature(a: tau, compare: (a, a) -> order): set-signature(a) {
       - Leaf =>
         False
       - Node(left, x, right) =>
-        match compare(needle, !x) {
+        match compare(needle, *x) {
         - LT =>
           member(needle, left)
         - EQ =>

--- a/test/pfds/binomial-heap/module.ens
+++ b/test/pfds/binomial-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/pfds/binomial-heap/module.ens
+++ b/test/pfds/binomial-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/pfds/binomial-heap/source/binomial-heap.nt
+++ b/test/pfds/binomial-heap/source/binomial-heap.nt
@@ -29,7 +29,7 @@ define join(a: tau, cmp: (a, a) -> order, t1: tree(a), t2: tree(a)): tree(a) {
 define rank(a: tau, t: &tree(a)): int {
   &match t {
   - Node(r, _, _) =>
-    !r
+    *r
   }
 }
 
@@ -75,7 +75,7 @@ define merge(a: tau, cmp: (a, a) -> order, h1: heap(a), h2: heap(a)): heap(a) {
 define root(a: tau, t: &tree(a)): a {
   &match t {
   - Node(_, v, _) =>
-    !v
+    *v
   }
 }
 

--- a/test/pfds/binomial-heap/source/binomial-heap.nt
+++ b/test/pfds/binomial-heap/source/binomial-heap.nt
@@ -27,7 +27,7 @@ define join(a: tau, cmp: (a, a) -> order, t1: tree(a), t2: tree(a)): tree(a) {
 }
 
 define rank(a: tau, t: &tree(a)): int {
-  &match t {
+  case t {
   - Node(r, _, _) =>
     *r
   }
@@ -73,7 +73,7 @@ define merge(a: tau, cmp: (a, a) -> order, h1: heap(a), h2: heap(a)): heap(a) {
 
 
 define root(a: tau, t: &tree(a)): a {
-  &match t {
+  case t {
   - Node(_, v, _) =>
     *v
   }
@@ -82,7 +82,7 @@ define root(a: tau, t: &tree(a)): a {
 define find-min(a: tau, cmp: (a, a) -> order, h: &heap(a)): ?a {
   let helper =
     mu self(cand: a, h: &heap(a)): a {
-      &match h {
+      case h {
       - [] =>
         cand
       - t :: ts =>
@@ -96,7 +96,7 @@ define find-min(a: tau, cmp: (a, a) -> order, h: &heap(a)): ?a {
       }
     }
   in
-  &match h {
+  case h {
   - [] =>
     None
   - t :: ts =>
@@ -112,7 +112,7 @@ define remove-min-tree(a: tau, cmp: (a, a) -> order, h: heap(a)): ?tuple(tree(a)
   - [t] =>
     Some(Tuple(t, []))
   - t :: ts =>
-    let? Tuple(cand, ts-adjusted) = remove-min-tree(a, cmp, ts) in
+    try Tuple(cand, ts-adjusted) = remove-min-tree(a, cmp, ts) in
     let c on t, cand =
       let root-head = root(a, t) in
       let root-cand = root(a, cand) in
@@ -128,7 +128,7 @@ define remove-min-tree(a: tau, cmp: (a, a) -> order, h: heap(a)): ?tuple(tree(a)
 }
 
 define delete-min(a: tau, cmp: (a, a) -> order, h: heap(a)): ?heap(a) {
-  let? Tuple(Node(_, _, ts1), ts2): tuple(tree(a), heap(a)) = remove-min-tree(a, cmp, h) in
+  try Tuple(Node(_, _, ts1), ts2): tuple(tree(a), heap(a)) = remove-min-tree(a, cmp, h) in
   Some(merge(a, cmp, reverse(ts1), ts2))
 }
 

--- a/test/pfds/custom-stack/module.ens
+++ b/test/pfds/custom-stack/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/pfds/custom-stack/module.ens
+++ b/test/pfds/custom-stack/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/pfds/custom-stack/source/custom-stack.nt
+++ b/test/pfds/custom-stack/source/custom-stack.nt
@@ -13,7 +13,7 @@ define empty(a: tau): custom-stack(a) {
 }
 
 define is-empty(a: tau, xs: &custom-stack(a)): bool {
-  &match xs {
+  case xs {
   - Nil =>
     True
   - Cons(_, _) =>
@@ -22,7 +22,7 @@ define is-empty(a: tau, xs: &custom-stack(a)): bool {
 }
 
 define head(a: tau, xs: &custom-stack(a)): ?&tuple(a, a) {
-  &match xs {
+  case xs {
   - Nil =>
     None
   - Cons(a, _) =>
@@ -31,7 +31,7 @@ define head(a: tau, xs: &custom-stack(a)): ?&tuple(a, a) {
 }
 
 define tail(a: tau, xs: &custom-stack(a)): ?&custom-stack(a) {
-  &match xs {
+  case xs {
   - Nil =>
     None
   - Cons(_, rest) =>
@@ -55,7 +55,7 @@ define main(): unit {
     - None =>
       1
     - Some(pair) =>
-      &let Tuple(_, right) = pair in
+      tie Tuple(_, right) = pair in
       {*right}()
     }
   in

--- a/test/pfds/custom-stack/source/custom-stack.nt
+++ b/test/pfds/custom-stack/source/custom-stack.nt
@@ -56,7 +56,7 @@ define main(): unit {
       1
     - Some(pair) =>
       &let Tuple(_, right) = pair in
-      {!right}()
+      {*right}()
     }
   in
   let _ = zs in

--- a/test/pfds/finite-map/module.ens
+++ b/test/pfds/finite-map/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/pfds/finite-map/module.ens
+++ b/test/pfds/finite-map/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/pfds/finite-map/source/finite-map.nt
+++ b/test/pfds/finite-map/source/finite-map.nt
@@ -47,11 +47,11 @@ define make-finite-map(a: tau, b: tau, compare: (a, a) -> order): finite-map-sig
       - Leaf =>
         None
       - Node(left, k, v, right) =>
-        match compare(key, !k) {
+        match compare(key, *k) {
         - LT =>
           lookup(key, left)
         - EQ =>
-          Some(!v)
+          Some(*v)
         - GT =>
           lookup(key, right)
         }

--- a/test/pfds/finite-map/source/finite-map.nt
+++ b/test/pfds/finite-map/source/finite-map.nt
@@ -43,7 +43,7 @@ define make-finite-map(a: tau, b: tau, compare: (a, a) -> order): finite-map-sig
     }
   - lookup =>
     mu lookup(key: a, haystack: &finite-map(a, b)): ?b {
-      &match haystack {
+      case haystack {
       - Leaf =>
         None
       - Node(left, k, v, right) =>

--- a/test/pfds/leftist-heap/module.ens
+++ b/test/pfds/leftist-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/pfds/leftist-heap/module.ens
+++ b/test/pfds/leftist-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/pfds/leftist-heap/source/leftist-heap.nt
+++ b/test/pfds/leftist-heap/source/leftist-heap.nt
@@ -33,7 +33,7 @@ define make-heap-signature(a: tau, compare: (a, a) -> order): heap-signature(a) 
         - Leaf =>
           0
         - Node(r, _, _, _) =>
-          !r
+          *r
         }
       }
     in
@@ -88,7 +88,7 @@ define make-heap-signature(a: tau, compare: (a, a) -> order): heap-signature(a) 
       - Leaf =>
         None
       - Node(_, value, _, _) =>
-        Some(!value)
+        Some(*value)
       }
     }
   - delete-min =>

--- a/test/pfds/leftist-heap/source/leftist-heap.nt
+++ b/test/pfds/leftist-heap/source/leftist-heap.nt
@@ -29,7 +29,7 @@ define make-heap-signature(a: tau, compare: (a, a) -> order): heap-signature(a) 
   let merge =
     let rank =
       (h: &heap(a)) => {
-        &match h {
+        case h {
         - Leaf =>
           0
         - Node(r, _, _, _) =>
@@ -69,7 +69,7 @@ define make-heap-signature(a: tau, compare: (a, a) -> order): heap-signature(a) 
     Leaf
   - is-empty =>
     (h: &heap(a)) => {
-      &match h {
+      case h {
       - Leaf =>
         True
       - Node(_, _, _, _) =>
@@ -84,7 +84,7 @@ define make-heap-signature(a: tau, compare: (a, a) -> order): heap-signature(a) 
     merge
   - find-min =>
     (h: &heap(a)) => {
-      &match h {
+      case h {
       - Leaf =>
         None
       - Node(_, value, _, _) =>

--- a/test/pfds/naive-queue/module.ens
+++ b/test/pfds/naive-queue/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/pfds/naive-queue/module.ens
+++ b/test/pfds/naive-queue/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/pfds/naive-queue/source/naive-queue.nt
+++ b/test/pfds/naive-queue/source/naive-queue.nt
@@ -13,7 +13,7 @@ define empty(a: tau): queue(a) {
 }
 
 define head(a: tau, q: &queue(a)): ?a {
-  &match q {
+  case q {
   - Tuple(x :: _, _) =>
     Some(*x)
   - _ =>
@@ -45,7 +45,7 @@ define snoc(a: tau, v: a, q: queue(a)): queue(a) {
 }
 
 define sum(xs: &list(int)): int {
-  &match xs {
+  case xs {
   - [] =>
     0
   - v :: rest =>

--- a/test/pfds/naive-queue/source/naive-queue.nt
+++ b/test/pfds/naive-queue/source/naive-queue.nt
@@ -15,7 +15,7 @@ define empty(a: tau): queue(a) {
 define head(a: tau, q: &queue(a)): ?a {
   &match q {
   - Tuple(x :: _, _) =>
-    Some(!x)
+    Some(*x)
   - _ =>
     None
   }
@@ -49,7 +49,7 @@ define sum(xs: &list(int)): int {
   - [] =>
     0
   - v :: rest =>
-    add-int(!v, sum(rest))
+    add-int(*v, sum(rest))
   }
 }
 

--- a/test/pfds/pairing-heap/module.ens
+++ b/test/pfds/pairing-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/pfds/pairing-heap/module.ens
+++ b/test/pfds/pairing-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/pfds/pairing-heap/source/pairing-heap.nt
+++ b/test/pfds/pairing-heap/source/pairing-heap.nt
@@ -10,7 +10,7 @@ data order {
 }
 
 define find-min(a: tau, h: &heap(a)): ?a {
-  &match h {
+  case h {
   - Leaf =>
     None: ?a
   - Node(v, _) =>

--- a/test/pfds/pairing-heap/source/pairing-heap.nt
+++ b/test/pfds/pairing-heap/source/pairing-heap.nt
@@ -14,7 +14,7 @@ define find-min(a: tau, h: &heap(a)): ?a {
   - Leaf =>
     None: ?a
   - Node(v, _) =>
-    Some(!v)
+    Some(*v)
   }
 }
 

--- a/test/pfds/random-access-list/module.ens
+++ b/test/pfds/random-access-list/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/pfds/random-access-list/module.ens
+++ b/test/pfds/random-access-list/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/pfds/random-access-list/source/random-access-list.nt
+++ b/test/pfds/random-access-list/source/random-access-list.nt
@@ -20,7 +20,7 @@ define size(a: tau, t: &tree(a)): int {
   - Leaf(_) =>
     1
   - Node(w, _, _) =>
-    !w
+    *w
   }
 }
 
@@ -74,12 +74,12 @@ define lookup-tree(a: tau, i: int, t: &tree(a)): option(a) {
   &match t {
   - Leaf(v) =>
     if eq-int(i, 0) {
-      Some(!v)
+      Some(*v)
     } else {
       None
     }
   - Node(w, t1, t2) =>
-    let w-div-2 = div-int(!w, 2) in
+    let w-div-2 = div-int(*w, 2) in
     if lt-int(i, w-div-2) {
       lookup-tree(a, i, t1)
     } else {

--- a/test/pfds/random-access-list/source/random-access-list.nt
+++ b/test/pfds/random-access-list/source/random-access-list.nt
@@ -16,7 +16,7 @@ data R-list(a) {
 }
 
 define size(a: tau, t: &tree(a)): int {
-  &match t {
+  case t {
   - Leaf(_) =>
     1
   - Node(w, _, _) =>
@@ -71,7 +71,7 @@ define uncons-tree(a: tau, ts: R-list(a)): option(tuple(tree(a), R-list(a))) {
 }
 
 define lookup-tree(a: tau, i: int, t: &tree(a)): option(a) {
-  &match t {
+  case t {
   - Leaf(v) =>
     if eq-int(i, 0) {
       Some(*v)
@@ -89,7 +89,7 @@ define lookup-tree(a: tau, i: int, t: &tree(a)): option(a) {
 }
 
 define lookup-list(a: tau, i: int, xs: &list(digit(a))): option(a) {
-  &match xs {
+  case xs {
   - [] =>
     None
   - DigitZero :: rest =>
@@ -105,7 +105,7 @@ define lookup-list(a: tau, i: int, xs: &list(digit(a))): option(a) {
 }
 
 define lookup(a: tau, i: int, xs: &R-list(a)): option(a) {
-  &let New(xs) = xs in
+  tie New(xs) = xs in
   lookup-list(_, i, xs)
 }
 

--- a/test/pfds/red-black-tree/module.ens
+++ b/test/pfds/red-black-tree/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/pfds/red-black-tree/module.ens
+++ b/test/pfds/red-black-tree/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/pfds/red-black-tree/source/red-black-tree.nt
+++ b/test/pfds/red-black-tree/source/red-black-tree.nt
@@ -22,7 +22,7 @@ inline Cmp(a: tau): tau {
 }
 
 define member(a: tau, cmp: Cmp(a), x: a, t: &tree(a)): bool {
-  &match t {
+  case t {
   - Leaf =>
     False
   - Node(_, t1, v, t2) =>

--- a/test/pfds/red-black-tree/source/red-black-tree.nt
+++ b/test/pfds/red-black-tree/source/red-black-tree.nt
@@ -26,7 +26,7 @@ define member(a: tau, cmp: Cmp(a), x: a, t: &tree(a)): bool {
   - Leaf =>
     False
   - Node(_, t1, v, t2) =>
-    match cmp(x, !v) {
+    match cmp(x, *v) {
     - LT =>
       member(a, cmp, x, t1)
     - EQ =>

--- a/test/pfds/splay-heap/module.ens
+++ b/test/pfds/splay-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/pfds/splay-heap/module.ens
+++ b/test/pfds/splay-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/pfds/splay-heap/source/splay-heap.nt
+++ b/test/pfds/splay-heap/source/splay-heap.nt
@@ -63,7 +63,7 @@ define find-min(a: tau, t: &heap(a)): ?a {
   - Leaf =>
     None
   - Node(Leaf, x, _) =>
-    Some(!x)
+    Some(*x)
   - Node(left, _, _) =>
     find-min(a, left)
   }
@@ -102,7 +102,7 @@ define sum(xs: &list(int)): int {
   - [] =>
     0
   - y :: ys =>
-    add-int(!y, sum(ys))
+    add-int(*y, sum(ys))
   }
 }
 

--- a/test/pfds/splay-heap/source/splay-heap.nt
+++ b/test/pfds/splay-heap/source/splay-heap.nt
@@ -59,7 +59,7 @@ define split(a: tau, cmp: (a, a) -> order, pivot: a, t: heap(a)): tuple(heap(a),
 }
 
 define find-min(a: tau, t: &heap(a)): ?a {
-  &match t {
+  case t {
   - Leaf =>
     None
   - Node(Leaf, x, _) =>
@@ -78,7 +78,7 @@ define delete-min(a: tau, t: heap(a)): ?heap(a) {
   - Node(Node(Leaf, _, t12), y, t2) =>
     Some(Node(t12, y, t2))
   - Node(Node(t11, x, t12), y, t2) =>
-    let? t11 = delete-min(a, t11) in
+    try t11 = delete-min(a, t11) in
     Some(Node(t11, x, Node(t12, y, t2)))
   }
 }
@@ -98,7 +98,7 @@ define compare-int-list(xs: list(int), ys: list(int)): order {
 }
 
 define sum(xs: &list(int)): int {
-  &match xs {
+  case xs {
   - [] =>
     0
   - y :: ys =>

--- a/test/pfds/stack/module.ens
+++ b/test/pfds/stack/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/pfds/stack/module.ens
+++ b/test/pfds/stack/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/pfds/stack/source/stack.nt
+++ b/test/pfds/stack/source/stack.nt
@@ -13,7 +13,7 @@ define empty(a: tau): stack(a) {
 }
 
 define is-empty(a: tau, xs: &stack(a)): bool {
-  &match xs {
+  case xs {
   - Nil =>
     True
   - Cons(_, _) =>
@@ -22,7 +22,7 @@ define is-empty(a: tau, xs: &stack(a)): bool {
 }
 
 define head(a: tau, xs: &stack(a)): option(&a) {
-  &match xs {
+  case xs {
   - Nil =>
     None
   - Cons(a, _) =>
@@ -31,7 +31,7 @@ define head(a: tau, xs: &stack(a)): option(&a) {
 }
 
 define tail(a: tau, xs: &stack(a)): option(&stack(a)) {
-  &match xs {
+  case xs {
   - Nil =>
     None
   - Cons(_, rest) =>
@@ -62,7 +62,7 @@ define suffixes(a: tau, xs: stack(a)): stack(stack(a)) {
 }
 
 define suffixes-noetic(a: tau, xs: &stack(a)): stack(&stack(a)) {
-  &match xs {
+  case xs {
   - Nil =>
     Nil
   - Cons(_, ys) =>

--- a/test/pfds/stream/module.ens
+++ b/test/pfds/stream/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/pfds/stream/module.ens
+++ b/test/pfds/stream/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/statement/define/module.ens
+++ b/test/statement/define/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/statement/define/module.ens
+++ b/test/statement/define/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/statement/define/source/define.nt
+++ b/test/statement/define/source/define.nt
@@ -53,26 +53,6 @@ define is-odd(x: int): int {
   }
 }
 
-define multiple-argument-list(x: int)(y: int, z: bool, w: int -> int): int {
-  if eq-int(x, y) {
-    10
-  } else-if z {
-    w(x)
-  } else {
-    3
-  }
-}
-
-define dependent-multiple(a: tau, x: a)(y: int, z: bool, w: a -> int): int {
-  if eq-int(1, y) {
-    10
-  } else-if z {
-    w(x)
-  } else {
-    3
-  }
-}
-
 define implicit-0[](a : tau, x: a): a {
   x
 }
@@ -85,20 +65,8 @@ define implicit-2[a, b](x: a, y: b): tuple(a, b) {
   Tuple(x, y)
 }
 
-define multi(a: tau, x: a)(y: int)(z: bool)(w: a -> int): int {
-  if eq-int(1, y) {
-    10
-  } else-if z {
-    w(x)
-  } else {
-    multi(a, x)(y)(z)(w)
-  }
-}
-
 define main(): unit {
   let _ = is-even(12345) in
-  let _ = multiple-argument-list(10)(20, True, (x) => { add-int(x, 1) }) in
-  let _ = dependent-multiple(tau, tau)(10, False, (_) => { 20 }) in
   let _ = implicit-0(&text, "hello") in
   let _ = implicit-1("hello") in
   let _ = implicit-2("hello", tau) in

--- a/test/statement/empty-import-export/module.ens
+++ b/test/statement/empty-import-export/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/statement/empty-import-export/module.ens
+++ b/test/statement/empty-import-export/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/statement/import-names/module.ens
+++ b/test/statement/import-names/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/statement/import-names/module.ens
+++ b/test/statement/import-names/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/statement/resource-basic/module.ens
+++ b/test/statement/resource-basic/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/statement/resource-basic/module.ens
+++ b/test/statement/resource-basic/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/statement/variant-struct/module.ens
+++ b/test/statement/variant-struct/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/statement/variant-struct/module.ens
+++ b/test/statement/variant-struct/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/statement/variant-struct/source/variant-struct.nt
+++ b/test/statement/variant-struct/source/variant-struct.nt
@@ -72,11 +72,11 @@ define yo(x: top): unit {
 
 define foo(c: &config): &text {
   &let Config of { counter, func, path } = c in
-  let _: int = !counter in
-  let _ = !counter in
-  let _ = {!func}(3) in
-  let _ = !func in
-  !path
+  let _: int = *counter in
+  let _ = *counter in
+  let _ = {*func}(3) in
+  let _ = *func in
+  *path
 }
 
 define main(): unit {

--- a/test/statement/variant-struct/source/variant-struct.nt
+++ b/test/statement/variant-struct/source/variant-struct.nt
@@ -71,7 +71,7 @@ define yo(x: top): unit {
 }
 
 define foo(c: &config): &text {
-  &let Config of { counter, func, path } = c in
+  tie Config of { counter, func, path } = c in
   let _: int = *counter in
   let _ = *counter in
   let _ = {*func}(3) in

--- a/test/term/flow/module.ens
+++ b/test/term/flow/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/term/flow/module.ens
+++ b/test/term/flow/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/term/noema/module.ens
+++ b/test/term/noema/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/term/noema/module.ens
+++ b/test/term/noema/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/term/noema/source/noema.nt
+++ b/test/term/noema/source/noema.nt
@@ -5,12 +5,12 @@ define test-syntax(): unit {
   let xs: list(int) = [1, 2, 3] in
   let _ on xs =
     let _ on xs =
-      let l1 = length(!xs) in
-      let l2 = length(!xs) in
+      let l1 = length(*xs) in
+      let l2 = length(*xs) in
       add-int(l1, l2)
     in
     let _ = length(xs) in
-    let xs-copy = !xs in
+    let xs-copy = *xs in
     let _ = xs in
     let _ = xs in
     let _ = xs in
@@ -55,7 +55,7 @@ define nested-enum-match(t: &term(my-enum)): term(my-enum) {
     &match t {
     - App(Abs(x, t'), Var(e)) =>
       let _ = Var(e) in
-      let t' = !t' in
+      let t' = *t' in
       let _ = t' in
       let _ = x in
       let _ = Var(e) in
@@ -70,7 +70,7 @@ define nested-enum-match(t: &term(my-enum)): term(my-enum) {
       let _ = x in
       Bar
     - App(Abs(x, _), App(Var(_), App(_, App(w, _)))) =>
-      let foo = !w in
+      let foo = *w in
       let _ = foo in
       let _ = foo in
       let _ = foo in
@@ -84,7 +84,7 @@ define nested-enum-match(t: &term(my-enum)): term(my-enum) {
     - App(App(Abs(_, _), Var(_)), App(App(_, App(_, _)), Var(_))) =>
       Bar
     - t =>
-      let t = !t in
+      let t = *t in
       let _ = t in
       let _ = t in
       let _ = t in
@@ -94,9 +94,9 @@ define nested-enum-match(t: &term(my-enum)): term(my-enum) {
   match val {
   - Foo =>
     let _ = val in
-    !t
+    *t
   - Bar =>
-    !t
+    *t
   }
 }
 
@@ -112,25 +112,25 @@ define unbalanced-freevars-in-branches(a: tau, t: &term(a)): term(a) {
     - Var(_) =>
       let _ = g in
       let _ = x in
-      !t
+      *t
     - Abs(_, t) =>
-      let val = !t in
+      let val = *t in
       let _ = val in
       let _ = val in
       let _ = val in
       let _ = val in
       val
     - _ =>
-      !t
+      *t
     }
   - Abs(_, t) =>
     &match t {
     - App(_, e2) =>
-      !e2
+      *e2
     - _ =>
       let _ = t in
       let _ = t in
-      !t
+      *t
     }
   - App(t1, _) =>
     let _ = g in
@@ -138,7 +138,7 @@ define unbalanced-freevars-in-branches(a: tau, t: &term(a)): term(a) {
     let _ = k in
     let _ = k in
     let _ = k in
-    !t1
+    *t1
   }
 }
 

--- a/test/term/noema/source/noema.nt
+++ b/test/term/noema/source/noema.nt
@@ -17,7 +17,7 @@ define test-syntax(): unit {
     let _ = xs-copy in
     let _ = xs-copy in
     let _ = xs-copy in
-    &match xs {
+    case xs {
     - [] =>
       length(xs)
     - _ :: ys =>
@@ -52,7 +52,7 @@ data my-enum {
 
 define nested-enum-match(t: &term(my-enum)): term(my-enum) {
   let val =
-    &match t {
+    case t {
     - App(Abs(x, t'), Var(e)) =>
       let _ = Var(e) in
       let t' = *t' in
@@ -105,10 +105,10 @@ define unbalanced-freevars-in-branches(a: tau, t: &term(a)): term(a) {
   let f = () => { foo } in
   let g = () => { foo } in
   let h = () => { foo } in
-  &match t {
+  case t {
   - Var(x) =>
     let _ = f in
-    &match t {
+    case t {
     - Var(_) =>
       let _ = g in
       let _ = x in
@@ -124,7 +124,7 @@ define unbalanced-freevars-in-branches(a: tau, t: &term(a)): term(a) {
       *t
     }
   - Abs(_, t) =>
-    &match t {
+    case t {
     - App(_, e2) =>
       *e2
     - _ =>
@@ -147,7 +147,7 @@ data ctx {
 }
 
 define with-ctx(c: &ctx): unit {
-  &let Ctx(counter) = c in
+  tie Ctx(counter) = c in
   let current-value = clone(counter) in
   if eq-int(current-value, 0) {
     print("stop\n")

--- a/test/term/pi/module.ens
+++ b/test/term/pi/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/term/pi/module.ens
+++ b/test/term/pi/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/term/pi/source/pi-keyword.nt
+++ b/test/term/pi/source/pi-keyword.nt
@@ -61,7 +61,8 @@ define test-syntax(): unit {
   in
   let _ =
     // hole-notation + keyword arguments
-    bar/1 of {
+    bar of {
+    - a => _
     - some-value => tau
     }
   in

--- a/test/term/prim/module.ens
+++ b/test/term/prim/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/term/prim/module.ens
+++ b/test/term/prim/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/term/tau/module.ens
+++ b/test/term/tau/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/term/tau/module.ens
+++ b/test/term/tau/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/term/unitary/module.ens
+++ b/test/term/unitary/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/term/unitary/module.ens
+++ b/test/term/unitary/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/term/unitary/source/unitary.nt
+++ b/test/term/unitary/source/unitary.nt
@@ -36,7 +36,7 @@ define use-item1(x: item1): list(int) {
 }
 
 define use-item1-noetic(x: &item1): list(int) {
-  &match x {
+  case x {
   - Item1(value) =>
     trace-list(*value)
   }
@@ -64,7 +64,7 @@ define use-item2(a: tau, x: item2(a)): a {
 }
 
 define use-item2-noetic(a: tau, x: &item2(a)): &a {
-  &match x {
+  case x {
   - Item2(value) =>
     value
   }
@@ -92,7 +92,7 @@ define use-item3(a: tau, b: tau, f: item3(a, b), x: a): b {
 }
 
 define use-item3-noetic(a: tau, b: tau, f: &item3(a, b), x: a): b {
-  &match f {
+  case f {
   - Item3(func) =>
     {*func}(x)
   }
@@ -120,7 +120,7 @@ define use-item4(x: item4(int, list(int))): list(int) {
 }
 
 define use-item4-noetic(x: &item4(int, list(int))): list(int) {
-  &match x {
+  case x {
   - Item4(Tuple(v, xs)) =>
     trace-list(*v :: *xs)
   }

--- a/test/term/unitary/source/unitary.nt
+++ b/test/term/unitary/source/unitary.nt
@@ -38,7 +38,7 @@ define use-item1(x: item1): list(int) {
 define use-item1-noetic(x: &item1): list(int) {
   &match x {
   - Item1(value) =>
-    trace-list(!value)
+    trace-list(*value)
   }
 }
 
@@ -94,7 +94,7 @@ define use-item3(a: tau, b: tau, f: item3(a, b), x: a): b {
 define use-item3-noetic(a: tau, b: tau, f: &item3(a, b), x: a): b {
   &match f {
   - Item3(func) =>
-    {!func}(x)
+    {*func}(x)
   }
 }
 
@@ -122,7 +122,7 @@ define use-item4(x: item4(int, list(int))): list(int) {
 define use-item4-noetic(x: &item4(int, list(int))): list(int) {
   &match x {
   - Item4(Tuple(v, xs)) =>
-    trace-list(!v :: !xs)
+    trace-list(*v :: *xs)
   }
 }
 

--- a/test/term/var/module.ens
+++ b/test/term/var/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/term/var/module.ens
+++ b/test/term/var/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/term/variant/module.ens
+++ b/test/term/variant/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/term/variant/module.ens
+++ b/test/term/variant/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }

--- a/test/term/with/module.ens
+++ b/test/term/with/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "LWjYIMfT75wCtu4l-zmABZ21RsyEBzek8iofQpBCJNs="
+      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-8.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
       ]
     }
   }

--- a/test/term/with/module.ens
+++ b/test/term/with/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "ioBGOlxsSpUHNzlcquA4KUoDXImHljIRAMX0qM9L8yQ="
+      digest "tdD1XQaQGOrgbuHz7sbvY_3hudbRjp_XsNB3ExWXL_g="
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-9.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-10.tar.zst"
       ]
     }
   }


### PR DESCRIPTION
Changed:
- `!e` => `*e`
- `let?` => `try`
- `&match` => `case`
- `&let` => `tie`

Removed:
- `func/2(x, y)` (supplying holes explicitly)
- `define foo(x: a)(y: b)(z: c): d { ..}` (argument lists in `define`s)