### PR TITLE
LSP-related fixes

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -13,9 +13,11 @@ import Context.External qualified as External
 import Context.OptParse qualified as OptParse
 import Context.Throw qualified as Throw
 import Entity.Command qualified as C
+import System.IO
 
 main :: IO ()
-main =
+main = do
+  mapM_ (`hSetEncoding` utf8) [stdin, stdout, stderr]
   Main.execute
 
 execute :: IO ()

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -93,7 +93,8 @@ discern nenv term =
         Var s
           | Just (mDef, name') <- lookup s nenv -> do
               UnusedVariable.delete name'
-              Tag.insert m (T.length s) mDef
+              unless (isHole name') $ do
+                Tag.insert m (T.length s) mDef
               return $ m :< WT.Var name'
         _ -> do
           (dd, (_, gn)) <- resolveName m name


### PR DESCRIPTION
This PR:

1. fixes `hPutChar: invalid argument (cannot encode character '..')` by specifying utf-8 explicitly.
2. fixes broken location info by preventing cached locations being overwritten by temporary variables.