### PR TITLE
Fix: don't reuse the app env when running the LSP server

### DIFF
--- a/src/Act/LSP.hs
+++ b/src/Act/LSP.hs
@@ -3,10 +3,8 @@ module Act.LSP (lsp) where
 import Context.App
 import Control.Monad
 import Entity.Config.LSP
-import Scene.Initialize qualified as Initialize
 import Scene.LSP qualified as L
 
 lsp :: Config -> App ()
 lsp cfg = do
-  Initialize.initializeCompiler (remarkCfg cfg) Nothing
-  void L.lsp
+  void $ L.lsp $ remarkCfg cfg


### PR DESCRIPTION
This PR fixes the LSP server so that it reflects changes to `module.ens` immediately.