### PR TITLE
Add a statement `constant` (and remove `type`)

### DIFF
--- a/src/Context/Definition.hs
+++ b/src/Context/Definition.hs
@@ -1,5 +1,6 @@
 module Context.Definition
-  ( insert,
+  ( initialize,
+    insert,
     get,
   )
 where
@@ -13,6 +14,10 @@ import Entity.DefiniteDescription qualified as DD
 import Entity.Opacity qualified as O
 import Entity.Term qualified as TM
 import Prelude hiding (lookup, read)
+
+initialize :: App ()
+initialize = do
+  writeRef' defMap Map.empty
 
 insert :: O.Opacity -> DD.DefiniteDescription -> [BinderF TM.Term] -> TM.Term -> App ()
 insert opacity name xts e =

--- a/src/Context/WeakDefinition.hs
+++ b/src/Context/WeakDefinition.hs
@@ -1,5 +1,6 @@
 module Context.WeakDefinition
-  ( insert,
+  ( initialize,
+    insert,
     read,
     lookup,
   )
@@ -21,6 +22,10 @@ import Prelude hiding (lookup, read)
 
 type DefMap =
   Map.HashMap DD.DefiniteDescription WeakTerm
+
+initialize :: App ()
+initialize = do
+  writeRef' weakDefMap Map.empty
 
 insert :: O.Opacity -> Hint -> DD.DefiniteDescription -> [BinderF WeakTerm] -> WeakTerm -> App ()
 insert opacity m name xts e =

--- a/src/Entity/Const.hs
+++ b/src/Entity/Const.hs
@@ -65,6 +65,10 @@ executableRelDir :: Path Rel Dir
 executableRelDir =
   $(mkRelDir "executable")
 
+defaultInlineLimit :: Int
+defaultInlineLimit =
+  100000
+
 core :: T.Text
 core =
   "core"

--- a/src/Entity/Module.hs
+++ b/src/Entity/Module.hs
@@ -33,7 +33,8 @@ data Module = Module
     moduleAntecedents :: [ModuleDigest],
     moduleLocation :: Path Abs File,
     moduleForeignDirList :: [Path Rel Dir],
-    modulePrefixMap :: Map.HashMap BN.BaseName (ModuleAlias, SL.SourceLocator)
+    modulePrefixMap :: Map.HashMap BN.BaseName (ModuleAlias, SL.SourceLocator),
+    moduleInlineLimit :: Maybe Int
   }
   deriving (Show)
 
@@ -72,6 +73,10 @@ keyForeign =
 keyPrefix :: T.Text
 keyPrefix =
   "prefix"
+
+keyInlineLimit :: T.Text
+keyInlineLimit =
+  "inline-limit"
 
 getSourceDir :: Module -> Path Abs Dir
 getSourceDir baseModule =
@@ -145,7 +150,8 @@ ppModule someModule = do
                 getForeignInfo someModule,
                 getAntecedentInfo someModule,
                 getDependencyInfo someModule,
-                getPrefixMapInfo someModule
+                getPrefixMapInfo someModule,
+                getInlineLimitInfo someModule
               ]
         )
 
@@ -217,6 +223,11 @@ getPrefixMapInfo someModule = do
             () :< E.String (GL.reify (GL.GlobalLocator alias locator))
       let prefixMapDict' = Map.mapKeys BN.reify prefixMapDict
       return (keyPrefix, () :< E.Dictionary prefixMapDict')
+
+getInlineLimitInfo :: Module -> Maybe (T.Text, E.MiniEns)
+getInlineLimitInfo someModule = do
+  limit <- moduleInlineLimit someModule
+  return (keyInlineLimit, () :< E.Int limit)
 
 ppAntecedent :: ModuleDigest -> T.Text
 ppAntecedent (ModuleDigest digest) =

--- a/src/Entity/Stmt.hs
+++ b/src/Entity/Stmt.hs
@@ -33,6 +33,7 @@ data RawStmt
       [RawBinder RT.RawTerm]
       RT.RawTerm
       RT.RawTerm
+  | RawStmtDefineConst Hint DD.DefiniteDescription RT.RawTerm RT.RawTerm
   | RawStmtDefineResource Hint DD.DefiniteDescription RT.RawTerm RT.RawTerm
 
 data WeakStmt
@@ -45,6 +46,7 @@ data WeakStmt
       [BinderF WT.WeakTerm]
       WT.WeakTerm
       WT.WeakTerm
+  | WeakStmtDefineConst Hint DD.DefiniteDescription WT.WeakTerm WT.WeakTerm
   | WeakStmtDefineResource Hint DD.DefiniteDescription WT.WeakTerm WT.WeakTerm
 
 type Program =
@@ -60,6 +62,7 @@ data Stmt
       [BinderF TM.Term]
       TM.Term
       TM.Term
+  | StmtDefineConst Hint DD.DefiniteDescription TM.Term TM.Term
   | StmtDefineResource Hint DD.DefiniteDescription TM.Term TM.Term
   deriving (Generic)
 
@@ -76,6 +79,8 @@ compress stmt =
           StmtDefine isConstLike stmtKind m functionName impArgNum args codType (m :< TM.Tau)
         _ ->
           stmt
+    StmtDefineConst {} ->
+      stmt
     StmtDefineResource {} ->
       stmt
 
@@ -84,6 +89,8 @@ getNameFromWeakStmt stmt =
   case stmt of
     WeakStmtDefine _ _ _ functionName _ _ _ _ ->
       functionName
+    WeakStmtDefineConst _ constName _ _ ->
+      constName
     WeakStmtDefineResource _ resourceName _ _ ->
       resourceName
 

--- a/src/Entity/Term.hs
+++ b/src/Entity/Term.hs
@@ -65,8 +65,8 @@ isValue term =
       True
     _ :< PiIntro {} ->
       True
-    _ :< Data {} ->
-      True
+    _ :< Data _ _ args ->
+      all isValue args
     _ :< DataIntro _ _ dataArgs consArgs ->
       all isValue $ dataArgs ++ consArgs
     _ :< Noema {} ->

--- a/src/Entity/Term/Weaken.hs
+++ b/src/Entity/Term/Weaken.hs
@@ -34,6 +34,10 @@ weakenStmt stmt = do
       let codType' = weaken codType
       let e' = weaken e
       WeakStmtDefine isConstLike stmtKind' m name impArgNum xts' codType' e'
+    StmtDefineConst m dd t v -> do
+      let t' = weaken t
+      let v' = weaken v
+      WeakStmtDefineConst m dd t' v'
     StmtDefineResource m name discarder copier -> do
       let discarder' = weaken discarder
       let copier' = weaken copier

--- a/src/Scene/Clarify.hs
+++ b/src/Scene/Clarify.hs
@@ -44,6 +44,7 @@ import Entity.PrimOp
 import Entity.PrimValue qualified as PV
 import Entity.Stmt
 import Entity.StmtKind
+import Entity.StmtKind qualified as SK
 import Entity.Term qualified as TM
 import Entity.Term.Chain qualified as TM
 import Entity.Term.FromPrimNum
@@ -131,6 +132,8 @@ clarifyStmt stmt =
         _ -> do
           e' <- clarifyStmtDefineBody tenv xts' e
           return (f, (toLowOpacity stmtKind, map fst xts', e'))
+    StmtDefineConst m dd t' v' ->
+      clarifyStmt $ StmtDefine True (SK.Normal O.Clear) m dd AN.zero [] t' v'
     StmtDefineResource m name discarder copier -> do
       switchValue <- Gensym.newIdentFromText "switchValue"
       value <- Gensym.newIdentFromText "value"

--- a/src/Scene/Clarify.hs
+++ b/src/Scene/Clarify.hs
@@ -120,14 +120,13 @@ clarifyStmt stmt =
             Just OD.Unary
               | [(_, _, _, [(_, _, t)], _)] <- consInfoList -> do
                   (dataArgs', t') <- clarifyBinderBody IntMap.empty dataArgs t
-                  return (f, (O.Clear, map fst dataArgs', t'))
+                  return (f, (O.Opaque, map fst dataArgs', t'))
               | otherwise ->
                   Throw.raiseCritical m "found a broken unary data"
             Nothing -> do
               let dataInfo = map (\(_, _, _, consArgs, discriminant) -> (discriminant, dataArgs, consArgs)) consInfoList
               dataInfo' <- mapM clarifyDataClause dataInfo
-              let opacity = if length consInfoList <= 1 then O.Clear else O.Opaque
-              returnSigmaDataS4 name opacity dataInfo' >>= clarifyStmtDefineBody' name xts'
+              returnSigmaDataS4 name O.Opaque dataInfo' >>= clarifyStmtDefineBody' name xts'
         _ -> do
           e' <- clarifyStmtDefineBody tenv xts' e
           return (f, (toLowOpacity stmtKind, map fst xts', e'))

--- a/src/Scene/Clarify.hs
+++ b/src/Scene/Clarify.hs
@@ -52,7 +52,6 @@ import Scene.Clarify.Linearize
 import Scene.Clarify.Sigma
 import Scene.Clarify.Utility
 import Scene.Comp.Reduce qualified as Reduce
-import Scene.Term.Inline qualified as TM
 import Scene.Term.Subst qualified as TM
 
 clarify :: ([Stmt], [DE.Decl]) -> App ([C.CompDef], Maybe DD.DefiniteDescription, [DE.Decl])
@@ -163,8 +162,7 @@ clarifyStmtDefineBody ::
   TM.Term ->
   App C.Comp
 clarifyStmtDefineBody tenv xts e = do
-  e' <- TM.inline e >>= clarifyTerm tenv
-  linearize xts e' >>= Reduce.reduce
+  clarifyTerm tenv e >>= linearize xts >>= Reduce.reduce
 
 clarifyStmtDefineBody' ::
   DD.DefiniteDescription ->

--- a/src/Scene/Elaborate.hs
+++ b/src/Scene/Elaborate.hs
@@ -133,21 +133,21 @@ elaborateStmt stmt = do
       return result
 
 inlineStmt :: Stmt -> App Stmt
-inlineStmt stmt =
+inlineStmt stmt = do
   case stmt of
     StmtDefine isConstLike stmtKind m x impArgNum xts codType e -> do
-      e' <- TM.inline e
+      e' <- TM.inline m e
       return $ StmtDefine isConstLike stmtKind m x impArgNum xts codType e'
     StmtDefineConst m dd t v -> do
-      t' <- TM.inline t
-      v' <- TM.inline v
+      t' <- TM.inline m t
+      v' <- TM.inline m v
       unless (TM.isValue v') $ do
         Throw.raiseError m $
           "couldn't reduce this term into a constant, but got:\n" <> toText (weaken v')
       return $ StmtDefineConst m dd t' v'
     StmtDefineResource m name discarder copier -> do
-      discarder' <- TM.inline discarder
-      copier' <- TM.inline copier
+      discarder' <- TM.inline m discarder
+      copier' <- TM.inline m copier
       return $ StmtDefineResource m name discarder' copier'
 
 insertStmt :: Stmt -> App ()

--- a/src/Scene/Elaborate/Infer.hs
+++ b/src/Scene/Elaborate/Infer.hs
@@ -53,6 +53,11 @@ inferStmt mMainDD stmt =
         unitType <- getUnitType m
         insConstraintEnv (m :< WT.Pi [] unitType) (m :< WT.Pi xts' codType')
       return $ WeakStmtDefine isConstLike stmtKind' m x impArgNum xts' codType' e'
+    WeakStmtDefineConst m dd t v -> do
+      t' <- inferType' [] t
+      (v', tv) <- infer' [] v
+      insConstraintEnv t' tv
+      return $ WeakStmtDefineConst m dd t' v'
     WeakStmtDefineResource m name discarder copier -> do
       Type.insert name $ m :< WT.Tau
       (discarder', td) <- infer' [] discarder

--- a/src/Scene/Elaborate/Reveal.hs
+++ b/src/Scene/Elaborate/Reveal.hs
@@ -35,6 +35,10 @@ revealStmt stmt =
         e' <- reveal' varEnv e
         return (codType', e')
       return $ WeakStmtDefine isConstLike stmtKind' m x impArgNum xts' codType' e'
+    WeakStmtDefineConst m dd t v -> do
+      t' <- reveal' [] t
+      v' <- reveal' [] v
+      return $ WeakStmtDefineConst m dd t' v'
     WeakStmtDefineResource m name discarder copier -> do
       discarder' <- reveal' [] discarder
       copier' <- reveal' [] copier

--- a/src/Scene/Initialize.hs
+++ b/src/Scene/Initialize.hs
@@ -10,6 +10,7 @@ where
 import Context.Alias qualified as Alias
 import Context.App
 import Context.Decl qualified as Decl
+import Context.Definition qualified as Definition
 import Context.Env qualified as Env
 import Context.Global qualified as Global
 import Context.LLVM qualified as LLVM
@@ -19,6 +20,7 @@ import Context.Remark qualified as Remark
 import Context.Tag qualified as Tag
 import Context.Unravel qualified as Unravel
 import Context.UnusedVariable qualified as UnusedVariable
+import Context.WeakDefinition qualified as WeakDefinition
 import Data.Maybe
 import Entity.Config.Remark qualified as Remark
 import Entity.Module
@@ -48,6 +50,8 @@ initializeForTarget = do
   Unravel.initialize
   Remark.setGlobalRemarkList []
   Global.clearSourceNameMap
+  WeakDefinition.initialize
+  Definition.initialize
 
 initializeForSource :: Source.Source -> App ()
 initializeForSource source = do

--- a/src/Scene/New.hs
+++ b/src/Scene/New.hs
@@ -52,7 +52,8 @@ constructDefaultModule name = do
         moduleAntecedents = [],
         moduleLocation = moduleRootDir </> moduleFile,
         moduleForeignDirList = [],
-        modulePrefixMap = Map.empty
+        modulePrefixMap = Map.empty,
+        moduleInlineLimit = Nothing
       }
 
 createModuleFile :: App ()

--- a/src/Scene/Parse.hs
+++ b/src/Scene/Parse.hs
@@ -176,8 +176,8 @@ defineFunction stmtKind m name impArgNum binder codType e = do
 
 parseConstant :: P.Parser RawStmt
 parseConstant = do
-  m <- P.getCurrentHint
   try $ P.keyword "constant"
+  m <- P.getCurrentHint
   constName <- P.baseName >>= lift . Locator.attachCurrentLocator
   t <- parseDefInfoCod m
   v <- P.betweenBrace rawExpr

--- a/src/Scene/Parse.hs
+++ b/src/Scene/Parse.hs
@@ -93,6 +93,8 @@ parseCachedStmtList stmtList = do
         let explicitArgs = drop (AN.reify impArgNum) args
         let argNames = map (\(_, x, _) -> toText x) explicitArgs
         Global.registerStmtDefine isConstLike m stmtKind name impArgNum argNames
+      StmtDefineConst m dd _ _ ->
+        Global.registerStmtDefine True m (SK.Normal O.Clear) dd AN.zero []
       StmtDefineResource m name _ _ ->
         Global.registerStmtDefineResource m name
 
@@ -126,8 +128,8 @@ parseStmt = do
   choice
     [ return <$> parseDefine O.Opaque,
       parseDefineData,
-      return <$> parseType,
       return <$> parseDefine O.Clear,
+      return <$> parseConstant,
       return <$> parseDefineResource
     ]
 
@@ -172,15 +174,14 @@ defineFunction ::
 defineFunction stmtKind m name impArgNum binder codType e = do
   return $ RawStmtDefine False stmtKind m name impArgNum binder codType e
 
-parseType :: P.Parser RawStmt
-parseType = do
+parseConstant :: P.Parser RawStmt
+parseConstant = do
   m <- P.getCurrentHint
-  try $ P.keyword "type"
-  aliasName <- P.baseName >>= lift . Locator.attachCurrentLocator
-  (argList, isConstLike) <- choice [(,False) <$> P.argSeqOrList preBinder, return ([], True)]
-  t <- P.betweenBrace rawExpr
-  let stmtKind = SK.Normal O.Clear
-  return $ RawStmtDefine isConstLike stmtKind m aliasName AN.zero argList (m :< RT.Tau) t
+  try $ P.keyword "constant"
+  constName <- P.baseName >>= lift . Locator.attachCurrentLocator
+  t <- parseDefInfoCod m
+  v <- P.betweenBrace rawExpr
+  return $ RawStmtDefineConst m constName t v
 
 parseDefineData :: P.Parser [RawStmt]
 parseDefineData = do
@@ -327,6 +328,9 @@ registerTopLevelNames stmtList =
       let argNames = map (\(_, x, _) -> x) explicitArgs
       Global.registerStmtDefine isConstLike m stmtKind functionName impArgNum argNames
       registerTopLevelNames rest
+    RawStmtDefineConst m dd _ _ : rest -> do
+      Global.registerStmtDefine True m (SK.Normal O.Clear) dd AN.zero []
+      registerTopLevelNames rest
     RawStmtDefineResource m name _ _ : rest -> do
       Global.registerStmtDefineResource m name
       registerTopLevelNames rest
@@ -336,6 +340,8 @@ getWeakStmtName stmt =
   case stmt of
     WeakStmtDefine _ _ m name _ _ _ _ ->
       (m, name)
+    WeakStmtDefineConst m name _ _ ->
+      (m, name)
     WeakStmtDefineResource m name _ _ ->
       (m, name)
 
@@ -343,6 +349,8 @@ getStmtName :: Stmt -> (Hint, DD.DefiniteDescription)
 getStmtName stmt =
   case stmt of
     StmtDefine _ _ m name _ _ _ _ ->
+      (m, name)
+    StmtDefineConst m name _ _ ->
       (m, name)
     StmtDefineResource m name _ _ ->
       (m, name)

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -56,6 +56,11 @@ discernStmtList stmtList =
       e' <- discern nenv e
       rest' <- discernStmtList rest
       return $ WeakStmtDefine isConstLike stmtKind' m functionName impArgNum xts' codType' e' : rest'
+    RawStmtDefineConst m dd t v : rest -> do
+      t' <- discern empty t
+      v' <- discern empty v
+      rest' <- discernStmtList rest
+      return $ WeakStmtDefineConst m dd t' v' : rest'
     RawStmtDefineResource m name discarder copier : rest -> do
       discarder' <- discern empty discarder
       copier' <- discern empty copier

--- a/src/Scene/Parse/RawTerm.hs
+++ b/src/Scene/Parse/RawTerm.hs
@@ -3,6 +3,7 @@ module Scene.Parse.RawTerm
     preAscription,
     preBinder,
     parseTopDefInfo,
+    parseDefInfoCod,
     typeWithoutIdent,
     preVar,
     parseName,

--- a/src/Scene/Term/Inline.hs
+++ b/src/Scene/Term/Inline.hs
@@ -2,73 +2,120 @@ module Scene.Term.Inline (inline) where
 
 import Context.App
 import Context.Definition qualified as Definition
+import Context.Env qualified as Env
+import Context.Throw qualified as Throw
 import Control.Comonad.Cofree
+import Control.Monad
 import Data.HashMap.Strict qualified as Map
 import Data.IntMap qualified as IntMap
+import Data.Maybe (fromMaybe)
+import Data.Text qualified as T
 import Entity.Attr.DataIntro qualified as AttrDI
 import Entity.Binder
+import Entity.Const (defaultInlineLimit)
 import Entity.DecisionTree qualified as DT
+import Entity.DefiniteDescription qualified as DD
 import Entity.Discriminant
+import Entity.Hint
 import Entity.Ident
 import Entity.Ident.Reify qualified as Ident
 import Entity.LamKind qualified as LK
 import Entity.Magic qualified as M
+import Entity.Module (moduleInlineLimit)
 import Entity.Opacity qualified as O
+import Entity.Source (sourceModule)
 import Entity.Term qualified as TM
 import Scene.Term.Subst qualified as Subst
 
-inline :: TM.Term -> App TM.Term
-inline term =
+data Axis = Axis
+  { dmap :: Map.HashMap DD.DefiniteDescription ([BinderF TM.Term], TM.Term),
+    inlineLimit :: Int,
+    currentStep :: Int,
+    location :: Hint
+  }
+
+newAxis :: Hint -> App Axis
+newAxis m = do
+  source <- Env.getCurrentSource
+  dmap <- Definition.get
+  let limit = fromMaybe defaultInlineLimit $ moduleInlineLimit (sourceModule source)
+  return
+    Axis
+      { dmap = dmap,
+        inlineLimit = limit,
+        currentStep = 0,
+        location = m
+      }
+
+incrementStep :: Axis -> Axis
+incrementStep axis = do
+  let Axis {currentStep} = axis
+  axis {currentStep = currentStep + 1}
+
+detectPossibleInfiniteLoop :: Axis -> App ()
+detectPossibleInfiniteLoop axis = do
+  let Axis {inlineLimit, currentStep, location} = axis
+  when (inlineLimit < currentStep) $ do
+    Throw.raiseError location $ "exceeded max recursion depth of " <> T.pack (show inlineLimit)
+
+inline :: Hint -> TM.Term -> App TM.Term
+inline m e = do
+  axis <- newAxis m
+  inline' axis e
+
+inline' :: Axis -> TM.Term -> App TM.Term
+inline' axis term =
   case term of
-    (m :< TM.Pi xts cod) -> do
+    m :< TM.Pi xts cod -> do
       let (ms, xs, ts) = unzip3 xts
-      ts' <- mapM inline ts
-      cod' <- inline cod
+      ts' <- mapM (inline' axis) ts
+      cod' <- inline' axis cod
       return (m :< TM.Pi (zip3 ms xs ts') cod')
-    (m :< TM.PiIntro kind xts e) -> do
+    m :< TM.PiIntro kind xts e -> do
       let (ms, xs, ts) = unzip3 xts
-      ts' <- mapM inline ts
-      e' <- inline e
+      ts' <- mapM (inline' axis) ts
+      e' <- inline' axis e
       case kind of
         LK.Fix (mx, x, t) -> do
-          t' <- inline t
+          t' <- inline' axis t
           return (m :< TM.PiIntro (LK.Fix (mx, x, t')) (zip3 ms xs ts') e')
         _ ->
           return (m :< TM.PiIntro kind (zip3 ms xs ts') e')
-    (m :< TM.PiElim e es) -> do
-      e' <- inline e
-      es' <- mapM inline es
-      dmap <- Definition.get
+    m :< TM.PiElim e es -> do
+      e' <- inline' axis e
+      es' <- mapM (inline' axis) es
+      let Axis {dmap} = axis
       case e' of
         (_ :< TM.PiIntro LK.Normal xts (_ :< body))
           | length xts == length es' -> do
-              inline $ bind (zip xts es') (m :< body)
+              inline' axis $ bind (zip xts es') (m :< body)
         (_ :< TM.VarGlobal _ dd)
           | Just (xts, _ :< body) <- Map.lookup dd dmap -> do
-              inline $ bind (zip xts es') (m :< body)
+              detectPossibleInfiniteLoop axis
+              inline' (incrementStep axis) $ bind (zip xts es') (m :< body)
         _ ->
           return (m :< TM.PiElim e' es')
     m :< TM.Data attr name es -> do
-      es' <- mapM inline es
+      es' <- mapM (inline' axis) es
       return $ m :< TM.Data attr name es'
     m :< TM.DataIntro attr consName dataArgs consArgs -> do
-      dataArgs' <- mapM inline dataArgs
-      consArgs' <- mapM inline consArgs
+      dataArgs' <- mapM (inline' axis) dataArgs
+      consArgs' <- mapM (inline' axis) consArgs
       return $ m :< TM.DataIntro attr consName dataArgs' consArgs'
     m :< TM.DataElim isNoetic oets decisionTree -> do
       let (os, es, ts) = unzip3 oets
-      es' <- mapM inline es
-      ts' <- mapM inline ts
+      es' <- mapM (inline' axis) es
+      ts' <- mapM (inline' axis) ts
       let oets' = zip3 os es' ts'
       if isNoetic
         then do
-          decisionTree' <- inlineDecisionTree decisionTree
+          decisionTree' <- inlineDecisionTree axis decisionTree
           return $ m :< TM.DataElim isNoetic oets' decisionTree'
         else do
           case decisionTree of
             DT.Leaf _ e -> do
               let sub = IntMap.fromList $ zip (map Ident.toInt os) (map Right es')
-              Subst.subst sub e >>= inline
+              Subst.subst sub e >>= inline' axis
             DT.Unreachable ->
               return $ m :< TM.DataElim isNoetic oets' DT.Unreachable
             DT.Switch (cursor, cursorType) (fallbackTree, caseList) -> do
@@ -76,66 +123,69 @@ inline term =
                 Just (e@(_ :< TM.DataIntro (AttrDI.Attr {..}) _ _ consArgs), oets'') -> do
                   let (newBaseCursorList, cont) = findClause discriminant fallbackTree caseList
                   let newCursorList = zipWith (\(o, t) arg -> (o, arg, t)) newBaseCursorList consArgs
-                  inline $
+                  inline' axis $
                     bind [((m, cursor, cursorType), e)] $
                       m :< TM.DataElim isNoetic (oets'' ++ newCursorList) cont
                 _ -> do
-                  decisionTree' <- inlineDecisionTree decisionTree
+                  decisionTree' <- inlineDecisionTree axis decisionTree
                   return $ m :< TM.DataElim isNoetic oets' decisionTree'
     m :< TM.Let opacity (mx, x, t) e1 e2 -> do
-      e1' <- inline e1
+      e1' <- inline' axis e1
       case opacity of
         O.Clear
           | TM.isValue e1' -> do
               let sub = IntMap.fromList [(Ident.toInt x, Right e1')]
-              Subst.subst sub e2 >>= inline
+              Subst.subst sub e2 >>= inline' axis
         _ -> do
-          t' <- inline t
-          e2' <- inline e2
+          t' <- inline' axis t
+          e2' <- inline' axis e2
           return $ m :< TM.Let opacity (mx, x, t') e1' e2'
     (m :< TM.Magic magic) -> do
       case magic of
         M.Cast _ _ e ->
-          inline e
+          inline' axis e
         _ -> do
-          magic' <- traverse inline magic
+          magic' <- traverse (inline' axis) magic
           return (m :< TM.Magic magic')
     _ ->
       return term
 
 inlineDecisionTree ::
+  Axis ->
   DT.DecisionTree TM.Term ->
   App (DT.DecisionTree TM.Term)
-inlineDecisionTree tree =
+inlineDecisionTree axis tree =
   case tree of
     DT.Leaf xs e -> do
-      e' <- inline e
+      e' <- inline' axis e
       return $ DT.Leaf xs e'
     DT.Unreachable ->
       return DT.Unreachable
     DT.Switch (cursorVar, cursor) clauseList -> do
-      cursor' <- inline cursor
-      clauseList' <- inlineCaseList clauseList
+      cursor' <- inline' axis cursor
+      clauseList' <- inlineCaseList axis clauseList
       return $ DT.Switch (cursorVar, cursor') clauseList'
 
 inlineCaseList ::
+  Axis ->
   DT.CaseList TM.Term ->
   App (DT.CaseList TM.Term)
-inlineCaseList (fallbackTree, clauseList) = do
-  fallbackTree' <- inlineDecisionTree fallbackTree
-  clauseList' <- mapM inlineCase clauseList
+inlineCaseList axis (fallbackTree, clauseList) = do
+  fallbackTree' <- inlineDecisionTree axis fallbackTree
+  clauseList' <- mapM (inlineCase axis) clauseList
   return (fallbackTree', clauseList')
 
 inlineCase ::
+  Axis ->
   DT.Case TM.Term ->
   App (DT.Case TM.Term)
-inlineCase decisionCase = do
+inlineCase axis decisionCase = do
   let (dataTerms, dataTypes) = unzip $ DT.dataArgs decisionCase
-  dataTerms' <- mapM inline dataTerms
-  dataTypes' <- mapM inline dataTypes
+  dataTerms' <- mapM (inline' axis) dataTerms
+  dataTypes' <- mapM (inline' axis) dataTypes
   let (ms, xs, ts) = unzip3 $ DT.consArgs decisionCase
-  ts' <- mapM inline ts
-  cont' <- inlineDecisionTree $ DT.cont decisionCase
+  ts' <- mapM (inline' axis) ts
+  cont' <- inlineDecisionTree axis $ DT.cont decisionCase
   return $
     decisionCase
       { DT.dataArgs = zip dataTerms' dataTypes',

--- a/test/pfds/binomial-heap/source/binomial-heap.nt
+++ b/test/pfds/binomial-heap/source/binomial-heap.nt
@@ -3,7 +3,7 @@ data tree(a) {
 - Node(int, a, list(tree(a)))
 }
 
-type heap(a: tau) {
+inline heap(a: tau) {
   // the list is in increasing order of rank
   list(tree(a))
 }

--- a/test/statement/variant-struct/source/variant-struct.nt
+++ b/test/statement/variant-struct/source/variant-struct.nt
@@ -70,7 +70,15 @@ define yo(x: top): unit {
   Unit
 }
 
-define foo(c: &config): &text {
+data foo {
+- Foo(bar)
+}
+
+data bar {
+- Bar(foo)
+}
+
+define buz(c: &config): &text {
   tie Config of { counter, func, path } = c in
   let _: int = *counter in
   let _ = *counter in


### PR DESCRIPTION
Added:

```
// the body of a constant (`e` in this case) must be reduced into a value at compile-time
constant foo: some-type {
  e
}
```

Removed:

```
// this can be replaced with: `constant foo: tau { e }`
type foo {
  e
}

// this can be replaced with: `inline foo(x: A) { e }`
type foo(x: A) {
  e
}
```