### PR TITLE
Faster completion by splitting cache files

### DIFF
--- a/src/Context/Path.hs
+++ b/src/Context/Path.hs
@@ -25,6 +25,7 @@ module Context.Path
     sourceToOutputPath,
     getZenExecutableDir,
     getSourceCachePath,
+    getSourceCompletionCachePath,
     attachOutputPath,
     getOutputPathForEntryPoint,
   )
@@ -252,6 +253,13 @@ getSourceCachePath source = do
   relPath <- Src.getRelPathFromSourceDir source
   (relPathWithoutExtension, _) <- P.splitExtension relPath
   P.addExtension ".i" (artifactDir </> relPathWithoutExtension)
+
+getSourceCompletionCachePath :: Src.Source -> App (Path Abs File)
+getSourceCompletionCachePath source = do
+  artifactDir <- getArtifactDir $ Src.sourceModule source
+  relPath <- Src.getRelPathFromSourceDir source
+  (relPathWithoutExtension, _) <- P.splitExtension relPath
+  P.addExtension ".ic" (artifactDir </> relPathWithoutExtension)
 
 attachOutputPath :: OK.OutputKind -> Src.Source -> App (OK.OutputKind, Path Abs File)
 attachOutputPath outputKind source = do

--- a/src/Entity/Cache.hs
+++ b/src/Entity/Cache.hs
@@ -12,34 +12,34 @@ import GHC.Generics
 data Cache = Cache
   { stmtList :: [Stmt.Stmt],
     remarkList :: [Remark],
-    locationTree :: LT.LocationTree,
-    localVarTree :: LVT.LocalVarTree,
-    topCandidate :: [TopCandidate],
-    rawImportSummary :: Maybe RawImportSummary
+    locationTree :: LT.LocationTree
   }
   deriving (Generic)
 
 data LowCache = LowCache
   { stmtList' :: [Stmt.StrippedStmt],
     remarkList' :: [Remark],
-    locationTree' :: LT.LocationTree,
-    localVarTree' :: LVT.LocalVarTree,
-    topCandidate' :: [TopCandidate],
-    rawImportSummary' :: Maybe RawImportSummary
+    locationTree' :: LT.LocationTree
   }
   deriving (Generic)
 
 instance Binary LowCache
+
+data CompletionCache = CompletionCache
+  { localVarTree :: LVT.LocalVarTree,
+    topCandidate :: [TopCandidate],
+    rawImportSummary :: Maybe RawImportSummary
+  }
+  deriving (Generic)
+
+instance Binary CompletionCache
 
 compress :: Cache -> LowCache
 compress cache =
   LowCache
     { stmtList' = map Stmt.compress (stmtList cache),
       remarkList' = remarkList cache,
-      locationTree' = locationTree cache,
-      localVarTree' = localVarTree cache,
-      topCandidate' = topCandidate cache,
-      rawImportSummary' = rawImportSummary cache
+      locationTree' = locationTree cache
     }
 
 extend :: LowCache -> Cache
@@ -47,8 +47,5 @@ extend cache =
   Cache
     { stmtList = map Stmt.extend (stmtList' cache),
       remarkList = remarkList' cache,
-      locationTree = locationTree' cache,
-      localVarTree = localVarTree' cache,
-      topCandidate = topCandidate' cache,
-      rawImportSummary = rawImportSummary' cache
+      locationTree = locationTree' cache
     }

--- a/src/Scene/Elaborate.hs
+++ b/src/Scene/Elaborate.hs
@@ -85,8 +85,11 @@ synthesizeStmtList stmtList = do
     Cache.Cache
       { Cache.stmtList = stmtList',
         Cache.remarkList = remarkList,
-        Cache.locationTree = tmap,
-        Cache.localVarTree = localVarTree,
+        Cache.locationTree = tmap
+      }
+  Cache.saveCompletionCache source $
+    Cache.CompletionCache
+      { Cache.localVarTree = localVarTree,
         Cache.topCandidate = topCandidate,
         Cache.rawImportSummary = rawImportSummary
       }

--- a/src/Scene/LSP/GetAllCachesInModule.hs
+++ b/src/Scene/LSP/GetAllCachesInModule.hs
@@ -1,8 +1,12 @@
-module Scene.LSP.GetAllCachesInModule (getAllCachesInModule, getCache) where
+module Scene.LSP.GetAllCachesInModule
+  ( getAllCachesInModule,
+    getAllCompletionCachesInModule,
+  )
+where
 
 import Context.App
 import Context.Cache qualified as Cache
-import Context.Path (getSourceCachePath)
+import Context.Path (getSourceCachePath, getSourceCompletionCachePath)
 import Data.Maybe (catMaybes)
 import Entity.Cache
 import Entity.Module
@@ -20,6 +24,21 @@ getCache :: Module -> Path Abs File -> App (Maybe (Source, Cache))
 getCache baseModule filePath = do
   let source = Source {sourceFilePath = filePath, sourceModule = baseModule, sourceHint = Nothing}
   cacheOrNone <- getSourceCachePath source >>= Cache.loadCacheOptimistically
+  case cacheOrNone of
+    Nothing ->
+      return Nothing
+    Just cache ->
+      return $ Just (source, cache)
+
+getAllCompletionCachesInModule :: Module -> App [(Source, CompletionCache)]
+getAllCompletionCachesInModule baseModule = do
+  (_, filePathList) <- listDirRecur $ getSourceDir baseModule
+  fmap catMaybes $ forConcurrently filePathList $ \path -> getCompletionCache baseModule path
+
+getCompletionCache :: Module -> Path Abs File -> App (Maybe (Source, CompletionCache))
+getCompletionCache baseModule filePath = do
+  let source = Source {sourceFilePath = filePath, sourceModule = baseModule, sourceHint = Nothing}
+  cacheOrNone <- getSourceCompletionCachePath source >>= Cache.loadCompletionCacheOptimistically
   case cacheOrNone of
     Nothing ->
       return Nothing


### PR DESCRIPTION
This PR extracts completion-related parts from cache files. This results in about 5x faster completion.

## Example Case

Run `Scene.LSP.Complete.complete` at `(*)` in the following file:

```
define make-adder(x: int): (int) -> int {
  let adder =
    (y) => {
      add-int(x, y)
    }
  in
  adder
}

define main(): unit {
  print-int(make-adder(3)(7)); 
  // (*)
  print("\n")
}
```

## Result (Before)

```
	total time  =        0.06 secs   (88 ticks @ 1000 us, 10 processors)
	total alloc =  79,720,928 bytes  (excludes profiling overheads)

COST CENTRE             MODULE                     SRC                                         %time %alloc

get                     Entity.Hint                src/Entity/Hint.hs:(47,3)-(48,48)            68.2   43.7
get                     Entity.Term                src/Entity/Term.hs:44:10-39                  11.4    7.9
normalizeDir            Path.Posix                 src/Path/Include.hs:(782,1)-(790,25)          2.3    1.0
get                     Entity.PrimType            src/Entity/PrimType.hs:12:10-24               2.3    0.6
MAIN                    MAIN                       <built-in>                                    1.1    0.2
...
```

## Result (After)

```
	total time  =        0.01 secs   (19 ticks @ 1000 us, 10 processors)
	total alloc =  18,026,072 bytes  (excludes profiling overheads)

COST CENTRE                       MODULE                          SRC                                          %time %alloc

normalizeFilePath                 Path.Posix                      src/Path/Include.hs:(820,1)-(822,58)          26.3   21.0
lookup#                           Data.HashMap.Internal           Data/HashMap/Internal.hs:609:1-82             15.8    0.0
MAIN                              MAIN                            <built-in>                                    10.5    0.9
CAF                               GHC.IO.Handle.FD                <entire-module>                                5.3    0.3
takeWhile_                        Text.Megaparsec.Stream          Text/Megaparsec/Stream.hs:231:3-62             5.3    2.1
mplus                             Text.Megaparsec.Internal        Text/Megaparsec/Internal.hs:295:3-15           5.3    1.3
...
```