### PR TITLE
Add `neut zen`

### DIFF
--- a/src/Act/Zen.hs
+++ b/src/Act/Zen.hs
@@ -1,0 +1,39 @@
+module Act.Zen (zen) where
+
+import Act.Build (Axis (..), buildTarget)
+import Context.App
+import Context.Env qualified as Env
+import Context.Module qualified as Module
+import Context.Path qualified as Path
+import Control.Monad
+import Data.Maybe
+import Entity.Config.Zen
+import Entity.OutputKind
+import Entity.Target
+import Path.IO (resolveFile')
+import Scene.Fetch qualified as Fetch
+import Scene.Initialize qualified as Initialize
+import Prelude hiding (log)
+
+zen :: Config -> App ()
+zen cfg = do
+  setup cfg
+  path <- resolveFile' (filePathString cfg)
+  buildTarget (fromConfig cfg) $ ZenTarget path
+
+fromConfig :: Config -> Axis
+fromConfig cfg =
+  Axis
+    { _outputKindList = [Object],
+      _shouldSkipLink = False,
+      _shouldExecute = True,
+      _installDir = Nothing,
+      _executeArgs = args cfg
+    }
+
+setup :: Config -> App ()
+setup cfg = do
+  Path.ensureNotInLibDir
+  Initialize.initializeCompiler (remarkCfg cfg) (mClangOptString cfg)
+  Env.setBuildMode $ buildMode cfg
+  Module.getMainModule >>= Fetch.fetch

--- a/src/Context/OptParse.hs
+++ b/src/Context/OptParse.hs
@@ -15,6 +15,7 @@ import Entity.Config.Format qualified as Format
 import Entity.Config.LSP qualified as LSP
 import Entity.Config.Remark qualified as Remark
 import Entity.Config.Version qualified as Version
+import Entity.Config.Zen qualified as Zen
 import Entity.FileType qualified as FT
 import Entity.ModuleURL
 import Entity.OutputKind qualified as OK
@@ -38,6 +39,7 @@ parseOpt = do
         cmd "add" parseGetOpt "add a dependency",
         cmd "format-source" (parseFormatOpt FT.Source) "format a source file",
         cmd "format-ens" (parseFormatOpt FT.Ens) "format an ens file",
+        cmd "zen" parseZenOpt "execute `zen` of given file",
         cmd "lsp" parseLSPOpt "start the LSP server",
         cmd "version" parseVersionOpt "show version info"
       ]
@@ -91,6 +93,23 @@ parseGetOpt = do
         { Add.moduleAliasText = T.pack moduleAlias,
           Add.moduleURL = ModuleURL $ T.pack moduleURL,
           Add.remarkCfg = remarkCfg
+        }
+
+parseZenOpt :: Parser Command
+parseZenOpt = do
+  inputFilePath <- argument str (mconcat [metavar "INPUT", help "The path of input file"])
+  mClangOptString <- optional $ strOption $ mconcat [long "clang-option", metavar "OPT", help "Options for clang"]
+  remarkCfg <- remarkConfigOpt
+  buildMode <- option buildModeReader $ mconcat [long "mode", metavar "MODE", help "develop, release", value BM.Develop]
+  rest <- (many . strArgument) (metavar "args")
+  pure $
+    Zen $
+      Zen.Config
+        { Zen.filePathString = inputFilePath,
+          Zen.mClangOptString = mClangOptString,
+          Zen.remarkCfg = remarkCfg,
+          Zen.buildMode = buildMode,
+          Zen.args = rest
         }
 
 parseLSPOpt :: Parser Command

--- a/src/Entity/BaseName.hs
+++ b/src/Entity/BaseName.hs
@@ -14,6 +14,7 @@ module Entity.BaseName
     resourceName,
     textName,
     mainName,
+    zenName,
     fromText,
     this,
     new,
@@ -110,6 +111,10 @@ core =
 mainName :: BaseName
 mainName =
   MakeBaseName "main"
+
+zenName :: BaseName
+zenName =
+  MakeBaseName "zen"
 
 new :: BaseName
 new =

--- a/src/Entity/Command.hs
+++ b/src/Entity/Command.hs
@@ -9,6 +9,7 @@ import Entity.Config.Create qualified as Create
 import Entity.Config.Format qualified as Format
 import Entity.Config.LSP qualified as LSP
 import Entity.Config.Version qualified as Version
+import Entity.Config.Zen qualified as Zen
 
 data Command
   = Build Build.Config
@@ -20,3 +21,4 @@ data Command
   | Format Format.Config
   | LSP LSP.Config
   | ShowVersion Version.Config
+  | Zen Zen.Config

--- a/src/Entity/Config/Zen.hs
+++ b/src/Entity/Config/Zen.hs
@@ -1,0 +1,12 @@
+module Entity.Config.Zen (Config (..)) where
+
+import Entity.BuildMode
+import Entity.Config.Remark qualified as Remark
+
+data Config = Config
+  { filePathString :: FilePath,
+    mClangOptString :: Maybe String,
+    remarkCfg :: Remark.Config,
+    buildMode :: BuildMode,
+    args :: [String]
+  }

--- a/src/Entity/Const.hs
+++ b/src/Entity/Const.hs
@@ -77,6 +77,10 @@ executableRelDir :: Path Rel Dir
 executableRelDir =
   $(mkRelDir "executable")
 
+zenRelDir :: Path Rel Dir
+zenRelDir =
+  $(mkRelDir "zen")
+
 defaultInlineLimit :: Int
 defaultInlineLimit =
   100000

--- a/src/Entity/DefiniteDescription.hs
+++ b/src/Entity/DefiniteDescription.hs
@@ -12,6 +12,7 @@ module Entity.DefiniteDescription
     cls,
     toBuilder,
     llvmGlobalLocator,
+    isEntryPoint,
   )
 where
 
@@ -176,3 +177,7 @@ initLast xs =
 llvmGlobalLocator :: T.Text
 llvmGlobalLocator =
   "base.llvm"
+
+isEntryPoint :: DefiniteDescription -> Bool
+isEntryPoint dd =
+  localLocator dd `elem` ["main", "zen"]

--- a/src/Entity/Target.hs
+++ b/src/Entity/Target.hs
@@ -3,8 +3,11 @@ module Entity.Target where
 import Data.Hashable
 import Data.Text qualified as T
 import GHC.Generics (Generic)
+import Path
 
-newtype Target = Target {extract :: T.Text}
+data Target
+  = Target T.Text
+  | ZenTarget (Path Abs File)
   deriving (Show, Eq, Generic)
 
 instance Hashable Target

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -9,6 +9,7 @@ import Act.Create qualified as Create
 import Act.Format qualified as Format
 import Act.LSP qualified as LSP
 import Act.Version qualified as Version
+import Act.Zen qualified as Zen
 import Context.App
 import Context.External qualified as External
 import Context.OptParse qualified as OptParse
@@ -46,3 +47,5 @@ execute = do
           LSP.lsp cfg
         C.ShowVersion cfg ->
           Version.showVersion cfg
+        C.Zen cfg ->
+          Zen.zen cfg

--- a/src/Scene/Elaborate.hs
+++ b/src/Scene/Elaborate.hs
@@ -6,7 +6,6 @@ import Context.DataDefinition qualified as DataDefinition
 import Context.Definition qualified as Definition
 import Context.Elaborate
 import Context.Env qualified as Env
-import Context.Locator qualified as Locator
 import Context.RawImportSummary qualified as RawImportSummary
 import Context.Remark qualified as Remark
 import Context.SymLoc qualified as SymLoc
@@ -64,11 +63,9 @@ elaborate cacheOrStmt = do
 
 analyzeStmtList :: [WeakStmt] -> App [WeakStmt]
 analyzeStmtList stmtList = do
-  source <- Env.getCurrentSource
-  mMainDD <- Locator.getMainDefiniteDescription source
   -- mapM_ viewStmt stmtList
   forM stmtList $ \stmt -> do
-    stmt' <- Infer.inferStmt mMainDD stmt
+    stmt' <- Infer.inferStmt stmt
     insertWeakStmt stmt'
     return stmt'
 

--- a/src/Scene/Elaborate/Infer.hs
+++ b/src/Scene/Elaborate/Infer.hs
@@ -52,8 +52,8 @@ import Scene.WeakTerm.Subst qualified as WT
 
 type BoundVarEnv = [BinderF WT.WeakTerm]
 
-inferStmt :: Maybe DD.DefiniteDescription -> WeakStmt -> App WeakStmt
-inferStmt mMainDD stmt =
+inferStmt :: WeakStmt -> App WeakStmt
+inferStmt stmt =
   case stmt of
     WeakStmtDefine isConstLike stmtKind m x impArgs expArgs codType e -> do
       (impArgs', varEnv) <- inferBinder' [] impArgs
@@ -63,7 +63,7 @@ inferStmt mMainDD stmt =
       stmtKind' <- inferStmtKind stmtKind
       (e', te) <- infer varEnv' e
       insConstraintEnv codType' te
-      when (mMainDD == Just x) $ do
+      when (DD.isEntryPoint x) $ do
         let _m = m {metaShouldSaveLocation = False}
         unitType <- getUnitType _m
         insConstraintEnv (m :< WT.Pi [] [] unitType) (m :< WT.Pi impArgs' expArgs' codType')

--- a/src/Scene/Install.hs
+++ b/src/Scene/Install.hs
@@ -11,8 +11,12 @@ import Path.IO
 import Prelude hiding (log)
 
 install :: Target.Target -> Path Abs Dir -> App ()
-install target dir = do
-  execPath <- Module.getMainModule >>= Path.getExecutableOutputPath target
-  execName <- parseRelFile $ T.unpack $ Target.extract target
-  let destPath = dir </> execName
-  copyFile execPath destPath
+install targetOrZen dir = do
+  execPath <- Module.getMainModule >>= Path.getExecutableOutputPath targetOrZen
+  case targetOrZen of
+    Target.Target target -> do
+      execName <- parseRelFile $ T.unpack target
+      let destPath = dir </> execName
+      copyFile execPath destPath
+    Target.ZenTarget {} ->
+      return ()

--- a/src/Scene/Module/Reflect.hs
+++ b/src/Scene/Module/Reflect.hs
@@ -29,7 +29,6 @@ import Entity.ModuleDigest
 import Entity.ModuleID qualified as MID
 import Entity.ModuleURL
 import Entity.SourceLocator qualified as SL
-import Entity.Target
 import Path
 import Path.IO
 import Scene.Ens.Reflect qualified as Ens
@@ -86,7 +85,7 @@ fromFilePath moduleID moduleFilePath = do
         moduleArchiveDir = archiveDir,
         moduleBuildDir = buildDir,
         moduleSourceDir = sourceDir,
-        moduleTarget = Map.mapKeys Target target,
+        moduleTarget = target,
         moduleDependency = dependency,
         moduleExtraContents = extraContents,
         moduleAntecedents = antecedents,

--- a/src/Scene/New.hs
+++ b/src/Scene/New.hs
@@ -16,7 +16,6 @@ import Entity.Const
 import Entity.Module
 import Entity.ModuleID qualified as MID
 import Entity.SourceLocator qualified as SL
-import Entity.Target
 import Path (parent, (</>))
 
 createNewProject :: T.Text -> Module -> App ()
@@ -43,7 +42,7 @@ constructDefaultModule name = do
         moduleSourceDir = sourceRelDir,
         moduleTarget =
           Map.fromList
-            [ ( Target name,
+            [ ( name,
                 SL.SourceLocator mainFile
               )
             ],

--- a/src/Scene/Unravel.hs
+++ b/src/Scene/Unravel.hs
@@ -52,18 +52,17 @@ type ObjectTime =
   Maybe UTCTime
 
 unravel :: Target -> App (A.ArtifactTime, [Source.Source])
-unravel target = do
+unravel targetOrZen = do
   mainModule <- Module.getMainModule
-  case getTargetPath mainModule target of
-    Nothing ->
-      Throw.raiseError' $ "no such target is defined: `" <> extract target <> "`"
-    Just mainFilePath -> do
-      unravel' $
-        Source.Source
-          { Source.sourceModule = mainModule,
-            Source.sourceFilePath = mainFilePath,
-            Source.sourceHint = Nothing
-          }
+  case targetOrZen of
+    ZenTarget path ->
+      unravelFromFile path
+    Target target -> do
+      case getTargetPath mainModule target of
+        Nothing ->
+          Throw.raiseError' $ "no such target is defined: `" <> target <> "`"
+        Just path -> do
+          unravelFromFile path
 
 unravelFromFile ::
   Path Abs File ->

--- a/test/misc/multi-targets/source/main.nt
+++ b/test/misc/multi-targets/source/main.nt
@@ -1,7 +1,3 @@
-import {
-- this.multi-targets
-}
-
 define main(): unit {
   Unit
 }

--- a/test/misc/multi-targets/source/multi-targets.nt
+++ b/test/misc/multi-targets/source/multi-targets.nt
@@ -1,3 +1,7 @@
 define main(): unit {
   print("Hello, world!\n")
 }
+
+define zen(): unit {
+  print("this is zen. I can test local functions.\n")
+}


### PR DESCRIPTION
This PR adds a subcommand `zen`, a calming way to think about program.

`neut zen FILE` compiles & executes `FILE` as if the function `zen` in the file were `main`.  For example, given the following `foo.nt`:

```
define foo(): text { 
  "foo" 
}

define zen(): unit {
  print(foo())
}
```

executing `neut zen path/to/foo.nt` results in `"foo"`.

This `zen` can be used against every file in a module, even if the file isn't a main file.