### PR TITLE
new syntax: `pin x = e1 in e2`

### DIFF
--- a/src/Entity/RawTerm.hs
+++ b/src/Entity/RawTerm.hs
@@ -8,6 +8,7 @@ module Entity.RawTerm
     RawMagic (..),
     KeywordClause,
     EL,
+    MustIgnoreRelayedVars,
     Args,
     RawGeist (..),
     RawDef (..),
@@ -63,6 +64,7 @@ data RawTermF a
   | Noema a
   | Embody a
   | Let LetKind C (Hint, RP.RawPattern, C, C, a) C (SE.Series (Hint, RawIdent)) C a C Loc C a Loc
+  | Pin C (RawBinder a) C C a C Loc C a Loc
   | StaticText a T.Text
   | Rune a T.Text
   | Magic C RawMagic -- (magic kind arg-1 ... arg-n)
@@ -175,8 +177,11 @@ lam loc m varList codType e =
           }
       )
 
+type MustIgnoreRelayedVars =
+  Bool
+
 data LetKind
-  = Plain
+  = Plain MustIgnoreRelayedVars
   | Noetic
   | Try
   | Bind
@@ -184,7 +189,7 @@ data LetKind
 decodeLetKind :: LetKind -> T.Text
 decodeLetKind letKind =
   case letKind of
-    Plain -> "let"
+    Plain _ -> "let"
     Noetic -> "tie"
     Try -> "try"
     Bind -> "bind"

--- a/src/Entity/RawTerm/Decode.hs
+++ b/src/Entity/RawTerm/Decode.hs
@@ -102,6 +102,20 @@ toDoc term =
           D.line,
           attachComment c5 $ toDoc cont
         ]
+    _ :< Pin c1 mxt c2 c3 e1 c4 _ c5 e2 _ -> do
+      D.join
+        [ PI.arrange
+            [ PI.beforeBareSeries $ D.text "pin",
+              PI.bareSeries $ D.join [attachComment c1 $ piIntroArgToDoc mxt, C.asSuffix c2]
+            ],
+          PI.arrange
+            [ PI.beforeBareSeries $ D.text "=",
+              PI.bareSeries $ D.join [attachComment c3 $ toDoc e1, C.asSuffix c4]
+            ],
+          D.text "in",
+          D.line,
+          attachComment c5 $ toDoc e2
+        ]
     _ :< StaticText _ txt -> do
       quoteText txt
     _ :< Rune _ ch -> do

--- a/src/Scene/Parse/RawTerm.hs
+++ b/src/Scene/Parse/RawTerm.hs
@@ -45,6 +45,7 @@ rawExpr = do
   choice
     [ rawTermLet m,
       rawTermUse m,
+      rawTermPin m,
       do
         e1 <- rawTerm
         choice
@@ -172,7 +173,7 @@ rawTermLet :: Hint -> Parser (RT.RawTerm, C)
 rawTermLet mLet = do
   (letKind, c1) <-
     choice
-      [ keyword "let" >>= \c1 -> return (RT.Plain, c1),
+      [ keyword "let" >>= \c1 -> return (RT.Plain False, c1),
         keyword "try" >>= \c1 -> return (RT.Try, c1),
         keyword "bind" >>= \c1 -> return (RT.Bind, c1),
         keyword "tie" >>= \c1 -> return (RT.Noetic, c1)
@@ -195,6 +196,19 @@ rawTermLet mLet = do
   (e2, c) <- rawExpr
   endLoc <- getCurrentLoc
   return (mLet :< RT.Let letKind c1 (mx, patInner, c2, c3, t) c4 noeticVarList c5 e1 c6 loc c7 e2 endLoc, c)
+
+rawTermPin :: Hint -> Parser (RT.RawTerm, C)
+rawTermPin m = do
+  c1 <- keyword "pin"
+  ((mx, x), c2) <- rawTermNoeticVar
+  (c3, (t, c4)) <- rawTermLetVarAscription mx
+  c5 <- delimiter "="
+  (e1, c6) <- rawExpr
+  loc <- getCurrentLoc
+  c7 <- delimiter "in"
+  (e2, c) <- rawExpr
+  endLoc <- getCurrentLoc
+  return (m :< RT.Pin c1 (mx, x, c2, c3, t) c4 c5 e1 c6 loc c7 e2 endLoc, c)
 
 rawTermUse :: Hint -> Parser (RT.RawTerm, C)
 rawTermUse m = do


### PR DESCRIPTION
Syntax:

```
pin x = e1 in
e2
```

Semantics:

```neut
pin x = e1 in
e2

↓

let x = e1 in
let result on x = e2 in
let _ = x in
result
```

Example:

```neut
// before
define foo(): unit {
  let xs = make-list(123) in
  let result on xs = some-func(xs) in
  let _ = xs in
  result
}

↓

// after
define foo(): unit {
  pin xs = make-list(123) in
  some-func(xs)
}
```