### PR TITLE
pass clang options to `neut zen` via `module.ens`

### DIFF
--- a/src/Act/Zen.hs
+++ b/src/Act/Zen.hs
@@ -9,7 +9,7 @@ import Control.Monad
 import Data.Maybe
 import Entity.Config.Zen
 import Entity.OutputKind
-import Entity.Target hiding (compileOption, linkOption)
+import Entity.Target
 import Path.IO (resolveFile')
 import Scene.Build (Axis (..), buildTarget)
 import Scene.Fetch qualified as Fetch

--- a/src/Act/Zen.hs
+++ b/src/Act/Zen.hs
@@ -7,9 +7,12 @@ import Context.Module qualified as Module
 import Context.Path qualified as Path
 import Control.Monad
 import Data.Maybe
+import Entity.ClangOption qualified as CL
 import Entity.Config.Zen
+import Entity.Module (Module (moduleZenConfig))
 import Entity.OutputKind
 import Entity.Target
+import Entity.ZenConfig qualified as Z
 import Path.IO (resolveFile')
 import Scene.Build (Axis (..), buildTarget)
 import Scene.Fetch qualified as Fetch
@@ -21,8 +24,9 @@ zen cfg = do
   setup cfg
   path <- resolveFile' (filePathString cfg)
   mainModule <- getMainModule
+  let zenConfig = Z.clangOption $ moduleZenConfig mainModule
   buildTarget (fromConfig cfg) mainModule $
-    Concrete (Zen path (compileOption cfg) (linkOption cfg))
+    Concrete (Zen path (CL.compileOption zenConfig) (CL.linkOption zenConfig))
 
 fromConfig :: Config -> Axis
 fromConfig cfg =

--- a/src/Context/OptParse.hs
+++ b/src/Context/OptParse.hs
@@ -95,22 +95,6 @@ parseGetOpt = do
 parseZenOpt :: Parser Command
 parseZenOpt = do
   inputFilePath <- argument str (mconcat [metavar "INPUT", help "The path of input file"])
-  compileOption <-
-    strOption $
-      mconcat
-        [ long "compile-option",
-          metavar "OPT",
-          help "Options used by clang when compiling source files",
-          value ""
-        ]
-  linkOption <-
-    strOption $
-      mconcat
-        [ long "link-option",
-          metavar "OPT",
-          help "Options used by clang when linking object files",
-          value ""
-        ]
   remarkCfg <- remarkConfigOpt
   buildMode <- option buildModeReader $ mconcat [long "mode", metavar "MODE", help "develop, release", value BM.Develop]
   rest <- (many . strArgument) (metavar "args")
@@ -118,8 +102,6 @@ parseZenOpt = do
     Entity.Command.Zen $
       Zen.Config
         { Zen.filePathString = inputFilePath,
-          Zen.compileOption = compileOption,
-          Zen.linkOption = linkOption,
           Zen.remarkCfg = remarkCfg,
           Zen.buildMode = buildMode,
           Zen.args = rest

--- a/src/Entity/ClangOption.hs
+++ b/src/Entity/ClangOption.hs
@@ -1,0 +1,33 @@
+module Entity.ClangOption
+  ( ClangOption (..),
+    new,
+    empty,
+  )
+where
+
+import Data.Hashable
+import Data.Text qualified as T
+import GHC.Generics (Generic)
+
+data ClangOption
+  = ClangOption
+  { compileOption :: [T.Text],
+    linkOption :: [T.Text]
+  }
+  deriving (Show, Eq, Generic)
+
+instance Hashable ClangOption
+
+new :: [T.Text] -> [T.Text] -> [T.Text] -> ClangOption
+new buildOption compileOption linkOption =
+  ClangOption
+    { compileOption = buildOption ++ compileOption,
+      linkOption = buildOption ++ linkOption
+    }
+
+empty :: ClangOption
+empty =
+  ClangOption
+    { compileOption = [],
+      linkOption = []
+    }

--- a/src/Entity/Config/Zen.hs
+++ b/src/Entity/Config/Zen.hs
@@ -1,13 +1,10 @@
 module Entity.Config.Zen (Config (..)) where
 
-import Data.Text qualified as T
 import Entity.BuildMode
 import Entity.Config.Remark qualified as Remark
 
 data Config = Config
   { filePathString :: FilePath,
-    compileOption :: T.Text,
-    linkOption :: T.Text,
     remarkCfg :: Remark.Config,
     buildMode :: BuildMode,
     args :: [String]

--- a/src/Entity/Module.hs
+++ b/src/Entity/Module.hs
@@ -10,6 +10,7 @@ import Data.List.NonEmpty qualified as NE
 import Data.Maybe (catMaybes, maybeToList)
 import Data.Text qualified as T
 import Entity.BaseName qualified as BN
+import Entity.ClangOption qualified as CL
 import Entity.Const
 import Entity.Ens qualified as E
 import Entity.Error
@@ -22,6 +23,7 @@ import Entity.ModuleURL
 import Entity.SourceLocator qualified as SL
 import Entity.Syntax.Series qualified as SE
 import Entity.Target qualified as Target
+import Entity.ZenConfig
 import Path
 import System.FilePath qualified as FP
 
@@ -58,6 +60,7 @@ data Module = Module
   { moduleID :: MID.ModuleID,
     moduleSourceDir :: Path Rel Dir,
     moduleTarget :: Map.HashMap TargetName Target.TargetSummary,
+    moduleZenConfig :: ZenConfig,
     moduleArchiveDir :: Path Rel Dir,
     moduleBuildDir :: Path Rel Dir,
     moduleDependency :: Map.HashMap MA.ModuleAlias Dependency,
@@ -87,6 +90,10 @@ keySource =
 keyTarget :: T.Text
 keyTarget =
   "target"
+
+keyZen :: T.Text
+keyZen =
+  "zen"
 
 keyMain :: T.Text
 keyMain =
@@ -247,12 +254,12 @@ getBuildDirInfo someModule = do
 getTargetInfo :: Module -> (T.Text, E.Ens)
 getTargetInfo someModule = do
   let targetDict = flip Map.map (moduleTarget someModule) $ \summary -> do
-        let compileOption = map (\x -> _m :< E.String x) $ Target.compileOption summary
+        let compileOption = map (\x -> _m :< E.String x) $ CL.compileOption (Target.clangOption summary)
         let compileOption' =
               if null compileOption
                 then Nothing
                 else Just (keyCompileOption, _m :< E.List (seriesFromList compileOption))
-        let linkOption = map (\x -> _m :< E.String x) $ Target.linkOption summary
+        let linkOption = map (\x -> _m :< E.String x) $ CL.linkOption (Target.clangOption summary)
         let linkOption' =
               if null linkOption
                 then Nothing

--- a/src/Entity/Target.hs
+++ b/src/Entity/Target.hs
@@ -25,7 +25,7 @@ data AbstractTarget
 
 data ConcreteTarget
   = Named T.Text TargetSummary
-  | Zen (Path Abs File) T.Text T.Text
+  | Zen (Path Abs File) [T.Text] [T.Text]
   deriving (Show, Eq, Generic)
 
 instance Hashable Target
@@ -38,7 +38,7 @@ instance Hashable ConcreteTarget
 
 emptyZen :: Path Abs File -> ConcreteTarget
 emptyZen path =
-  Zen path "" ""
+  Zen path [] []
 
 getEntryPointName :: ConcreteTarget -> BN.BaseName
 getEntryPointName target =
@@ -58,7 +58,7 @@ getCompileOption target =
         Named _ targetSummary -> do
           map T.unpack $ CL.compileOption (clangOption targetSummary)
         Zen _ compileOption _ ->
-          [T.unpack compileOption]
+          map T.unpack compileOption
 
 getLinkOption :: Target -> [String]
 getLinkOption target =
@@ -70,4 +70,4 @@ getLinkOption target =
         Named _ targetSummary ->
           map T.unpack $ CL.linkOption (clangOption targetSummary)
         Zen _ _ linkOption ->
-          [T.unpack linkOption]
+          map T.unpack linkOption

--- a/src/Entity/Target.hs
+++ b/src/Entity/Target.hs
@@ -3,6 +3,7 @@ module Entity.Target where
 import Data.Hashable
 import Data.Text qualified as T
 import Entity.BaseName qualified as BN
+import Entity.ClangOption qualified as CL
 import Entity.SourceLocator qualified as SL
 import GHC.Generics (Generic)
 import Path
@@ -14,9 +15,7 @@ data Target
 
 data TargetSummary = TargetSummary
   { entryPoint :: SL.SourceLocator,
-    buildOption :: [T.Text],
-    compileOption :: [T.Text],
-    linkOption :: [T.Text]
+    clangOption :: CL.ClangOption
   }
   deriving (Show, Eq, Generic)
 
@@ -56,8 +55,8 @@ getCompileOption target =
       []
     Concrete c ->
       case c of
-        Named _ targetSummary ->
-          map T.unpack $ buildOption targetSummary ++ compileOption targetSummary
+        Named _ targetSummary -> do
+          map T.unpack $ CL.compileOption (clangOption targetSummary)
         Zen _ compileOption _ ->
           [T.unpack compileOption]
 
@@ -69,6 +68,6 @@ getLinkOption target =
     Concrete c ->
       case c of
         Named _ targetSummary ->
-          map T.unpack $ buildOption targetSummary ++ linkOption targetSummary
+          map T.unpack $ CL.linkOption (clangOption targetSummary)
         Zen _ _ linkOption ->
           [T.unpack linkOption]

--- a/src/Entity/ZenConfig.hs
+++ b/src/Entity/ZenConfig.hs
@@ -1,0 +1,7 @@
+module Entity.ZenConfig (ZenConfig (..)) where
+
+import Entity.ClangOption
+
+newtype ZenConfig
+  = ZenConfig {clangOption :: ClangOption}
+  deriving (Show)

--- a/src/Scene/Build.hs
+++ b/src/Scene/Build.hs
@@ -230,6 +230,6 @@ expandClangOptions target =
                     }
                 )
         Zen path compileOption linkOption -> do
-          compileOption' <- External.expandText compileOption
-          linkOption' <- External.expandText linkOption
+          compileOption' <- mapM External.expandText compileOption
+          linkOption' <- mapM External.expandText linkOption
           return $ Concrete $ Zen path compileOption' linkOption'

--- a/src/Scene/Build.hs
+++ b/src/Scene/Build.hs
@@ -21,6 +21,7 @@ import Data.Maybe
 import Data.Text qualified as T
 import Data.Time
 import Entity.Cache
+import Entity.ClangOption qualified as CL
 import Entity.LowComp qualified as LC
 import Entity.Module qualified as M
 import Entity.ModuleID qualified as MID
@@ -213,17 +214,19 @@ expandClangOptions target =
     Concrete concreteTarget ->
       case concreteTarget of
         Named targetName summary -> do
-          buildOption' <- mapM External.expandText (buildOption summary)
-          compileOption' <- mapM External.expandText (compileOption summary)
-          linkOption' <- mapM External.expandText (linkOption summary)
+          let cl = clangOption summary
+          compileOption' <- mapM External.expandText (CL.compileOption cl)
+          linkOption' <- mapM External.expandText (CL.linkOption cl)
           return $
             Concrete $
               Named
                 targetName
                 ( summary
-                    { buildOption = buildOption',
-                      compileOption = compileOption',
-                      linkOption = linkOption'
+                    { clangOption =
+                        CL.ClangOption
+                          { compileOption = compileOption',
+                            linkOption = linkOption'
+                          }
                     }
                 )
         Zen path compileOption linkOption -> do

--- a/src/Scene/New.hs
+++ b/src/Scene/New.hs
@@ -6,12 +6,14 @@ where
 
 import Context.App
 import Context.Module qualified as Module
+import Entity.ZenConfig
 import Context.Path qualified as Path
 import Context.Remark qualified as Remark
 import Context.Throw qualified as Throw
 import Control.Monad
 import Data.HashMap.Strict qualified as Map
 import Data.Text qualified as T
+import Entity.ClangOption qualified as CL
 import Entity.Const
 import Entity.Module
 import Entity.ModuleID qualified as MID
@@ -46,12 +48,11 @@ constructDefaultModule name = do
             [ ( name,
                 TargetSummary
                   { entryPoint = SL.SourceLocator mainFile,
-                    buildOption = [],
-                    compileOption = [],
-                    linkOption = []
+                    clangOption = CL.empty
                   }
               )
             ],
+        moduleZenConfig = ZenConfig {clangOption = CL.empty},
         moduleDependency = Map.empty,
         moduleExtraContents = [],
         moduleAntecedents = [],


### PR DESCRIPTION
Example:

```ens
{
  // ...
  zen {
    build-option [
      "$(pkg-config libpq --libs --cflags)",
    ],
  },
  // ...
}
```