### PR TITLE
Fix the handling of nullary constructors in `let`s

### DIFF
--- a/src/Scene/Parse/Discern/Name.hs
+++ b/src/Scene/Parse/Discern/Name.hs
@@ -72,7 +72,7 @@ resolveVarOrErr m name = do
   let foundNameList = Maybe.mapMaybe candFilter $ zip candList candList'
   case foundNameList of
     [] ->
-      return $ Left $ "undefined variable: " <> name
+      return $ Left $ "undefined symbol: " <> name
     [globalVar@(_, (mDef, _))] -> do
       Tag.insert m (T.length name) mDef
       return $ Right globalVar

--- a/src/Scene/Parse/RawTerm.hs
+++ b/src/Scene/Parse/RawTerm.hs
@@ -18,6 +18,7 @@ import Context.Throw qualified as Throw
 import Control.Comonad.Cofree
 import Control.Monad
 import Control.Monad.Trans
+import Data.Char (isUpper)
 import Data.Set qualified as S
 import Data.Text qualified as T
 import Data.Vector qualified as V
@@ -208,8 +209,10 @@ rawTermLetOrLetOn mLet = do
 getContinuationModifier :: (Hint, RP.RawPattern) -> Parser (RawIdent, N.IsNoetic -> RT.RawTerm -> RT.RawTerm)
 getContinuationModifier pat =
   case pat of
-    (_, RP.Var (Var x)) ->
-      return (x, \_ cont -> cont)
+    (_, RP.Var (Var x))
+      | Just (c, _) <- T.uncons x,
+        not (isUpper c) ->
+          return (x, \_ cont -> cont)
     _ -> do
       tmp <- lift Gensym.newTextForHole
       return

--- a/test/term/var/source/var.nt
+++ b/test/term/var/source/var.nt
@@ -10,9 +10,6 @@ define test(): tau {
   // ordinary variable
   let x = tau in
   let _ = x in
-  // ordinary variable, capitalized
-  let FooBar = tau in
-  let _ = FooBar in
   // definite description in current module
   let _ = this.var.test in
   let _ = core.data.vector.vector in


### PR DESCRIPTION
Before this PR:

```
let Foo = e in // ← the `Foo` is regarded as a variable
cont
```

After this PR:

```
let Foo = e in // ← the `Foo` is regarded as a nullary constructor
cont
```

The latter is thus equivalent to:

```
match e {
- Foo => cont
}
```