### PR TITLE
allow creating modules using specified target names

### DIFF
--- a/src/Act/Create.hs
+++ b/src/Act/Create.hs
@@ -8,7 +8,7 @@ import Scene.New qualified as New
 
 create :: Config -> App ()
 create cfg = do
-  newModule <- New.constructDefaultModule (moduleName cfg)
+  newModule <- New.constructDefaultModule (moduleName cfg) (targetName cfg)
   Initialize.initializeLogger (remarkCfg cfg)
   Initialize.initializeCompilerWithModule newModule
   New.createNewProject (moduleName cfg) newModule

--- a/src/Context/OptParse.hs
+++ b/src/Context/OptParse.hs
@@ -117,11 +117,20 @@ parseLSPOpt = do
 parseCreateOpt :: Parser Command
 parseCreateOpt = do
   moduleName <- argument str (mconcat [metavar "MODULE", help "The name of the module"])
+  targetName <-
+    optional $
+      strOption $
+        mconcat
+          [ long "target",
+            metavar "TARGET_NAME",
+            help "The name of the target"
+          ]
   remarkCfg <- remarkConfigOpt
   pure $
     Create $
       Create.Config
         { Create.moduleName = T.pack moduleName,
+          Create.targetName = targetName,
           Create.remarkCfg = remarkCfg
         }
 

--- a/src/Entity/Config/Create.hs
+++ b/src/Entity/Config/Create.hs
@@ -5,5 +5,6 @@ import Entity.Config.Remark qualified as Remark
 
 data Config = Config
   { moduleName :: T.Text,
+    targetName :: Maybe T.Text,
     remarkCfg :: Remark.Config
   }


### PR DESCRIPTION
Use `--target` to specify the name of the created target:

```sh
neut create foo --target whatever
# Note: Created a module: foo

cd foo

tree
# ./
# ├── build/
# │  └── ...
# ├── source/
# │  └── whatever.nt ← ⭐
# └── module.ens

cat module.ens
# {
#   target {
#     whatever { ← ⭐
#       main "whatever.nt", ← ⭐
#     },
#   },
#   ...
# }
```