### PR TITLE
don't leave escape sequences to haskell

### DIFF
--- a/book/src/terms.md
+++ b/book/src/terms.md
@@ -429,7 +429,9 @@ define foo(): unit {
 
 ### Syntax
 
-`` `A` ``, `` `\n` ``, `` `\1234` ``, etc.
+`` `A` ``, `` `\n` ``, `` `\u{123}` ``, etc.
+
+The available escape sequences in rune literals are the same as those of [text literals](./terms.md#texts).
 
 ### Semantics
 
@@ -482,7 +484,22 @@ define foo(): unit {
 
 ### Syntax
 
-`"hello"`, `"Hello, world!\n"`, etc.
+`"hello"`, `"Hello, world!\n"`, `"\u{1f338} ← Cherry Blossom"`, etc.
+
+Below is the list of all the escape sequences in Neut:
+
+| Escape Sequence | Meaning                        |
+| --------------- | ------------------------------ |
+| `\0`            | U+0000 (null character)        |
+| `\t`            | U+0009 (horizontal tab)        |
+| `\n`            | U+000A (line feed)             |
+| `\r`            | U+000D (carriage return)       |
+| `\"`            | U+0022 (double quotation mark) |
+| `\\`            | U+005C (backslash)             |
+| `` \` ``        | U+0060 (backtick)              |
+| `\u{n}`         | U+n                            |
+
+The `n` in `\u{n}` must be a lowercase hexadecimal number.
 
 ### Semantics
 

--- a/src/Entity/RawTerm/Decode.hs
+++ b/src/Entity/RawTerm/Decode.hs
@@ -117,7 +117,7 @@ toDoc term =
           attachComment c5 $ toDoc e2
         ]
     _ :< StaticText _ txt -> do
-      quoteText txt
+      D.text $ "\"" <> txt <> "\""
     _ :< Rune _ ch -> do
       D.text $ "`" <> T.replace "`" "\\`" ch <> "`"
     _ :< Magic c magic ->
@@ -265,10 +265,6 @@ toDoc term =
         ]
     _ :< Brace c1 (e, c2) -> do
       decodeBrace False c1 e c2
-
-quoteText :: T.Text -> D.Doc
-quoteText txt =
-  D.text $ "\"" <> txt <> "\""
 
 decodeDef :: (a -> D.Doc) -> T.Text -> C -> RawDef a -> D.Doc
 decodeDef nameDecoder keyword c def = do

--- a/src/Scene/Parse/Discern/Text.hs
+++ b/src/Scene/Parse/Discern/Text.hs
@@ -1,0 +1,76 @@
+module Scene.Parse.Discern.Text (parseText) where
+
+import Data.Char
+import Data.List
+import Data.Text qualified as T
+import Numeric (readHex)
+
+isLowerHexDigit :: Char -> Bool
+isLowerHexDigit c =
+  isDigit c || (fromIntegral (ord c - ord 'a') :: Word) <= 5
+
+readUnicodeScalarValueMaybe :: T.Text -> Either T.Text Char
+readUnicodeScalarValueMaybe t =
+  case readHex (T.unpack t) of
+    [(value, _)]
+      | 0 <= value && value <= 0x10FFFF ->
+          return $ chr value
+      | otherwise ->
+          Left $ "The value `" <> t <> "` is outside the Unicode codespace"
+    _ ->
+      Left $ "Could not parse `" <> t <> "` as a hexadecimal integer"
+
+readChar :: Char -> T.Text -> Either T.Text T.Text
+readChar c t = do
+  case T.uncons t of
+    Just (c', rest)
+      | c == c' ->
+          Right rest
+      | otherwise ->
+          Left $ "Expected `" <> T.singleton c <> "`, but got: `" <> T.singleton c' <> "`"
+    Nothing ->
+      Left $ "Expected `" <> T.singleton c <> "`, but got: end of text"
+
+unquoteText :: T.Text -> Either T.Text [T.Text]
+unquoteText t = do
+  case T.uncons t of
+    Nothing ->
+      Right ["\\"]
+    Just (c, rest) -> do
+      case c of
+        '0' ->
+          Right ["\0", rest]
+        't' ->
+          Right ["\t", rest]
+        'n' ->
+          Right ["\n", rest]
+        'r' ->
+          Right ["\r", rest]
+        '`' ->
+          Right ["`", rest]
+        '"' ->
+          Right ["\"", rest]
+        'u' -> do
+          rest' <- readChar '{' rest
+          let (scalarValueText, rest'') = T.span isLowerHexDigit rest'
+          rest''' <- readChar '}' rest''
+          ch <- readUnicodeScalarValueMaybe scalarValueText
+          Right [T.singleton ch, rest''']
+        _ ->
+          Left $ "Unknown escape sequence: \\" <> T.singleton c
+
+parseTextFragment :: T.Text -> Either T.Text [T.Text]
+parseTextFragment t = do
+  case T.splitOn "\\" t of
+    [] ->
+      -- unreachable
+      Left "Got an empty list from `Data.Text.splitOn`"
+    t' : rest -> do
+      fragments <- concat <$> mapM unquoteText rest
+      Right $ t' : fragments
+
+parseText :: T.Text -> Either T.Text T.Text
+parseText t = do
+  let ts = T.splitOn "\\\\" t
+  ts' <- mapM parseTextFragment ts
+  return $ T.concat $ intercalate ["\\"] ts'

--- a/test/term/prim/source/prim.nt
+++ b/test/term/prim/source/prim.nt
@@ -84,7 +84,7 @@ define opaque(a: type, x: a): a {
 define test-string(): unit {
   let _ = opaque(_, "") in
   let _ = opaque(_, "test") in
-  let _ = opaque(_, "🌟あ♥️a🌕亜\n\o33\x333") in
+  let _ = opaque(_, "🌟あ♥️a🌕亜\n\u{33}\u{333}\u{1f338}\0\t\n\r\"\\\`") in
   Unit
 }
 


### PR DESCRIPTION
The available escape sequences:

| Escape Sequence | Meaning                        |
| --------------- | ------------------------------ |
| `\0`            | U+0000 (null character)        |
| `\t`            | U+0009 (horizontal tab)        |
| `\n`            | U+000A (line feed)             |
| `\r`            | U+000D (carriage return)       |
| `\"`            | U+0022 (double quotation mark) |
| `\\`            | U+005C (backslash)             |
| `` \` ``        | U+0060 (backtick)              |
| `\u{n}`         | U+n                            |