### PR TITLE
Generalize the syntax of pi-intro

### DIFF
--- a/src/Scene/Parse/RawTerm.hs
+++ b/src/Scene/Parse/RawTerm.hs
@@ -148,7 +148,7 @@ rawTermPiIntro = do
   m <- getCurrentHint
   varList <- argList preBinder
   delimiter "=>"
-  lam m varList <$> betweenBrace rawExpr
+  lam m varList <$> rawExpr
 
 rawTermPiOrConsOrAscOrBasic :: Parser RT.RawTerm
 rawTermPiOrConsOrAscOrBasic = do

--- a/test/term/pi/source/pi-term.nt
+++ b/test/term/pi/source/pi-term.nt
@@ -16,6 +16,14 @@ define test-syntax(): unit {
   let _: (tau, tau) -> tau = (x: tau, _) => {x} in
   let _ = (x: tau, y: tau) => {Pair(x, y)} in
   let _ = {(x: tau) => {x}}(tau) in
+  // exprs in bodies
+  let _ = (f: tau -> tau) => f(tau) in
+  let _ =
+    (f: tau -> tau) =>
+    let _ = f(tau) in
+    tau
+  in
+  let _ = (_: tau -> tau) => Unit; Unit in
   // (unnecessarily) complex type
   let _ =
     (
@@ -26,9 +34,8 @@ define test-syntax(): unit {
       _: {
         tau -> tau
       }
-    ) => {
-      x
-    }
+    ) =>
+    x
   in
   let f = (_: tau, _: tau, _: tau) => {tau} in
   let _ =


### PR DESCRIPTION
Before:

```
(x: tau) => {x} // allowed

(x: tau) => x // not allowed

(x: tau) => some-func(x) // not allowed

(x: tau) => (y: tau) => foo(x, y) // not alllowed
```

After:

```
(x: tau) => {x} // allowed

(x: tau) => x // allowed

(x: tau) => some-func(x) // allowed

(x: tau) => (y: tau) => foo(x, y) // alllowed
```
