### PR TITLE
remove unused items in `import {..}` only when required (for better LSP experience)

### DIFF
--- a/build/package.template.yaml
+++ b/build/package.template.yaml
@@ -14,6 +14,7 @@ default-extensions:
   - StrictData
 
 dependencies:
+  - aeson
   - ansi-terminal
   - async
   - base

--- a/src/Act/Format.hs
+++ b/src/Act/Format.hs
@@ -15,7 +15,7 @@ format cfg = do
   Initialize.initializeForTarget
   path <- resolveFile' $ filePathString cfg
   content <- readTextFile path
-  content' <- Format.format (inputFileType cfg) path content
+  content' <- Format.format (shouldMinimizeImports cfg) (inputFileType cfg) path content
   if mustUpdateInPlace cfg
     then Write.write path content'
     else Parse.printTextFile content'

--- a/src/Context/OptParse.hs
+++ b/src/Context/OptParse.hs
@@ -162,6 +162,7 @@ parseFormatOpt :: FT.FileType -> Parser Command
 parseFormatOpt fileType = do
   inputFilePath <- argument str (mconcat [metavar "INPUT", help "The path of input file"])
   inPlaceOpt <- flag False True (mconcat [long "in-place", help "Set this to perform in-place update"])
+  shouldMinimizeImports <- flag False True (mconcat [long "minimize-imports", help "Set this to remove unused items in `import {..}`"])
   remarkCfg <- remarkConfigOpt
   pure $
     Format $
@@ -169,6 +170,7 @@ parseFormatOpt fileType = do
         { Format.remarkCfg = remarkCfg,
           Format.filePathString = inputFilePath,
           Format.mustUpdateInPlace = inPlaceOpt,
+          Format.shouldMinimizeImports = shouldMinimizeImports,
           Format.inputFileType = fileType
         }
 

--- a/src/Entity/AppLsp.hs
+++ b/src/Entity/AppLsp.hs
@@ -1,6 +1,7 @@
 module Entity.AppLsp (AppLsp, lspOptions) where
 
 import Context.App
+import Entity.CodeAction qualified as CA
 import Language.LSP.Protocol.Types
 import Language.LSP.Server
 
@@ -19,5 +20,6 @@ lspOptions =
               _willSaveWaitUntil = Just False,
               _save = Just $ InR $ SaveOptions {_includeText = Just False}
             },
-      optCompletionTriggerCharacters = Just ['.']
+      optCompletionTriggerCharacters = Just ['.'],
+      optExecuteCommandCommands = Just [CA.minimizeImportsCommandName]
     }

--- a/src/Entity/CodeAction.hs
+++ b/src/Entity/CodeAction.hs
@@ -1,0 +1,26 @@
+module Entity.CodeAction
+  ( minimizeImportsCommandTitle,
+    minimizeImportsCommandName,
+    minimizeImportsCommand,
+  )
+where
+
+import Data.Aeson.Types qualified as A
+import Data.Text qualified as T
+import Language.LSP.Protocol.Types
+
+minimizeImportsCommandTitle :: T.Text
+minimizeImportsCommandTitle =
+  "Minimize imports"
+
+minimizeImportsCommandName :: T.Text
+minimizeImportsCommandName =
+  "minimizeImports"
+
+minimizeImportsCommand :: Uri -> Command
+minimizeImportsCommand uri =
+  Command
+    { _title = minimizeImportsCommandTitle,
+      _command = minimizeImportsCommandName,
+      _arguments = Just [A.String (getUri uri)]
+    }

--- a/src/Entity/Config/Format.hs
+++ b/src/Entity/Config/Format.hs
@@ -7,5 +7,6 @@ data Config = Config
   { remarkCfg :: Remark.Config,
     filePathString :: FilePath,
     mustUpdateInPlace :: Bool,
+    shouldMinimizeImports :: Bool,
     inputFileType :: FT.FileType
   }

--- a/src/Scene/LSP/Util.hs
+++ b/src/Scene/LSP/Util.hs
@@ -2,6 +2,7 @@ module Scene.LSP.Util
   ( liftAppM,
     report,
     maxDiagNum,
+    getUriParam,
   )
 where
 
@@ -10,6 +11,7 @@ import Control.Lens hiding (Iso, List)
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans
+import Data.Aeson.Types qualified as A
 import Data.ByteString qualified as B
 import Data.Function (on)
 import Data.List (sortBy, sortOn)
@@ -120,3 +122,11 @@ levelToSeverity level =
       DiagnosticSeverity_Information
     Fail ->
       DiagnosticSeverity_Error
+
+getUriParam :: [A.Value] -> Maybe Uri
+getUriParam args =
+  case args of
+    [A.String uri] ->
+      Just $ Uri uri
+    _ ->
+      Nothing


### PR DESCRIPTION
## before
  - `neut format-source` tracks all the imported files recursively and remove unused items in `import {..}` automatically
  - `textDocument/formatting` == (format + remove used items in `import {..}`)

## after
  - `neut format-source` simply formats given files
  - `neut format-source --minimize-imports` formats given files and removes unused items in `import {..}`
  - `textDocument/formatting` == (format)
  - Added a new code action for (format + remove used items in `import {..}`)

## benchmark

```sh
# format ← (used by textDocument/formatting)
❯ hyperfine "neut format-source source/neural.nt"
Benchmark 1: neut format-source source/neural.nt
  Time (mean ± σ):      33.6 ms ±   1.3 ms    [User: 14.9 ms, System: 15.8 ms]
  Range (min … max):    30.4 ms …  36.1 ms    82 runs

# format + remove used items in `import {..}` ← (used by textDocument/codeAction)
❯ hyperfine "neut format-source --minimize-imports source/neural.nt"
Benchmark 1: neut format-source --minimize-imports source/neural.nt
  Time (mean ± σ):     135.7 ms ±   7.4 ms    [User: 245.9 ms, System: 74.6 ms]
  Range (min … max):   124.3 ms … 148.8 ms    19 runs
```