### PR TITLE
add a notation: `foo::bar` => `use foo {bar} in bar`

### DIFF
--- a/src/Entity/RawTerm.hs
+++ b/src/Entity/RawTerm.hs
@@ -81,6 +81,7 @@ data RawTermF a
   | Assert C (Hint, T.Text) C C (a, C)
   | Introspect C T.Text C (SE.Series (Maybe T.Text, C, a))
   | With (KeywordClause a)
+  | Projection a (Hint, RawIdent) Loc
   | Brace C (a, C)
 
 type Args a =

--- a/src/Entity/RawTerm/Decode.hs
+++ b/src/Entity/RawTerm/Decode.hs
@@ -230,6 +230,12 @@ toDoc term =
         ]
     _ :< With withClause -> do
       decodeKeywordClause "with" $ mapKeywordClause toDoc withClause
+    _ :< Projection e (_, proj) _ -> do
+      PI.arrange
+        [ PI.inject $ toDoc e,
+          PI.inject $ D.text "::",
+          PI.inject $ D.text proj
+        ]
     _ :< Brace c1 (e, c2) -> do
       SE.decode $ toDoc <$> SE.fromListWithComment SE.Brace SE.Comma [(c1, (e, c2))]
 

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -466,6 +466,11 @@ discern nenv term =
           discern nenv $ mUse :< RT.Use c1 item c2 vars c3 cont' endLoc
         _ ->
           discern nenv body
+    _ :< RT.Projection e (mProj, proj) loc -> do
+      t <- Gensym.newPreHole (blur mProj)
+      let args = (SE.fromList SE.Brace SE.Comma [(mProj, proj, [], [], t)], [])
+      let var = mProj :< RT.Var (Var proj)
+      discern nenv $ mProj :< RT.Use [] e [] args [] var loc
     _ :< RT.Brace _ (e, _) ->
       discern nenv e
 

--- a/test/misc/codata-basic/source/codata-basic.nt
+++ b/test/misc/codata-basic/source/codata-basic.nt
@@ -12,7 +12,8 @@ data stream(a: tau) {
 
 define int-stream(x: int): stream(int) {
   Stream of {
-  - head = x
+  - head =
+    x
   - tail =
     () => {
       int-stream(add-int(x, 1))


### PR DESCRIPTION
Example usage:

```
constant intdict: Dict.trope(int) {
  Dict.from-loset(this.int.as-loset)
}

define make-big-dict(): dict(int, int) {
  loop(700000, Dict.empty(), (acc, _) => {
    let key = random(1000000) in
    let val = random(1000000) in
    intdict::insert(key, val, acc) // ← here
  })
}
```