### PR TITLE
report uncovered patterns

### DIFF
--- a/src/Entity/DecisionTree.hs
+++ b/src/Entity/DecisionTree.hs
@@ -43,9 +43,9 @@ instance (Binary a) => Binary (DecisionTree a)
 
 instance (Binary a) => Binary (Case a)
 
-getConstructors :: [Case a] -> [DD.DefiniteDescription]
+getConstructors :: [Case a] -> [(DD.DefiniteDescription, IsConstLike)]
 getConstructors clauseList = do
-  map consDD clauseList
+  map (\c -> (consDD c, isConstLike c)) clauseList
 
 isUnreachable :: DecisionTree a -> Bool
 isUnreachable tree =


### PR DESCRIPTION
```neut
data sample {
| Foo
| Bar(int, int)
| Qux
| Buz(tau)
}

define foo(p: pair(list(int), sample)): unit {
  match p {
  | Pair(Cons(_, _), Foo) =>
    Unit
  | Pair(Nil, Bar(_, _)) =>
    Unit
  }
}
```

↓

(before)

```
/path/to/file.nt:9:3
Error: Encountered a non-exhaustive pattern matching
```

(after)

```
/path/to/file.nt:9:3
Error: This pattern matching does not cover:
       - Pair(Cons(_, _), Bar(_, _))
       - Pair(Cons(_, _), Buz(_))
       - Pair(Cons(_, _), Qux)
```