### PR TITLE
Reorganize import-items automatically

### DIFF
--- a/src/Entity/LocalLocator.hs
+++ b/src/Entity/LocalLocator.hs
@@ -20,7 +20,7 @@ import Prelude hiding (length)
 newtype LocalLocator = MakeLocalLocator
   { baseName :: BN.BaseName
   }
-  deriving (Generic, Show, Eq)
+  deriving (Generic, Show, Eq, Ord)
 
 instance Binary LocalLocator
 

--- a/src/Entity/RawProgram.hs
+++ b/src/Entity/RawProgram.hs
@@ -4,6 +4,7 @@ module Entity.RawProgram
     RawConsInfo,
     RawImport (..),
     RawImportItem (..),
+    compareImportItem,
     RawForeign (..),
     RawForeignItem (..),
   )
@@ -59,6 +60,12 @@ data RawImport
 
 data RawImportItem
   = RawImportItem Hint (T.Text, C) (SE.Series (Hint, LL.LocalLocator))
+
+compareImportItem :: RawImportItem -> RawImportItem -> Ordering
+compareImportItem item1 item2 = do
+  let RawImportItem _ locator1 _ = item1
+  let RawImportItem _ locator2 _ = item2
+  compare locator1 locator2
 
 data RawForeign
   = RawForeign C (SE.Series RawForeignItem)

--- a/src/Entity/RawProgram/Decode.hs
+++ b/src/Entity/RawProgram/Decode.hs
@@ -52,8 +52,24 @@ decImport (RawImport c _ importItemList) = do
 
 sortImport :: SE.Series RawImportItem -> SE.Series RawImportItem
 sortImport series = do
-  let series' = fmap sortLocalLocators series
-  SE.sortSeriesBy compareImportItem series'
+  let series' = SE.sortSeriesBy compareImportItem series
+  sortLocalLocators <$> series' {SE.elems = mergeAdjacentImport (SE.elems series')}
+
+mergeAdjacentImport :: [(C, RawImportItem)] -> [(C, RawImportItem)]
+mergeAdjacentImport importList = do
+  case importList of
+    [] ->
+      []
+    [item] ->
+      [item]
+    (c1, item1) : (c2, item2) : rest -> do
+      let RawImportItem m1 (locator1, c1') localLocatorList1 = item1
+      let RawImportItem _ (locator2, c2') localLocatorList2 = item2
+      if locator1 /= locator2
+        then (c1, item1) : mergeAdjacentImport ((c2, item2) : rest)
+        else do
+          let item = RawImportItem m1 (locator1, c1' ++ c2') (SE.appendLeftBiased localLocatorList1 localLocatorList2)
+          mergeAdjacentImport $ (c1 ++ c2, item) : rest
 
 sortLocalLocators :: RawImportItem -> RawImportItem
 sortLocalLocators (RawImportItem m locator localLocators) = do

--- a/src/Entity/RawProgram/Decode.hs
+++ b/src/Entity/RawProgram/Decode.hs
@@ -47,8 +47,18 @@ decImport (RawImport c _ importItemList) = do
   RT.attachComment c $
     D.join
       [ D.text "import ",
-        SE.decode $ SE.assoc $ fmap decImportItem importItemList
+        SE.decode $ SE.assoc $ decImportItem <$> sortImport importItemList
       ]
+
+sortImport :: SE.Series RawImportItem -> SE.Series RawImportItem
+sortImport series = do
+  let series' = fmap sortLocalLocators series
+  SE.sortSeriesBy compareImportItem series'
+
+sortLocalLocators :: RawImportItem -> RawImportItem
+sortLocalLocators (RawImportItem m locator localLocators) = do
+  let cmp (_, x) (_, y) = compare x y
+  RawImportItem m locator $ SE.sortSeriesBy cmp localLocators
 
 decImportItem :: RawImportItem -> (D.Doc, C)
 decImportItem (RawImportItem _ (item, c) args) = do

--- a/src/Entity/Syntax/Series.hs
+++ b/src/Entity/Syntax/Series.hs
@@ -17,10 +17,12 @@ module Entity.Syntax.Series
     extract,
     isEmpty,
     containsNoComment,
+    sortSeriesBy,
   )
 where
 
 import Data.Bifunctor
+import Data.List (sortBy)
 import Data.Text qualified as T
 import Entity.C (C)
 
@@ -137,3 +139,8 @@ containsNoComment series = do
   let cs = map fst $ elems series
   let c = trailingComment series
   all null (c : cs)
+
+sortSeriesBy :: (a -> a -> Ordering) -> Series a -> Series a
+sortSeriesBy cmp series = do
+  let cmp' (_, x) (_, y) = cmp x y
+  series {elems = sortBy cmp' $ elems series}

--- a/src/Entity/Syntax/Series.hs
+++ b/src/Entity/Syntax/Series.hs
@@ -18,6 +18,7 @@ module Entity.Syntax.Series
     isEmpty,
     containsNoComment,
     sortSeriesBy,
+    appendLeftBiased,
   )
 where
 
@@ -144,3 +145,13 @@ sortSeriesBy :: (a -> a -> Ordering) -> Series a -> Series a
 sortSeriesBy cmp series = do
   let cmp' (_, x) (_, y) = cmp x y
   series {elems = sortBy cmp' $ elems series}
+
+appendLeftBiased :: Series a -> Series a -> Series a
+appendLeftBiased series1 series2 = do
+  Series
+    { elems = elems series1 ++ elems series2,
+      trailingComment = trailingComment series1 ++ trailingComment series2,
+      prefix = prefix series1,
+      container = container series1,
+      separator = separator series1
+    }


### PR DESCRIPTION
```
import {
- Foo
- this.unit {Unit, unit}
- this.bool {True}
- Bar
- this.bool {bool, buz}
- this.bool
}

↓ (format)

import {
- Bar
- Foo
- this.bool {True, bool, buz}
- this.unit {Unit, unit}
}
```