### PR TITLE
Faster compilation when using cache

### DIFF
--- a/src/Act/Build.hs
+++ b/src/Act/Build.hs
@@ -40,9 +40,9 @@ build cfg = do
     (artifactTime, dependenceSeq) <- Unravel.unravel target
     llvmList <- forM dependenceSeq $ \source -> do
       Initialize.initializeForSource source
-      virtualCode <- Parse.parse >>= Elaborate.elaborate >>= Clarify.clarify
+      virtualCode <- Parse.parse >>= Elaborate.elaborate
       Cache.whenCompilationNecessary (outputKindList cfg) source $ do
-        llvm <- Lower.lower virtualCode >>= Emit.emit
+        llvm <- Clarify.clarify virtualCode >>= Lower.lower >>= Emit.emit
         return (llvm, source)
     currentTime <- liftIO getCurrentTime
     forConcurrently_ (catMaybes llvmList) $ \(llvm, source) -> do

--- a/src/Context/Cache.hs
+++ b/src/Context/Cache.hs
@@ -22,7 +22,7 @@ saveCache :: Source.Source -> Cache.Cache -> App ()
 saveCache source cache = do
   cachePath <- Path.getSourceCachePath source
   ensureDir $ parent cachePath
-  liftIO $ encodeFile (toFilePath cachePath) cache
+  liftIO $ encodeFile (toFilePath cachePath) $ Cache.compress cache
 
 loadCache :: Source.Source -> App (Maybe Cache.Cache)
 loadCache source = do

--- a/src/Context/Cache.hs
+++ b/src/Context/Cache.hs
@@ -54,7 +54,7 @@ loadCache' shouldCheckArtifactTime source = do
               removeFile cachePath
               return Nothing
             Right content ->
-              return $ Just content
+              return $ Just $ Cache.extend content
 
 whenCompilationNecessary :: [OK.OutputKind] -> Source.Source -> App a -> App (Maybe a)
 whenCompilationNecessary outputKindList source comp = do

--- a/src/Context/Gensym.hs
+++ b/src/Context/Gensym.hs
@@ -1,7 +1,5 @@
 module Context.Gensym
   ( newCount,
-    readCount,
-    writeCount,
     newText,
     newTextFromText,
     newTextForHole,
@@ -33,14 +31,6 @@ import Entity.WeakTerm qualified as WT
 newCount :: App Int
 newCount =
   asks counter >>= \ref -> liftIO $ atomicAddCounter ref 1
-
-readCount :: App Int
-readCount =
-  asks counter >>= liftIO . readIORefU
-
-writeCount :: Int -> App ()
-writeCount v =
-  asks counter >>= \ref -> liftIO $ writeIORefU ref v
 
 {-# INLINE newText #-}
 newText :: App T.Text

--- a/src/Entity/Cache.hs
+++ b/src/Entity/Cache.hs
@@ -15,8 +15,30 @@ data Cache = Cache
   }
   deriving (Generic)
 
-instance Binary Cache
+data LowCache = LowCache
+  { stmtList' :: [Stmt.StrippedStmt],
+    remarkList' :: [Remark],
+    locationTree' :: LT.LocationTree,
+    declList' :: [DE.Decl]
+  }
+  deriving (Generic)
 
-compress :: Cache -> Cache
+instance Binary LowCache
+
+compress :: Cache -> LowCache
 compress cache =
-  cache {stmtList = map Stmt.compress (stmtList cache)}
+  LowCache
+    { stmtList' = map Stmt.compress (stmtList cache),
+      remarkList' = remarkList cache,
+      locationTree' = locationTree cache,
+      declList' = declList cache
+    }
+
+extend :: LowCache -> Cache
+extend cache =
+  Cache
+    { stmtList = map Stmt.extend (stmtList' cache),
+      remarkList = remarkList' cache,
+      locationTree = locationTree' cache,
+      declList = declList' cache
+    }

--- a/src/Entity/Cache.hs
+++ b/src/Entity/Cache.hs
@@ -4,11 +4,11 @@ import Data.Binary
 import Entity.Decl qualified as DE
 import Entity.LocationTree qualified as LT
 import Entity.Remark
-import Entity.Stmt
+import Entity.Stmt qualified as Stmt
 import GHC.Generics
 
 data Cache = Cache
-  { stmtList :: [Stmt],
+  { stmtList :: [Stmt.Stmt],
     remarkList :: [Remark],
     locationTree :: LT.LocationTree,
     declList :: [DE.Decl]
@@ -16,3 +16,7 @@ data Cache = Cache
   deriving (Generic)
 
 instance Binary Cache
+
+compress :: Cache -> Cache
+compress cache =
+  cache {stmtList = map Stmt.compress (stmtList cache)}

--- a/src/Entity/DefiniteDescription.hs
+++ b/src/Entity/DefiniteDescription.hs
@@ -62,8 +62,8 @@ wrapWithQuote :: T.Text -> T.Text
 wrapWithQuote x =
   "\"" <> x <> "\""
 
--- this.core::nat.succ
--- ~> this.core::nat.succ#form
+-- this.foo.bar
+-- ~> this.foo.bar#form
 getFormDD :: DefiniteDescription -> DefiniteDescription
 getFormDD dd = do
   MakeDefiniteDescription

--- a/src/Entity/Hint.hs
+++ b/src/Entity/Hint.hs
@@ -40,6 +40,6 @@ new l c path =
 internalHint :: Hint
 internalHint =
   Hint
-    { metaFileName = "<internal>",
+    { metaFileName = "",
       metaLocation = (0, 0)
     }

--- a/src/Entity/Hint.hs
+++ b/src/Entity/Hint.hs
@@ -18,7 +18,9 @@ type Column =
 type Loc =
   (Line, Column)
 
-instance Binary Hint
+instance Binary Hint where
+  put _ = put ()
+  get = return internalHint
 
 instance Show Hint where
   show _ =

--- a/src/Entity/PrimOp/FromText.hs
+++ b/src/Entity/PrimOp/FromText.hs
@@ -1,10 +1,8 @@
 module Entity.PrimOp.FromText (fromDefiniteDescription) where
 
 import Data.Text qualified as T
-import Entity.BaseName qualified as BN
 import Entity.DataSize qualified as DS
 import Entity.DefiniteDescription qualified as DD
-import Entity.LocalLocator qualified as LL
 import Entity.PrimNumSize
 import Entity.PrimOp
 import Entity.PrimOp.BinaryOp
@@ -13,15 +11,14 @@ import Entity.PrimOp.ConvOp qualified as Conv
 import Entity.PrimOp.UnaryOp
 import Entity.PrimType qualified as PT
 import Entity.PrimType.FromText qualified as PT
-import Entity.StrictGlobalLocator qualified as SGL
 
 fromDefiniteDescription :: DS.DataSize -> DD.DefiniteDescription -> Maybe PrimOp
 fromDefiniteDescription dataSize dd = do
   let sgl = DD.globalLocator dd
   let ll = DD.localLocator dd
-  if SGL.llvmGlobalLocator /= sgl
+  if DD.llvmGlobalLocator /= sgl
     then Nothing
-    else fromText dataSize $ BN.reify $ LL.baseName ll
+    else fromText dataSize ll
 
 fromText :: DS.DataSize -> T.Text -> Maybe PrimOp
 fromText dataSize name

--- a/src/Entity/PrimType/FromText.hs
+++ b/src/Entity/PrimType/FromText.hs
@@ -1,22 +1,19 @@
 module Entity.PrimType.FromText (fromDefiniteDescription, fromText) where
 
 import Data.Text qualified as T
-import Entity.BaseName qualified as BN
 import Entity.DataSize qualified as DS
 import Entity.DefiniteDescription qualified as DD
-import Entity.LocalLocator qualified as LL
 import Entity.PrimNumSize
 import Entity.PrimType qualified as PT
-import Entity.StrictGlobalLocator qualified as SGL
 import Text.Read
 
 fromDefiniteDescription :: DS.DataSize -> DD.DefiniteDescription -> Maybe PT.PrimType
 fromDefiniteDescription dataSize dd = do
   let sgl = DD.globalLocator dd
   let ll = DD.localLocator dd
-  if SGL.llvmGlobalLocator /= sgl
+  if DD.llvmGlobalLocator /= sgl
     then Nothing
-    else fromText dataSize $ BN.reify $ LL.baseName ll
+    else fromText dataSize ll
 
 fromText :: DS.DataSize -> T.Text -> Maybe PT.PrimType
 fromText dataSize name

--- a/src/Entity/Stmt.hs
+++ b/src/Entity/Stmt.hs
@@ -16,6 +16,7 @@ import Entity.RawTerm qualified as RT
 import Entity.Source qualified as Source
 import Entity.StmtKind qualified as SK
 import Entity.Term qualified as TM
+import Entity.Term.Compress qualified as TM
 import Entity.WeakTerm qualified as WT
 import Entity.WeakTerm.ToText qualified as WT
 import GHC.Generics
@@ -73,12 +74,14 @@ type PathSet = S.Set (Path Abs File)
 compress :: Stmt -> Stmt
 compress stmt =
   case stmt of
-    StmtDefine isConstLike stmtKind m functionName impArgNum args codType _ ->
+    StmtDefine isConstLike stmtKind m functionName impArgNum args codType e -> do
+      let codType' = TM.compress codType
+      let e' = TM.compress e
       case stmtKind of
         SK.Normal O.Opaque ->
-          StmtDefine isConstLike stmtKind m functionName impArgNum args codType (m :< TM.Tau)
+          StmtDefine isConstLike stmtKind m functionName impArgNum args codType' (m :< TM.Tau)
         _ ->
-          stmt
+          StmtDefine isConstLike stmtKind m functionName impArgNum args codType' e'
     StmtDefineConst {} ->
       stmt
     StmtDefineResource {} ->

--- a/src/Entity/Stmt.hs
+++ b/src/Entity/Stmt.hs
@@ -10,7 +10,6 @@ import Entity.DefiniteDescription qualified as DD
 import Entity.Discriminant qualified as D
 import Entity.Hint
 import Entity.IsConstLike
-import Entity.Opacity qualified as O
 import Entity.RawBinder
 import Entity.RawTerm qualified as RT
 import Entity.Source qualified as Source
@@ -77,11 +76,7 @@ compress stmt =
     StmtDefine isConstLike stmtKind m functionName impArgNum args codType e -> do
       let codType' = TM.compress codType
       let e' = TM.compress e
-      case stmtKind of
-        SK.Normal O.Opaque ->
-          StmtDefine isConstLike stmtKind m functionName impArgNum args codType' (m :< TM.Tau)
-        _ ->
-          StmtDefine isConstLike stmtKind m functionName impArgNum args codType' e'
+      StmtDefine isConstLike stmtKind m functionName impArgNum args codType' e'
     StmtDefineConst {} ->
       stmt
     StmtDefineResource {} ->

--- a/src/Entity/Stmt.hs
+++ b/src/Entity/Stmt.hs
@@ -16,6 +16,7 @@ import Entity.Source qualified as Source
 import Entity.StmtKind qualified as SK
 import Entity.Term qualified as TM
 import Entity.Term.Compress qualified as TM
+import Entity.Term.Extend qualified as TM
 import Entity.WeakTerm qualified as WT
 import Entity.WeakTerm.ToText qualified as WT
 import GHC.Generics
@@ -52,35 +53,65 @@ data WeakStmt
 type Program =
   (Source.Source, [Stmt])
 
-data Stmt
+data StmtF a
   = StmtDefine
       IsConstLike
-      (SK.StmtKind TM.Term)
+      (SK.StmtKind a)
       Hint
       DD.DefiniteDescription
       AN.ArgNum
-      [BinderF TM.Term]
-      TM.Term
-      TM.Term
-  | StmtDefineConst Hint DD.DefiniteDescription TM.Term TM.Term
-  | StmtDefineResource Hint DD.DefiniteDescription TM.Term TM.Term
+      [BinderF a]
+      a
+      a
+  | StmtDefineConst Hint DD.DefiniteDescription a a
+  | StmtDefineResource Hint DD.DefiniteDescription a a
   deriving (Generic)
+
+type Stmt = StmtF TM.Term
+
+type StrippedStmt = StmtF (Cofree TM.TermF ())
 
 instance Binary Stmt
 
+instance Binary StrippedStmt
+
 type PathSet = S.Set (Path Abs File)
 
-compress :: Stmt -> Stmt
+compress :: Stmt -> StrippedStmt
 compress stmt =
   case stmt of
     StmtDefine isConstLike stmtKind m functionName impArgNum args codType e -> do
+      let stmtKind' = TM.compressStmtKind stmtKind
+      let args' = map TM.compressBinder args
       let codType' = TM.compress codType
       let e' = TM.compress e
-      StmtDefine isConstLike stmtKind m functionName impArgNum args codType' e'
-    StmtDefineConst {} ->
-      stmt
-    StmtDefineResource {} ->
-      stmt
+      StmtDefine isConstLike stmtKind' m functionName impArgNum args' codType' e'
+    StmtDefineConst m dd t e -> do
+      let t' = TM.compress t
+      let e' = TM.compress e
+      StmtDefineConst m dd t' e'
+    StmtDefineResource m dd discarder copier -> do
+      let discarder' = TM.compress discarder
+      let copier' = TM.compress copier
+      StmtDefineResource m dd discarder' copier'
+
+extend :: StrippedStmt -> Stmt
+extend stmt =
+  case stmt of
+    StmtDefine isConstLike stmtKind m functionName impArgNum args codType e -> do
+      let stmtKind' = TM.extendStmtKind stmtKind
+      let args' = map TM.extendBinder args
+      let codType' = TM.extend codType
+      let e' = TM.extend e
+      StmtDefine isConstLike stmtKind' m functionName impArgNum args' codType' e'
+    StmtDefineConst m dd t e -> do
+      let t' = TM.extend t
+      let e' = TM.extend e
+      StmtDefineConst m dd t' e'
+    StmtDefineResource m dd discarder copier -> do
+      let discarder' = TM.extend discarder
+      let copier' = TM.extend copier
+      StmtDefineResource m dd discarder' copier'
 
 getNameFromWeakStmt :: WeakStmt -> DD.DefiniteDescription
 getNameFromWeakStmt stmt =

--- a/src/Entity/Term.hs
+++ b/src/Entity/Term.hs
@@ -43,6 +43,8 @@ instance (Binary a) => Binary (TermF a)
 
 instance Binary Term
 
+instance Binary (Cofree TermF ())
+
 type TypeEnv =
   IntMap.IntMap Term
 

--- a/src/Entity/Term/Compress.hs
+++ b/src/Entity/Term/Compress.hs
@@ -1,0 +1,120 @@
+module Entity.Term.Compress (compress) where
+
+import Control.Comonad.Cofree
+import Data.Bifunctor
+import Entity.DecisionTree qualified as DT
+import Entity.Hint
+import Entity.Ident
+import Entity.LamKind qualified as LK
+import Entity.Prim qualified as P
+import Entity.PrimValue qualified as PV
+import Entity.Term qualified as TM
+
+_m :: Hint
+_m =
+  internalHint
+
+compress :: TM.Term -> TM.Term
+compress term =
+  case term of
+    _ :< TM.Tau ->
+      _m :< TM.Tau
+    _ :< TM.Var x ->
+      _m :< TM.Var x
+    _ :< TM.VarGlobal g argNum ->
+      _m :< TM.VarGlobal g argNum
+    _ :< TM.Pi xts t ->
+      _m :< TM.Pi (map compressBinder xts) (compress t)
+    _ :< TM.PiIntro kind xts e -> do
+      let kind' = compressKind kind
+      let xts' = map compressBinder xts
+      let e' = compress e
+      _m :< TM.PiIntro kind' xts' e'
+    _ :< TM.PiElim e es -> do
+      let e' = compress e
+      let es' = map compress es
+      _m :< TM.PiElim e' es'
+    _ :< TM.Data attr name es -> do
+      let es' = map compress es
+      _m :< TM.Data attr name es'
+    _ :< TM.DataIntro attr consName dataArgs consArgs -> do
+      let dataArgs' = map compress dataArgs
+      let consArgs' = map compress consArgs
+      _m :< TM.DataIntro attr consName dataArgs' consArgs'
+    _ :< TM.DataElim isNoetic oets tree -> do
+      let (os, es, ts) = unzip3 oets
+      let es' = map compress es
+      let ts' = map compress ts
+      let tree' = compressDecisionTree tree
+      _m :< TM.DataElim isNoetic (zip3 os es' ts') tree'
+    _ :< TM.Noema t ->
+      _m :< TM.Noema (compress t)
+    _ :< TM.Embody t e ->
+      _m :< TM.Embody (compress t) (compress e)
+    _ :< TM.Let opacity mxt e1 e2 ->
+      _m :< TM.Let opacity (compressBinder mxt) (compress e1) (compress e2)
+    _ :< TM.Prim prim ->
+      _m :< TM.Prim (compressPrim prim)
+    _ :< TM.ResourceType name ->
+      _m :< TM.ResourceType name
+    _ :< TM.Magic der -> do
+      _m :< TM.Magic (fmap compress der)
+
+compressBinder :: (Hint, Ident, TM.Term) -> (Hint, Ident, TM.Term)
+compressBinder (m, x, t) =
+  (m, x, compress t)
+
+compressKind :: LK.LamKindF TM.Term -> LK.LamKindF TM.Term
+compressKind kind =
+  case kind of
+    LK.Normal ->
+      LK.Normal
+    LK.Fix xt ->
+      LK.Fix (compressBinder xt)
+
+compressPrim :: P.Prim TM.Term -> P.Prim TM.Term
+compressPrim prim =
+  case prim of
+    P.Type t ->
+      P.Type t
+    P.Value v ->
+      P.Value $
+        case v of
+          PV.Int size integer ->
+            PV.Int size integer
+          PV.Float size float ->
+            PV.Float size float
+          PV.Op op ->
+            PV.Op op
+          PV.StaticText t text ->
+            PV.StaticText (compress t) text
+
+compressDecisionTree :: DT.DecisionTree TM.Term -> DT.DecisionTree TM.Term
+compressDecisionTree tree =
+  case tree of
+    DT.Leaf xs e -> do
+      let e' = compress e
+      DT.Leaf xs e'
+    DT.Unreachable ->
+      DT.Unreachable
+    DT.Switch (cursorVar, cursor) caseList -> do
+      let cursor' = compress cursor
+      let caseList' = compressCaseList caseList
+      DT.Switch (cursorVar, cursor') caseList'
+
+compressCaseList :: DT.CaseList TM.Term -> DT.CaseList TM.Term
+compressCaseList (fallbackClause, clauseList) = do
+  let fallbackClause' = compressDecisionTree fallbackClause
+  let clauseList' = map compressCase clauseList
+  (fallbackClause', clauseList')
+
+compressCase :: DT.Case TM.Term -> DT.Case TM.Term
+compressCase decisionCase = do
+  let dataArgs' = map (bimap compress compress) $ DT.dataArgs decisionCase
+  let consArgs' = map compressBinder $ DT.consArgs decisionCase
+  let cont' = compressDecisionTree $ DT.cont decisionCase
+  decisionCase
+    { DT.dataArgs = dataArgs',
+      DT.consArgs = consArgs',
+      DT.cont = cont'
+    }

--- a/src/Entity/Term/Compress.hs
+++ b/src/Entity/Term/Compress.hs
@@ -1,70 +1,68 @@
-module Entity.Term.Compress (compress) where
+module Entity.Term.Compress (compress, compressStmtKind, compressBinder) where
 
 import Control.Comonad.Cofree
 import Data.Bifunctor
+import Data.List (unzip5, zip5)
 import Entity.DecisionTree qualified as DT
 import Entity.Hint
 import Entity.Ident
 import Entity.LamKind qualified as LK
 import Entity.Prim qualified as P
 import Entity.PrimValue qualified as PV
+import Entity.StmtKind
 import Entity.Term qualified as TM
 
-_m :: Hint
-_m =
-  internalHint
-
-compress :: TM.Term -> TM.Term
+compress :: TM.Term -> Cofree TM.TermF ()
 compress term =
   case term of
     _ :< TM.Tau ->
-      _m :< TM.Tau
+      () :< TM.Tau
     _ :< TM.Var x ->
-      _m :< TM.Var x
+      () :< TM.Var x
     _ :< TM.VarGlobal g argNum ->
-      _m :< TM.VarGlobal g argNum
+      () :< TM.VarGlobal g argNum
     _ :< TM.Pi xts t ->
-      _m :< TM.Pi (map compressBinder xts) (compress t)
+      () :< TM.Pi (map compressBinder xts) (compress t)
     _ :< TM.PiIntro kind xts e -> do
       let kind' = compressKind kind
       let xts' = map compressBinder xts
       let e' = compress e
-      _m :< TM.PiIntro kind' xts' e'
+      () :< TM.PiIntro kind' xts' e'
     _ :< TM.PiElim e es -> do
       let e' = compress e
       let es' = map compress es
-      _m :< TM.PiElim e' es'
+      () :< TM.PiElim e' es'
     _ :< TM.Data attr name es -> do
       let es' = map compress es
-      _m :< TM.Data attr name es'
+      () :< TM.Data attr name es'
     _ :< TM.DataIntro attr consName dataArgs consArgs -> do
       let dataArgs' = map compress dataArgs
       let consArgs' = map compress consArgs
-      _m :< TM.DataIntro attr consName dataArgs' consArgs'
+      () :< TM.DataIntro attr consName dataArgs' consArgs'
     _ :< TM.DataElim isNoetic oets tree -> do
       let (os, es, ts) = unzip3 oets
       let es' = map compress es
       let ts' = map compress ts
       let tree' = compressDecisionTree tree
-      _m :< TM.DataElim isNoetic (zip3 os es' ts') tree'
+      () :< TM.DataElim isNoetic (zip3 os es' ts') tree'
     _ :< TM.Noema t ->
-      _m :< TM.Noema (compress t)
+      () :< TM.Noema (compress t)
     _ :< TM.Embody t e ->
-      _m :< TM.Embody (compress t) (compress e)
+      () :< TM.Embody (compress t) (compress e)
     _ :< TM.Let opacity mxt e1 e2 ->
-      _m :< TM.Let opacity (compressBinder mxt) (compress e1) (compress e2)
+      () :< TM.Let opacity (compressBinder mxt) (compress e1) (compress e2)
     _ :< TM.Prim prim ->
-      _m :< TM.Prim (compressPrim prim)
+      () :< TM.Prim (compressPrim prim)
     _ :< TM.ResourceType name ->
-      _m :< TM.ResourceType name
+      () :< TM.ResourceType name
     _ :< TM.Magic der -> do
-      _m :< TM.Magic (fmap compress der)
+      () :< TM.Magic (fmap compress der)
 
-compressBinder :: (Hint, Ident, TM.Term) -> (Hint, Ident, TM.Term)
+compressBinder :: (Hint, Ident, TM.Term) -> (Hint, Ident, Cofree TM.TermF ())
 compressBinder (m, x, t) =
   (m, x, compress t)
 
-compressKind :: LK.LamKindF TM.Term -> LK.LamKindF TM.Term
+compressKind :: LK.LamKindF TM.Term -> LK.LamKindF (Cofree TM.TermF ())
 compressKind kind =
   case kind of
     LK.Normal ->
@@ -72,7 +70,7 @@ compressKind kind =
     LK.Fix xt ->
       LK.Fix (compressBinder xt)
 
-compressPrim :: P.Prim TM.Term -> P.Prim TM.Term
+compressPrim :: P.Prim TM.Term -> P.Prim (Cofree TM.TermF ())
 compressPrim prim =
   case prim of
     P.Type t ->
@@ -89,7 +87,7 @@ compressPrim prim =
           PV.StaticText t text ->
             PV.StaticText (compress t) text
 
-compressDecisionTree :: DT.DecisionTree TM.Term -> DT.DecisionTree TM.Term
+compressDecisionTree :: DT.DecisionTree TM.Term -> DT.DecisionTree (Cofree TM.TermF ())
 compressDecisionTree tree =
   case tree of
     DT.Leaf xs e -> do
@@ -102,13 +100,13 @@ compressDecisionTree tree =
       let caseList' = compressCaseList caseList
       DT.Switch (cursorVar, cursor') caseList'
 
-compressCaseList :: DT.CaseList TM.Term -> DT.CaseList TM.Term
+compressCaseList :: DT.CaseList TM.Term -> DT.CaseList (Cofree TM.TermF ())
 compressCaseList (fallbackClause, clauseList) = do
   let fallbackClause' = compressDecisionTree fallbackClause
   let clauseList' = map compressCase clauseList
   (fallbackClause', clauseList')
 
-compressCase :: DT.Case TM.Term -> DT.Case TM.Term
+compressCase :: DT.Case TM.Term -> DT.Case (Cofree TM.TermF ())
 compressCase decisionCase = do
   let dataArgs' = map (bimap compress compress) $ DT.dataArgs decisionCase
   let consArgs' = map compressBinder $ DT.consArgs decisionCase
@@ -118,3 +116,19 @@ compressCase decisionCase = do
       DT.consArgs = consArgs',
       DT.cont = cont'
     }
+
+compressStmtKind :: StmtKind TM.Term -> StmtKind (Cofree TM.TermF ())
+compressStmtKind stmtKind =
+  case stmtKind of
+    Normal opacity ->
+      Normal opacity
+    Data dataName dataArgs consInfoList -> do
+      let dataArgs' = map compressBinder dataArgs
+      let (hintList, consNameList, constLikeList, consArgsList, discriminantList) = unzip5 consInfoList
+      let consArgsList' = map (map compressBinder) consArgsList
+      let consInfoList' = zip5 hintList consNameList constLikeList consArgsList' discriminantList
+      Data dataName dataArgs' consInfoList'
+    DataIntro dataName dataArgs consArgs discriminant -> do
+      let dataArgs' = map compressBinder dataArgs
+      let consArgs' = map compressBinder consArgs
+      DataIntro dataName dataArgs' consArgs' discriminant

--- a/src/Entity/Term/Extend.hs
+++ b/src/Entity/Term/Extend.hs
@@ -1,0 +1,139 @@
+module Entity.Term.Extend (extend, extendStmtKind, extendBinder) where
+
+import Control.Comonad.Cofree
+import Data.Bifunctor
+import Data.List (unzip5, zip5)
+import Entity.DecisionTree qualified as DT
+import Entity.Hint
+import Entity.Ident
+import Entity.LamKind qualified as LK
+import Entity.Prim qualified as P
+import Entity.PrimValue qualified as PV
+import Entity.StmtKind
+import Entity.Term qualified as TM
+
+{-# INLINE _m #-}
+_m :: Hint
+_m =
+  internalHint
+
+extend :: Cofree TM.TermF () -> TM.Term
+extend term =
+  case term of
+    _ :< TM.Tau ->
+      _m :< TM.Tau
+    _ :< TM.Var x ->
+      _m :< TM.Var x
+    _ :< TM.VarGlobal g argNum ->
+      _m :< TM.VarGlobal g argNum
+    _ :< TM.Pi xts t ->
+      _m :< TM.Pi (map extendBinder xts) (extend t)
+    _ :< TM.PiIntro kind xts e -> do
+      let kind' = extendKind kind
+      let xts' = map extendBinder xts
+      let e' = extend e
+      _m :< TM.PiIntro kind' xts' e'
+    _ :< TM.PiElim e es -> do
+      let e' = extend e
+      let es' = map extend es
+      _m :< TM.PiElim e' es'
+    _ :< TM.Data attr name es -> do
+      let es' = map extend es
+      _m :< TM.Data attr name es'
+    _ :< TM.DataIntro attr consName dataArgs consArgs -> do
+      let dataArgs' = map extend dataArgs
+      let consArgs' = map extend consArgs
+      _m :< TM.DataIntro attr consName dataArgs' consArgs'
+    _ :< TM.DataElim isNoetic oets tree -> do
+      let (os, es, ts) = unzip3 oets
+      let es' = map extend es
+      let ts' = map extend ts
+      let tree' = extendDecisionTree tree
+      _m :< TM.DataElim isNoetic (zip3 os es' ts') tree'
+    _ :< TM.Noema t ->
+      _m :< TM.Noema (extend t)
+    _ :< TM.Embody t e ->
+      _m :< TM.Embody (extend t) (extend e)
+    _ :< TM.Let opacity mxt e1 e2 ->
+      _m :< TM.Let opacity (extendBinder mxt) (extend e1) (extend e2)
+    _ :< TM.Prim prim ->
+      _m :< TM.Prim (extendPrim prim)
+    _ :< TM.ResourceType name ->
+      _m :< TM.ResourceType name
+    _ :< TM.Magic der -> do
+      _m :< TM.Magic (fmap extend der)
+
+extendBinder :: (Hint, Ident, Cofree TM.TermF ()) -> (Hint, Ident, TM.Term)
+extendBinder (m, x, t) =
+  (m, x, extend t)
+
+extendKind :: LK.LamKindF (Cofree TM.TermF ()) -> LK.LamKindF TM.Term
+extendKind kind =
+  case kind of
+    LK.Normal ->
+      LK.Normal
+    LK.Fix xt ->
+      LK.Fix (extendBinder xt)
+
+extendPrim :: P.Prim (Cofree TM.TermF ()) -> P.Prim TM.Term
+extendPrim prim =
+  case prim of
+    P.Type t ->
+      P.Type t
+    P.Value v ->
+      P.Value $
+        case v of
+          PV.Int size integer ->
+            PV.Int size integer
+          PV.Float size float ->
+            PV.Float size float
+          PV.Op op ->
+            PV.Op op
+          PV.StaticText t text ->
+            PV.StaticText (extend t) text
+
+extendDecisionTree :: DT.DecisionTree (Cofree TM.TermF ()) -> DT.DecisionTree TM.Term
+extendDecisionTree tree =
+  case tree of
+    DT.Leaf xs e -> do
+      let e' = extend e
+      DT.Leaf xs e'
+    DT.Unreachable ->
+      DT.Unreachable
+    DT.Switch (cursorVar, cursor) caseList -> do
+      let cursor' = extend cursor
+      let caseList' = extendCaseList caseList
+      DT.Switch (cursorVar, cursor') caseList'
+
+extendCaseList :: DT.CaseList (Cofree TM.TermF ()) -> DT.CaseList TM.Term
+extendCaseList (fallbackClause, clauseList) = do
+  let fallbackClause' = extendDecisionTree fallbackClause
+  let clauseList' = map extendCase clauseList
+  (fallbackClause', clauseList')
+
+extendCase :: DT.Case (Cofree TM.TermF ()) -> DT.Case TM.Term
+extendCase decisionCase = do
+  let dataArgs' = map (bimap extend extend) $ DT.dataArgs decisionCase
+  let consArgs' = map extendBinder $ DT.consArgs decisionCase
+  let cont' = extendDecisionTree $ DT.cont decisionCase
+  decisionCase
+    { DT.dataArgs = dataArgs',
+      DT.consArgs = consArgs',
+      DT.cont = cont'
+    }
+
+extendStmtKind :: StmtKind (Cofree TM.TermF ()) -> StmtKind TM.Term
+extendStmtKind stmtKind =
+  case stmtKind of
+    Normal opacity ->
+      Normal opacity
+    Data dataName dataArgs consInfoList -> do
+      let dataArgs' = map extendBinder dataArgs
+      let (hintList, consNameList, constLikeList, consArgsList, discriminantList) = unzip5 consInfoList
+      let consArgsList' = map (map extendBinder) consArgsList
+      let consInfoList' = zip5 hintList consNameList constLikeList consArgsList' discriminantList
+      Data dataName dataArgs' consInfoList'
+    DataIntro dataName dataArgs consArgs discriminant -> do
+      let dataArgs' = map extendBinder dataArgs
+      let consArgs' = map extendBinder consArgs
+      DataIntro dataName dataArgs' consArgs' discriminant

--- a/src/Entity/WeakTerm/ToText.hs
+++ b/src/Entity/WeakTerm/ToText.hs
@@ -5,7 +5,6 @@ import Data.Text qualified as T
 import Entity.Attr.Data qualified as AttrD
 import Entity.Attr.DataIntro qualified as AttrDI
 import Entity.Attr.VarGlobal qualified as AttrVG
-import Entity.BaseName qualified as BN
 import Entity.Binder
 import Entity.DecisionTree qualified as DT
 import Entity.DefiniteDescription qualified as DD
@@ -13,7 +12,6 @@ import Entity.Discriminant qualified as D
 import Entity.Ident
 import Entity.Ident.Reify qualified as Ident
 import Entity.LamKind qualified as LK
-import Entity.LocalLocator qualified as LL
 import Entity.PrimOp qualified as PO
 import Entity.PrimType.ToText qualified as PT
 import Entity.WeakPrim qualified as WP
@@ -125,8 +123,8 @@ showVariable x =
     else Ident.toText x
 
 showGlobalVariable :: DD.DefiniteDescription -> T.Text
-showGlobalVariable dd =
-  BN.reify $ LL.baseName $ DD.localLocator dd
+showGlobalVariable =
+  DD.localLocator
 
 showPrim :: WP.WeakPrim WT.WeakTerm -> T.Text
 showPrim prim =

--- a/src/Scene/Ens/Reflect.hs
+++ b/src/Scene/Ens/Reflect.hs
@@ -1,6 +1,7 @@
 module Scene.Ens.Reflect (fromFilePath) where
 
 import Context.App
+import Context.Parse
 import Control.Comonad.Cofree
 import Data.HashMap.Strict qualified as M
 import Data.Text qualified as T
@@ -10,8 +11,9 @@ import Scene.Parse.Core
 import Text.Megaparsec hiding (parse)
 
 fromFilePath :: Path Abs File -> App E.Ens
-fromFilePath =
-  run parseEns
+fromFilePath path = do
+  fileContent <- readSourceFile path
+  run parseEns path fileContent
 
 parseKeyValuePair :: Parser (T.Text, E.Ens)
 parseKeyValuePair = do

--- a/src/Scene/LSP/Complete.hs
+++ b/src/Scene/LSP/Complete.hs
@@ -14,7 +14,6 @@ import Entity.Const
 import Entity.DefiniteDescription qualified as DD
 import Entity.IsConstLike (IsConstLike)
 import Entity.Key
-import Entity.LocalLocator qualified as LL
 import Entity.Module
 import Entity.Source
 import Entity.TopNameMap
@@ -78,7 +77,7 @@ getLocalNameList :: TopNameMap -> App [(Maybe (IsConstLike, [Key]), T.Text)]
 getLocalNameList nameInfo = do
   let ddList = map fst $ Map.toList nameInfo
   mKeyArgList <- mapM KeyArg.lookupMaybe ddList
-  return $ zip mKeyArgList $ map (LL.reify . DD.localLocator) ddList
+  return $ zip mKeyArgList $ map DD.localLocator ddList
 
 newCompletionItem :: Maybe T.Text -> (Maybe (IsConstLike, [Key]), T.Text) -> CompletionItem
 newCompletionItem mLocator (_, t) =

--- a/src/Scene/Load.hs
+++ b/src/Scene/Load.hs
@@ -1,0 +1,17 @@
+module Scene.Load (load) where
+
+import Context.App
+import Context.Cache qualified as Cache
+import Context.Parse (readSourceFile)
+import Data.Text qualified as T
+import Entity.Cache qualified as Cache
+import Entity.Source qualified as Source
+
+load :: Source.Source -> App (Either Cache.Cache T.Text)
+load source = do
+  mCache <- Cache.loadCache source
+  case mCache of
+    Just cache -> do
+      return $ Left cache
+    Nothing -> do
+      fmap Right $ readSourceFile $ Source.sourceFilePath source

--- a/src/Scene/Parse.hs
+++ b/src/Scene/Parse.hs
@@ -6,9 +6,7 @@ where
 
 import Context.Alias qualified as Alias
 import Context.App
-import Context.Cache qualified as Cache
 import Context.Decl qualified as Decl
-import Context.Env qualified as Env
 import Context.Global qualified as Global
 import Context.Locator qualified as Locator
 import Context.Throw qualified as Throw

--- a/src/Scene/Parse/Core.hs
+++ b/src/Scene/Parse/Core.hs
@@ -2,7 +2,6 @@ module Scene.Parse.Core where
 
 import Context.App
 import Context.Gensym qualified as Gensym
-import Context.Parse
 import Context.Throw qualified as Throw
 import Control.Monad
 import Control.Monad.Trans
@@ -23,10 +22,9 @@ import Text.Read qualified as R
 
 type Parser = ParsecT Void T.Text App
 
-run :: Parser a -> Path Abs File -> App a
-run parser path = do
+run :: Parser a -> Path Abs File -> T.Text -> App a
+run parser path fileContent = do
   let filePath = toFilePath path
-  fileContent <- readSourceFile path
   result <- runParserT (spaceConsumer >> parser) filePath fileContent
   case result of
     Right v ->

--- a/src/Scene/Unravel.hs
+++ b/src/Scene/Unravel.hs
@@ -11,6 +11,7 @@ import Context.App
 import Context.Env qualified as Env
 import Context.Locator qualified as Locator
 import Context.Module qualified as Module
+import Context.Parse (readSourceFile)
 import Context.Parse qualified as Parse
 import Context.Path qualified as Path
 import Context.Throw qualified as Throw
@@ -246,7 +247,8 @@ parseSourceHeader currentSource = do
   Locator.initialize
   Parse.ensureExistence currentSource
   let path = Source.sourceFilePath currentSource
-  ParseCore.run (parseImportBlock currentSource) path
+  fileContent <- readSourceFile path
+  ParseCore.run (parseImportBlock currentSource) path fileContent
 
 registerAntecedentInfo :: [Source.Source] -> App ()
 registerAntecedentInfo sourceList =


### PR DESCRIPTION
For better compilation speed, this PR:

- parallelizes the build process to some extent,
- drops location information when saving cache, and
- optimizes the internal representation of definite descriptions.

---

```
before:
❯ hyperfine "neut build"
Benchmark 1: neut build
  Time (mean ± σ):      1.323 s ±  0.023 s    [User: 1.932 s, System: 0.313 s]
  Range (min … max):    1.277 s …  1.351 s    10 runs

after:
❯ hyperfine "neut build"
Benchmark 1: neut build
  Time (mean ± σ):      83.1 ms ±   3.9 ms    [User: 125.5 ms, System: 26.5 ms]
  Range (min … max):    76.6 ms …  94.7 ms    36 runs
```