### PR TITLE
select an appropriate next version if one isn't specified

### DIFF
--- a/src/Act/Archive.hs
+++ b/src/Act/Archive.hs
@@ -9,13 +9,14 @@ import Scene.Archive qualified as Archive
 import Scene.Collect qualified as Collect
 import Scene.Initialize qualified as Initialize
 import Scene.Module.MakeArchiveEns
+import Scene.PackageVersion.ChooseNewVersion qualified as PV
 import Scene.PackageVersion.Reflect qualified as PV
 
 archive :: Config -> App ()
 archive cfg = do
   Initialize.initializeCompiler (remarkCfg cfg)
   Path.ensureNotInLibDir
-  packageVersion <- PV.reflect (getArchiveName cfg)
+  packageVersion <- maybe PV.chooseNewVersion PV.reflect (getArchiveName cfg)
   archiveEns <- Module.getMainModule >>= makeArchiveEns packageVersion
   mainModule <- getMainModule
   let (moduleRootDir, contents) = Collect.collectModuleFiles mainModule

--- a/src/Context/OptParse.hs
+++ b/src/Context/OptParse.hs
@@ -144,7 +144,7 @@ parseCheckOpt = do
 
 parseArchiveOpt :: Parser Command
 parseArchiveOpt = do
-  archiveName <- argument str (mconcat [metavar "NAME", help "The name of the archive"])
+  archiveName <- optional $ argument str (mconcat [metavar "NAME", help "The name of the archive"])
   remarkCfg <- remarkConfigOpt
   pure $
     Archive $

--- a/src/Entity/Config/Archive.hs
+++ b/src/Entity/Config/Archive.hs
@@ -4,6 +4,6 @@ import Data.Text qualified as T
 import Entity.Config.Remark qualified as Remark
 
 data Config = Config
-  { getArchiveName :: T.Text,
+  { getArchiveName :: Maybe T.Text,
     remarkCfg :: Remark.Config
   }

--- a/src/Entity/DefiniteDescription.hs
+++ b/src/Entity/DefiniteDescription.hs
@@ -28,6 +28,7 @@ import Entity.Const
 import Entity.Error
 import Entity.GlobalLocator qualified as GL
 import Entity.Hint qualified as H
+import Entity.List (initLast)
 import Entity.LocalLocator qualified as LL
 import Entity.Module qualified as M
 import Entity.ModuleAlias qualified as MA
@@ -162,17 +163,6 @@ getLocatorPair m varText = do
       gl <- GL.reflect m $ T.intercalate "." initElems
       ll <- LL.reflect m lastElem
       return (gl, ll)
-
-initLast :: [a] -> Maybe ([a], a)
-initLast xs =
-  case xs of
-    [] ->
-      Nothing
-    [x] ->
-      return ([], x)
-    x : rest -> do
-      (initElems, lastElem) <- initLast rest
-      return (x : initElems, lastElem)
 
 llvmGlobalLocator :: T.Text
 llvmGlobalLocator =

--- a/src/Entity/List.hs
+++ b/src/Entity/List.hs
@@ -1,0 +1,12 @@
+module Entity.List (initLast) where
+
+initLast :: [a] -> Maybe ([a], a)
+initLast xs =
+  case xs of
+    [] ->
+      Nothing
+    [x] ->
+      return ([], x)
+    x : rest -> do
+      (initElems, lastElem) <- initLast rest
+      return (x : initElems, lastElem)

--- a/src/Entity/PackageVersion.hs
+++ b/src/Entity/PackageVersion.hs
@@ -4,12 +4,16 @@ module Entity.PackageVersion
     reify,
     isValidNewVersion,
     getAntecedents,
+    getNewestVersion,
+    increment,
+    initialVersion,
   )
 where
 
 import Data.List
 import Data.Text qualified as T
 import Entity.Const
+import Entity.List (initLast)
 import Text.Read
 
 type PackageVersion =
@@ -57,3 +61,20 @@ getAntecedents (alphaPrefix, (majorVersion1, minorVersionList1)) vs = do
   let vs' = filter (\(a, (m, _)) -> a == alphaPrefix && m == majorVersion1) vs
   let antecedentMinorVersionList = filter (< minorVersionList1) $ map (snd . snd) vs'
   map ((alphaPrefix,) . (majorVersion1,)) antecedentMinorVersionList
+
+getNewestVersion :: [PackageVersion] -> PackageVersion -> PackageVersion
+getNewestVersion candidates fallback =
+  foldl' max fallback candidates
+
+increment :: PackageVersion -> PackageVersion
+increment version = do
+  let (alphaPrefix, (majorVersion, minorVersionList)) = version
+  case initLast minorVersionList of
+    Just (minorVersionPrefix, lowestMinorVersion) ->
+      (alphaPrefix, (majorVersion, minorVersionPrefix ++ [lowestMinorVersion + 1]))
+    Nothing ->
+      (alphaPrefix, (majorVersion + 1, []))
+
+initialVersion :: PackageVersion
+initialVersion =
+  (1, (1, [0]))

--- a/src/Scene/PackageVersion/ChooseNewVersion.hs
+++ b/src/Scene/PackageVersion/ChooseNewVersion.hs
@@ -1,0 +1,22 @@
+module Scene.PackageVersion.ChooseNewVersion (chooseNewVersion) where
+
+import Context.App
+import Context.Module qualified as Module
+import Context.Remark (printNote')
+import Control.Monad
+import Entity.PackageVersion qualified as PV
+import Scene.Module.GetExistingVersions
+import Prelude hiding (log)
+
+chooseNewVersion :: App PV.PackageVersion
+chooseNewVersion = do
+  mainModule <- Module.getMainModule
+  existingVersions <- getExistingVersions mainModule
+  newVersion <-
+    case existingVersions of
+      [] -> do
+        return PV.initialVersion
+      v : vs ->
+        return $ PV.increment $ PV.getNewestVersion vs v
+  printNote' $ "Selected a new version: " <> PV.reify newVersion
+  return newVersion


### PR DESCRIPTION
Example:

```sh
❯ ls archive
0-1-0.tar.zst  0-1-1.tar.zst

❯ neut archive
Note: Selected a new version: 0-1-2

❯ ls archive
0-1-0.tar.zst  0-1-1.tar.zst  0-1-2.tar.zst
```