### PR TITLE
Remove paddings from module digests

### DIFF
--- a/src/Context/Locator.hs
+++ b/src/Context/Locator.hs
@@ -115,7 +115,7 @@ getMainDefiniteDescription ::
 getMainDefiniteDescription source = do
   b <- isMainFile source
   if b
-    then Just <$> attachCurrentLocator BN.main
+    then Just <$> attachCurrentLocator BN.mainName
     else return Nothing
 
 isMainFile :: Source.Source -> App Bool

--- a/src/Entity/BaseName.hs
+++ b/src/Entity/BaseName.hs
@@ -12,7 +12,7 @@ module Entity.BaseName
     lambdaName,
     muName,
     textName,
-    main,
+    mainName,
     fromText,
     this,
     new,
@@ -106,8 +106,8 @@ core :: BaseName
 core =
   MakeBaseName "core"
 
-main :: BaseName
-main =
+mainName :: BaseName
+mainName =
   MakeBaseName "main"
 
 new :: BaseName

--- a/src/Entity/Digest.hs
+++ b/src/Entity/Digest.hs
@@ -6,4 +6,4 @@ import Data.ByteString.Base64.URL qualified as Base64
 
 hashAndEncode :: B.ByteString -> B.ByteString
 hashAndEncode =
-  Base64.encode . SHA256.hash
+  Base64.encodeUnpadded . SHA256.hash

--- a/test/meta/module.ens
+++ b/test/meta/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/adder/module.ens
+++ b/test/misc/adder/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/args/module.ens
+++ b/test/misc/args/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/calc/module.ens
+++ b/test/misc/calc/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/check/module.ens
+++ b/test/misc/check/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/codata-basic/module.ens
+++ b/test/misc/codata-basic/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/complex-cancel/module.ens
+++ b/test/misc/complex-cancel/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/ex-falso/module.ens
+++ b/test/misc/ex-falso/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/fact/module.ens
+++ b/test/misc/fact/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/file/module.ens
+++ b/test/misc/file/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/file/source/file.nt
+++ b/test/misc/file/source/file.nt
@@ -9,7 +9,7 @@ define use-file(): system(unit) {
   try file = open("./test", FF.for-rw, FM.default-file-mode) in
   try _ = write("hey\n", file) in
   try _ = read(file) in
-  close(file)
+  Pass(close(file, (_) => {Unit}))
 }
 
 define main(): unit {

--- a/test/misc/fix-and-free-vars/module.ens
+++ b/test/misc/fix-and-free-vars/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/fold-tails/module.ens
+++ b/test/misc/fold-tails/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/foreign/module.ens
+++ b/test/misc/foreign/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/hello/module.ens
+++ b/test/misc/hello/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/lambda-list/module.ens
+++ b/test/misc/lambda-list/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/mutable/module.ens
+++ b/test/misc/mutable/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/nat-fact/module.ens
+++ b/test/misc/nat-fact/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/nat-list/module.ens
+++ b/test/misc/nat-list/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/misc/print-float/module.ens
+++ b/test/misc/print-float/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/pfds/binary-search-tree/module.ens
+++ b/test/pfds/binary-search-tree/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/pfds/binomial-heap/module.ens
+++ b/test/pfds/binomial-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/pfds/custom-stack/module.ens
+++ b/test/pfds/custom-stack/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/pfds/finite-map/module.ens
+++ b/test/pfds/finite-map/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/pfds/leftist-heap/module.ens
+++ b/test/pfds/leftist-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/pfds/naive-queue/module.ens
+++ b/test/pfds/naive-queue/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/pfds/pairing-heap/module.ens
+++ b/test/pfds/pairing-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/pfds/random-access-list/module.ens
+++ b/test/pfds/random-access-list/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/pfds/red-black-tree/module.ens
+++ b/test/pfds/red-black-tree/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/pfds/splay-heap/module.ens
+++ b/test/pfds/splay-heap/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/pfds/stack/module.ens
+++ b/test/pfds/stack/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/pfds/stream/module.ens
+++ b/test/pfds/stream/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/statement/define/module.ens
+++ b/test/statement/define/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/statement/import-names/module.ens
+++ b/test/statement/import-names/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/statement/resource-basic/module.ens
+++ b/test/statement/resource-basic/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/statement/variant-struct/module.ens
+++ b/test/statement/variant-struct/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/term/flow/module.ens
+++ b/test/term/flow/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/term/noema/module.ens
+++ b/test/term/noema/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/term/pi/module.ens
+++ b/test/term/pi/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/term/prim/module.ens
+++ b/test/term/prim/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/term/tau/module.ens
+++ b/test/term/tau/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/term/unary/module.ens
+++ b/test/term/unary/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/term/var/module.ens
+++ b/test/term/var/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/term/variant/module.ens
+++ b/test/term/variant/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/term/with/module.ens
+++ b/test/term/with/module.ens
@@ -1,9 +1,9 @@
 {
   dependency {
     core {
-      digest "zptXghmyD5druBl8kx2Qrei6O6fDsKCA7z2KoHp1aqA="
+      digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0"
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-25.tar.zst"
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
       ]
     }
   }

--- a/test/test-darwin.sh
+++ b/test/test-darwin.sh
@@ -6,7 +6,7 @@ COMPILER_VERSION=$($NEUT version)
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 LSAN_FILE=$SCRIPT_DIR/lsan.supp
 clang_option="-fsanitize=address"
-digest=$(echo "develop $clang_option\c" | shasum -a 256 -b | xxd -r -p | base64 | tr '/+' '_-' )
+digest=$(echo "develop $clang_option\c" | shasum -a 256 -b | xxd -r -p | base64 | tr '/+' '_-' | tr -d '=')
 
 cd $SCRIPT_DIR/meta
 NEUT_TARGET_ARCH=$TARGET_ARCH NEUT_CLANG=$CLANG_PATH $NEUT build --clang-option $clang_option

--- a/test/test-linux.sh
+++ b/test/test-linux.sh
@@ -5,7 +5,7 @@ base_dir=$(pwd)
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 COMPILER_VERSION=$($NEUT version)
 clang_option="-fsanitize=address"
-digest=$(echo -n "develop $clang_option" | sha256sum -b | xxd -r -p | base64 | tr '/+' '_-' )
+digest=$(echo -n "develop $clang_option" | sha256sum -b | xxd -r -p | base64 | tr '/+' '_-' | tr -d '=' )
 
 cd $SCRIPT_DIR/meta
 NEUT_TARGET_ARCH=$TARGET_ARCH $NEUT build --clang-option $clang_option


### PR DESCRIPTION
Before:

```
core {
  digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0=" // ← '=' at the end
  mirror [
    "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
  ]
}
```

After:

```
core {
  digest "uHq3ZX8f1BnJYMrzsalR-KUlCb5FasQtJj_jhP13yy0" // ← no '=' at the end
  mirror [
    "https://github.com/vekatze/neut-core/raw/main/archive/0-26.tar.zst"
  ]
}
```