### PR TITLE
Support `textDocument/hover`

### DIFF
--- a/src/Context/App/Internal.hs
+++ b/src/Context/App/Internal.hs
@@ -53,7 +53,7 @@ data Env = Env
     locatorAliasMap :: IORef (Map.HashMap GLA.GlobalLocatorAlias SGL.StrictGlobalLocator),
     sourceNameMap :: IORef (Map.HashMap (Path Abs File) TopNameMap),
     nameMap :: IORef (Map.HashMap DD.DefiniteDescription (Hint, GN.GlobalName)),
-    geistMap :: IORef (Map.HashMap DD.DefiniteDescription Hint),
+    geistMap :: IORef (Map.HashMap DD.DefiniteDescription (Hint, IsConstLike)),
     antecedentMap :: IORef (Map.HashMap MD.ModuleDigest M.Module),
     constraintEnv :: IORef [C.Constraint],
     suspendedEnv :: IORef [C.SuspendedConstraint],

--- a/src/Context/Cache.hs
+++ b/src/Context/Cache.hs
@@ -3,6 +3,7 @@ module Context.Cache
     loadCache,
     loadCacheOptimistically,
     whenCompilationNecessary,
+    invalidate,
   )
 where
 
@@ -64,3 +65,11 @@ whenCompilationNecessary outputKindList source comp = do
   if Source.isCompilationSkippable artifactTime outputKindList source
     then return Nothing
     else Just <$> comp
+
+invalidate :: Source.Source -> App ()
+invalidate source = do
+  cachePath <- Path.getSourceCachePath source
+  hasCache <- doesFileExist cachePath
+  if not hasCache
+    then return ()
+    else removeFile cachePath

--- a/src/Context/Global.hs
+++ b/src/Context/Global.hs
@@ -188,7 +188,7 @@ ensureDefFreshness m name = do
     (Just mGeist, True) -> do
       removeFromGeistMap name
       removeFromDefNameMap name
-      Tag.insertDD mGeist name m
+      Tag.insertGlobalVar mGeist name m
     (Nothing, True) ->
       Throw.raiseError m $ "`" <> DD.reify name <> "` is already defined"
     (Nothing, False) ->

--- a/src/Context/Locator.hs
+++ b/src/Context/Locator.hs
@@ -21,6 +21,7 @@ import Data.HashMap.Strict qualified as Map
 import Data.Maybe (maybeToList)
 import Entity.BaseName qualified as BN
 import Entity.DefiniteDescription qualified as DD
+import Entity.GlobalName qualified as GN
 import Entity.Hint
 import Entity.LocalLocator qualified as LL
 import Entity.Module qualified as Module
@@ -53,8 +54,8 @@ activateSpecifiedNames topNameMap sgl lls = do
     case Map.lookup dd topNameMap of
       Nothing ->
         Throw.raiseError m $ "the name `" <> LL.reify ll <> "` isn't defined in the module"
-      Just (mDef, _) -> do
-        Tag.insertGlobalVar m dd mDef
+      Just (mDef, gn) -> do
+        Tag.insertGlobalVar m dd (GN.getIsConstLike gn) mDef
         aenv <- readRef' activeDefiniteDescriptionList
         when (Map.member ll aenv) $ do
           Throw.raiseError m $ "the top-level name `" <> LL.reify ll <> "` is already imported"

--- a/src/Context/Locator.hs
+++ b/src/Context/Locator.hs
@@ -54,7 +54,7 @@ activateSpecifiedNames topNameMap sgl lls = do
       Nothing ->
         Throw.raiseError m $ "the name `" <> LL.reify ll <> "` isn't defined in the module"
       Just (mDef, _) -> do
-        Tag.insert m (LL.length ll) mDef
+        Tag.insertGlobalVar m dd mDef
         aenv <- readRef' activeDefiniteDescriptionList
         when (Map.member ll aenv) $ do
           Throw.raiseError m $ "the top-level name `" <> LL.reify ll <> "` is already imported"

--- a/src/Context/Tag.hs
+++ b/src/Context/Tag.hs
@@ -1,9 +1,10 @@
 module Context.Tag
   ( initialize,
     insert,
+    insertLocalVar,
+    insertGlobalVar,
     insertFileLoc,
     insertBinder,
-    insertDD,
     get,
   )
 where
@@ -23,11 +24,28 @@ initialize :: App ()
 initialize =
   writeRef' tagMap LT.empty
 
-insert :: Hint -> Int -> Hint -> App ()
-insert mUse nameLength mDef = do
+get :: App LT.LocationTree
+get = do
+  readRef' tagMap
+
+insertLocalVar :: Hint -> Ident -> Hint -> App ()
+insertLocalVar mUse ident@(I (var, varID)) mDef = do
+  unless (isHole ident) $ do
+    let nameLength = T.length var
+    let symbolLoc = LT.SymbolLoc (LT.Local varID)
+    insert mUse symbolLoc nameLength mDef
+
+insertGlobalVar :: Hint -> DD.DefiniteDescription -> Hint -> App ()
+insertGlobalVar mUse dd mDef = do
+  let nameLength = T.length (DD.localLocator dd)
+  let symbolLoc = LT.SymbolLoc (LT.Global dd)
+  insert mUse symbolLoc nameLength mDef
+
+insert :: Hint -> LT.LocType -> Int -> Hint -> App ()
+insert mUse locType nameLength mDef = do
   when (metaShouldSaveLocation mUse) $ do
     let (l, c) = metaLocation mUse
-    modifyRef' tagMap $ LT.insert LT.SymbolLoc (l, (c, c + nameLength)) mDef
+    modifyRef' tagMap $ LT.insert locType (l, (c, c + nameLength)) mDef
 
 insertFileLoc :: Hint -> Int -> Hint -> App ()
 insertFileLoc mUse nameLength mDef = do
@@ -35,14 +53,6 @@ insertFileLoc mUse nameLength mDef = do
     let (l, c) = metaLocation mUse
     modifyRef' tagMap $ LT.insert LT.FileLoc (l, (c, c + nameLength)) mDef
 
-get :: App LT.LocationTree
-get = do
-  readRef' tagMap
-
 insertBinder :: BinderF a -> App ()
-insertBinder (m, ident@(I (x, _)), _) =
-  unless (isHole ident) $ insert m (T.length x) m
-
-insertDD :: Hint -> DD.DefiniteDescription -> Hint -> App ()
-insertDD mUse dd =
-  insert mUse (T.length (DD.localLocator dd))
+insertBinder (m, ident, _) =
+  insertLocalVar m ident m

--- a/src/Context/Tag.hs
+++ b/src/Context/Tag.hs
@@ -17,6 +17,7 @@ import Entity.Binder
 import Entity.DefiniteDescription qualified as DD
 import Entity.Hint
 import Entity.Ident
+import Entity.IsConstLike
 import Entity.LocationTree qualified as LT
 import Prelude hiding (lookup, read)
 
@@ -35,10 +36,10 @@ insertLocalVar mUse ident@(I (var, varID)) mDef = do
     let symbolLoc = LT.SymbolLoc (LT.Local varID)
     insert mUse symbolLoc nameLength mDef
 
-insertGlobalVar :: Hint -> DD.DefiniteDescription -> Hint -> App ()
-insertGlobalVar mUse dd mDef = do
+insertGlobalVar :: Hint -> DD.DefiniteDescription -> IsConstLike -> Hint -> App ()
+insertGlobalVar mUse dd isConstLike mDef = do
   let nameLength = T.length (DD.localLocator dd)
-  let symbolLoc = LT.SymbolLoc (LT.Global dd)
+  let symbolLoc = LT.SymbolLoc (LT.Global dd isConstLike)
   insert mUse symbolLoc nameLength mDef
 
 insert :: Hint -> LT.LocType -> Int -> Hint -> App ()

--- a/src/Entity/GlobalName.hs
+++ b/src/Entity/GlobalName.hs
@@ -1,4 +1,8 @@
-module Entity.GlobalName (GlobalName (..)) where
+module Entity.GlobalName
+  ( GlobalName (..),
+    getIsConstLike,
+  )
+where
 
 import Data.Binary
 import Entity.ArgNum
@@ -19,3 +23,15 @@ data GlobalName
   deriving (Show, Generic)
 
 instance Binary GlobalName
+
+getIsConstLike :: GlobalName -> IsConstLike
+getIsConstLike gn =
+  case gn of
+    TopLevelFunc _ isConstLike ->
+      isConstLike
+    Data _ _ isConstLike ->
+      isConstLike
+    DataIntro _ _ _ isConstLike ->
+      isConstLike
+    _ ->
+      False

--- a/src/Entity/LocationTree.hs
+++ b/src/Entity/LocationTree.hs
@@ -12,6 +12,7 @@ where
 import Data.Binary
 import Entity.DefiniteDescription qualified as DD
 import Entity.Hint
+import Entity.IsConstLike
 import GHC.Generics (Generic)
 
 type ColInterval =
@@ -19,7 +20,7 @@ type ColInterval =
 
 data SymbolName
   = Local Int
-  | Global DD.DefiniteDescription
+  | Global DD.DefiniteDescription IsConstLike
   deriving (Show, Generic)
 
 data LocType

--- a/src/Entity/LocationTree.hs
+++ b/src/Entity/LocationTree.hs
@@ -1,6 +1,7 @@
 module Entity.LocationTree
   ( LocationTree,
     LocType (..),
+    SymbolName (..),
     empty,
     insert,
     find,
@@ -9,15 +10,21 @@ module Entity.LocationTree
 where
 
 import Data.Binary
+import Entity.DefiniteDescription qualified as DD
 import Entity.Hint
 import GHC.Generics (Generic)
 
 type ColInterval =
   (Int, Int)
 
+data SymbolName
+  = Local Int
+  | Global DD.DefiniteDescription
+  deriving (Show, Generic)
+
 data LocType
   = FileLoc
-  | SymbolLoc
+  | SymbolLoc SymbolName
   deriving (Show, Generic)
 
 -- I'll do balancing stuff later
@@ -27,6 +34,8 @@ data LocationTree
   deriving (Show, Generic)
 
 instance Binary LocationTree
+
+instance Binary SymbolName
 
 instance Binary LocType
 
@@ -48,12 +57,12 @@ insert lt loc value t =
         EQ ->
           Node lt' loc' (SavedHint value) t1 t2
 
-find :: Int -> Int -> LocationTree -> Maybe (Hint, ColInterval)
+find :: Int -> Int -> LocationTree -> Maybe (LocType, Hint, ColInterval)
 find line col t =
   case t of
     Leaf ->
       Nothing
-    Node _ (line', (colFrom, colTo)) (SavedHint value) t1 t2 ->
+    Node lt (line', (colFrom, colTo)) (SavedHint value) t1 t2 ->
       case compare line line' of
         LT ->
           find line col t1
@@ -66,7 +75,7 @@ find line col t =
             (_, True) ->
               find line col t2
             _ ->
-              Just (value, (colFrom, colTo))
+              Just (lt, value, (colFrom, colTo))
 
 findRef :: Loc -> LocationTree -> [(FilePath, (Line, ColInterval))]
 findRef loc t =
@@ -75,7 +84,7 @@ findRef loc t =
       []
     Node lt locRange (SavedHint m') left right
       | loc == metaLocation m',
-        SymbolLoc <- lt ->
+        SymbolLoc _ <- lt ->
           (metaFileName m', locRange) : findRef loc left ++ findRef loc right
       | otherwise ->
           findRef loc left ++ findRef loc right

--- a/src/Entity/WeakTerm/ToText.hs
+++ b/src/Entity/WeakTerm/ToText.hs
@@ -164,7 +164,7 @@ showVariable :: Ident -> T.Text
 showVariable x =
   if isHole x
     then "_"
-    else Ident.toText' x
+    else Ident.toText x
 
 showGlobalVariable :: DD.DefiniteDescription -> T.Text
 showGlobalVariable =

--- a/src/Scene/LSP/FindDefinition.hs
+++ b/src/Scene/LSP/FindDefinition.hs
@@ -28,7 +28,7 @@ _findDefinition ::
 _findDefinition params locationTree = do
   let line = fromEnum (params ^. J.position . J.line) + 1
   let col = fromEnum (params ^. J.position . J.character) + 1
-  (m, (colFrom, colTo)) <- liftMaybe $ LT.find line col locationTree
+  (_, m, (colFrom, colTo)) <- liftMaybe $ LT.find line col locationTree
   let defPath = H.metaFileName m
   let (defLine, defCol) = H.metaLocation m
   let defFilePath' = filePathToUri defPath

--- a/src/Scene/LSP/GetSymbolInfo.hs
+++ b/src/Scene/LSP/GetSymbolInfo.hs
@@ -1,0 +1,51 @@
+module Scene.LSP.GetSymbolInfo (getSymbolInfo) where
+
+import Context.AppM
+import Context.Cache (invalidate)
+import Context.Elaborate
+import Context.Type
+import Control.Lens
+import Control.Monad.Trans
+import Data.Text qualified as T
+import Entity.LocationTree qualified as LT
+import Entity.Term.Weaken (weaken)
+import Entity.WeakTerm.ToText
+import Language.LSP.Protocol.Lens qualified as J
+import Language.LSP.Protocol.Types
+import Scene.Check qualified as Check
+import Scene.Elaborate
+import Scene.LSP.FindDefinition qualified as LSP
+import Scene.LSP.GetSource qualified as LSP
+
+getSymbolInfo ::
+  (J.HasTextDocument p a1, J.HasUri a1 Uri, J.HasPosition p Position) =>
+  p ->
+  AppM T.Text
+getSymbolInfo params = do
+  source <- LSP.getSource params
+  lift $ invalidate source
+  let uri = params ^. (J.textDocument . J.uri)
+  path <- liftMaybe $ uriToFilePath uri
+  lift $ Check.check (Just path)
+  ((locType, _), _) <- lift (runAppM $ LSP.findDefinition params) >>= liftMaybe
+  lift (runAppM $ _getSymbolInfo locType) >>= liftMaybe
+
+_getSymbolInfo :: LT.LocType -> AppM T.Text
+_getSymbolInfo locType = do
+  symbolName <- liftMaybe $ getSymbolLoc locType
+  case symbolName of
+    LT.Local varID -> do
+      t <- lift (lookupWeakTypeEnvMaybe varID) >>= liftMaybe
+      t' <- lift $ elaborate' t
+      return $ toText $ weaken t'
+    LT.Global dd -> do
+      t <- lift (lookupMaybe dd) >>= liftMaybe
+      return $ toText t
+
+getSymbolLoc :: LT.LocType -> Maybe LT.SymbolName
+getSymbolLoc locType =
+  case locType of
+    LT.FileLoc ->
+      Nothing
+    LT.SymbolLoc symbolName ->
+      return symbolName

--- a/src/Scene/LSP/Highlight.hs
+++ b/src/Scene/LSP/Highlight.hs
@@ -13,7 +13,7 @@ highlight ::
   p ->
   AppM [DocumentHighlight]
 highlight params = do
-  (defLink@(DefinitionLink (LocationLink {_targetRange, _targetUri})), locTree) <- LSP.findDefinition params
+  ((_, defLink@(DefinitionLink (LocationLink {_targetRange, _targetUri}))), locTree) <- LSP.findDefinition params
   let reqUri = params ^. J.textDocument . J.uri
   refs <- lift $ LSP.findReferences defLink locTree
   if reqUri /= _targetUri

--- a/src/Scene/LSP/Lint.hs
+++ b/src/Scene/LSP/Lint.hs
@@ -25,11 +25,9 @@ import Scene.Check qualified as Check
 import Scene.Parse.Core qualified as Parse
 
 lint ::
-  (J.HasParams p a1, J.HasTextDocument a1 a2, J.HasUri a2 Uri) =>
-  p ->
+  Uri ->
   AppLsp () ()
-lint msg = do
-  let doc = msg ^. J.params . J.textDocument . J.uri
+lint doc = do
   case uriToFilePath doc of
     Just path -> do
       flushDiagnosticsBySource maxDiagNum (Just "neut")

--- a/src/Scene/LSP/References.hs
+++ b/src/Scene/LSP/References.hs
@@ -18,7 +18,7 @@ references ::
   AppM [Location]
 references params = do
   currentSource <- LSP.getSource params
-  (defLink, _) <- LSP.findDefinition params
+  ((_, defLink), _) <- LSP.findDefinition params
   locTreeSeq <- LSP.getAllCachesInModule $ sourceModule currentSource
   fmap concat $ lift $ forConcurrently locTreeSeq $ \(path, locTree) -> do
     refList <- LSP.findReferences defLink locTree

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -92,7 +92,7 @@ discernStmt stmt = do
       codType' <- discern nenv' codType
       stmtKind' <- discernStmtKind stmtKind
       body' <- discern nenv' body
-      Tag.insertDD m functionName m
+      Tag.insertGlobalVar m functionName m
       forM_ expArgs' Tag.insertBinder
       return [WeakStmtDefine isConstLike stmtKind' m functionName impArgs' expArgs' codType' body']
     RawStmtDefineConst _ m (name, _) (_, (t, _)) (_, (v, _)) -> do
@@ -100,7 +100,7 @@ discernStmt stmt = do
       registerTopLevelName nameLifter stmt
       t' <- discern empty t
       v' <- discern empty v
-      Tag.insertDD m dd m
+      Tag.insertGlobalVar m dd m
       return [WeakStmtDefineConst m dd t' v']
     RawStmtDefineData _ m (dd, _) args consInfo -> do
       stmtList <- defineData m dd args $ SE.extract consInfo
@@ -110,7 +110,7 @@ discernStmt stmt = do
       registerTopLevelName nameLifter stmt
       t' <- discern empty $ m :< RT.Tau
       e' <- discern empty $ m :< RT.Resource [] discarder copier
-      Tag.insertDD m dd m
+      Tag.insertGlobalVar m dd m
       return [WeakStmtDefineConst m dd t' e']
     RawStmtNominal _ m geistList -> do
       geistList' <- forM (SE.extract geistList) $ \geist -> do
@@ -214,8 +214,7 @@ discern nenv term =
               return $ m :< WT.Prim (WP.Value $ WPV.Float h x)
           | Just (mDef, name') <- lookup s nenv -> do
               UnusedVariable.delete name'
-              unless (isHole name') $ do
-                Tag.insert m (T.length s) mDef
+              Tag.insertLocalVar m name' mDef
               return $ m :< WT.Var name'
         _ -> do
           (dd, (_, gn)) <- resolveName m name

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -92,7 +92,7 @@ discernStmt stmt = do
       codType' <- discern nenv' codType
       stmtKind' <- discernStmtKind stmtKind
       body' <- discern nenv' body
-      Tag.insertGlobalVar m functionName m
+      Tag.insertGlobalVar m functionName isConstLike m
       forM_ expArgs' Tag.insertBinder
       return [WeakStmtDefine isConstLike stmtKind' m functionName impArgs' expArgs' codType' body']
     RawStmtDefineConst _ m (name, _) (_, (t, _)) (_, (v, _)) -> do
@@ -100,7 +100,7 @@ discernStmt stmt = do
       registerTopLevelName nameLifter stmt
       t' <- discern empty t
       v' <- discern empty v
-      Tag.insertGlobalVar m dd m
+      Tag.insertGlobalVar m dd True m
       return [WeakStmtDefineConst m dd t' v']
     RawStmtDefineData _ m (dd, _) args consInfo -> do
       stmtList <- defineData m dd args $ SE.extract consInfo
@@ -110,7 +110,7 @@ discernStmt stmt = do
       registerTopLevelName nameLifter stmt
       t' <- discern empty $ m :< RT.Tau
       e' <- discern empty $ m :< RT.Resource [] discarder copier
-      Tag.insertGlobalVar m dd m
+      Tag.insertGlobalVar m dd True m
       return [WeakStmtDefineConst m dd t' e']
     RawStmtNominal _ m geistList -> do
       geistList' <- forM (SE.extract geistList) $ \geist -> do

--- a/src/Scene/Parse/Discern/Name.hs
+++ b/src/Scene/Parse/Discern/Name.hs
@@ -67,8 +67,8 @@ resolveVarOrErr m name = do
   case foundNameList of
     [] ->
       return $ Left $ "undefined symbol: " <> name
-    [globalVar@(dd, (mDef, _))] -> do
-      Tag.insertGlobalVar m dd mDef
+    [globalVar@(dd, (mDef, gn))] -> do
+      Tag.insertGlobalVar m dd (GN.getIsConstLike gn) mDef
       UnusedLocalLocator.delete localLocator
       return $ Right globalVar
     _ -> do
@@ -88,12 +88,13 @@ resolveLocator m (gl, ll) shouldInsertTag = do
   case foundName of
     Nothing ->
       Throw.raiseError m $ "undefined constant: " <> L.reify (gl, ll)
-    Just globalVar@(dd, (mDef, _)) -> do
+    Just globalVar@(dd, (mDef, gn)) -> do
       when shouldInsertTag $ do
         let glLen = T.length $ GL.reify gl
         let llLen = T.length $ LL.reify ll
         let sepLen = T.length C.nsSep
-        Tag.insert m (LT.SymbolLoc (LT.Global dd)) (glLen + sepLen + llLen) mDef
+        let isConstLike = GN.getIsConstLike gn
+        Tag.insert m (LT.SymbolLoc (LT.Global dd isConstLike)) (glLen + sepLen + llLen) mDef
       return globalVar
 
 resolveConstructor ::

--- a/src/Scene/Parse/Discern/Name.hs
+++ b/src/Scene/Parse/Discern/Name.hs
@@ -28,6 +28,7 @@ import Entity.GlobalName qualified as GN
 import Entity.Hint
 import Entity.IsConstLike
 import Entity.LocalLocator qualified as LL
+import Entity.LocationTree qualified as LT
 import Entity.Locator qualified as L
 import Entity.Magic qualified as M
 import Entity.Name
@@ -66,8 +67,8 @@ resolveVarOrErr m name = do
   case foundNameList of
     [] ->
       return $ Left $ "undefined symbol: " <> name
-    [globalVar@(_, (mDef, _))] -> do
-      Tag.insert m (T.length name) mDef
+    [globalVar@(dd, (mDef, _))] -> do
+      Tag.insertGlobalVar m dd mDef
       UnusedLocalLocator.delete localLocator
       return $ Right globalVar
     _ -> do
@@ -87,12 +88,12 @@ resolveLocator m (gl, ll) shouldInsertTag = do
   case foundName of
     Nothing ->
       Throw.raiseError m $ "undefined constant: " <> L.reify (gl, ll)
-    Just globalVar@(_, (mDef, _)) -> do
+    Just globalVar@(dd, (mDef, _)) -> do
       when shouldInsertTag $ do
         let glLen = T.length $ GL.reify gl
         let llLen = T.length $ LL.reify ll
         let sepLen = T.length C.nsSep
-        Tag.insert m (glLen + sepLen + llLen) mDef
+        Tag.insert m (LT.SymbolLoc (LT.Global dd)) (glLen + sepLen + llLen) mDef
       return globalVar
 
 resolveConstructor ::

--- a/src/Scene/Parse/Discern/Noema.hs
+++ b/src/Scene/Parse/Discern/Noema.hs
@@ -49,7 +49,7 @@ attachPrefix binder cont@(m :< _) =
       e' <- castToNoema e
       cont' <- attachPrefix rest cont
       h <- Gensym.newHole m []
-      Tag.insert mDef (innerLength y) mOrig
+      Tag.insertLocalVar mDef y mOrig
       return $ m :< WT.Let WT.Opaque (m, y, h) e' cont'
 
 attachSuffix :: [(Ident, Ident)] -> WT.WeakTerm -> App WT.WeakTerm


### PR DESCRIPTION
This PR adds support for `textDocument/hover`, which allows LSP clients to show type info of symbols in their lovely popups:

![9B4D2C3C-1F83-478F-A8E7-5A292A15798C_4_5005_c](https://github.com/vekatze/neut/assets/59402289/61285e07-69b7-4534-81f9-b4dc7a5e7167)

↓ (`lsp-ui-doc-glance` in lsp-mode)

![20835F1E-8AC7-48A8-898A-00546E6E6F28_4_5005_c](https://github.com/vekatze/neut/assets/59402289/e26c4c97-1f8c-44b8-8b95-e441b0c5e8d0)
