### PR TITLE
improve completion-related stuff

### DIFF
--- a/src/Act/Check.hs
+++ b/src/Act/Check.hs
@@ -12,7 +12,10 @@ import Scene.Initialize qualified as Initialize
 check :: Config -> App ()
 check cfg = do
   setup cfg
-  logs <- Check.check
+  logs <-
+    if shouldCheckAllDependencies cfg
+      then Check.checkAll
+      else Check.check
   if shouldInsertPadding cfg
     then Remark.printErrorList logs
     else Remark.printErrorList $ map Remark.deactivatePadding logs

--- a/src/Context/OptParse.hs
+++ b/src/Context/OptParse.hs
@@ -139,11 +139,13 @@ parseVersionOpt =
 parseCheckOpt :: Parser Command
 parseCheckOpt = do
   padOpt <- flag True False (mconcat [long "no-padding", help "Set this to disable padding of the output"])
+  shouldCheckAllDependencies <- flag False True (mconcat [long "full", help "Set this to refresh the caches of all the dependencies"])
   remarkCfg <- remarkConfigOpt
   pure $
     Check $
       Check.Config
         { Check.shouldInsertPadding = padOpt,
+          Check.shouldCheckAllDependencies = shouldCheckAllDependencies,
           Check.remarkCfg = remarkCfg
         }
 

--- a/src/Entity/AppLsp.hs
+++ b/src/Entity/AppLsp.hs
@@ -21,5 +21,9 @@ lspOptions =
               _save = Just $ InR $ SaveOptions {_includeText = Just False}
             },
       optCompletionTriggerCharacters = Just ['.'],
-      optExecuteCommandCommands = Just [CA.minimizeImportsCommandName]
+      optExecuteCommandCommands =
+        Just
+          [ CA.minimizeImportsCommandName,
+            CA.refreshCacheCommandName
+          ]
     }

--- a/src/Entity/CodeAction.hs
+++ b/src/Entity/CodeAction.hs
@@ -2,6 +2,9 @@ module Entity.CodeAction
   ( minimizeImportsCommandTitle,
     minimizeImportsCommandName,
     minimizeImportsCommand,
+    refreshCacheCommandTitle,
+    refreshCacheCommandName,
+    refreshCacheCommand,
   )
 where
 
@@ -23,4 +26,20 @@ minimizeImportsCommand uri =
     { _title = minimizeImportsCommandTitle,
       _command = minimizeImportsCommandName,
       _arguments = Just [A.String (getUri uri)]
+    }
+
+refreshCacheCommandTitle :: T.Text
+refreshCacheCommandTitle =
+  "Refresh completion cache"
+
+refreshCacheCommandName :: T.Text
+refreshCacheCommandName =
+  "refreshCache"
+
+refreshCacheCommand :: Command
+refreshCacheCommand =
+  Command
+    { _title = refreshCacheCommandTitle,
+      _command = refreshCacheCommandName,
+      _arguments = Nothing
     }

--- a/src/Entity/Config/Check.hs
+++ b/src/Entity/Config/Check.hs
@@ -4,5 +4,6 @@ import Entity.Config.Remark qualified as Remark
 
 data Config = Config
   { shouldInsertPadding :: Bool,
+    shouldCheckAllDependencies :: Bool,
     remarkCfg :: Remark.Config
   }

--- a/src/Scene/Check.hs
+++ b/src/Scene/Check.hs
@@ -2,6 +2,7 @@ module Scene.Check
   ( check,
     checkModule,
     checkSingle,
+    checkAll,
   )
 where
 
@@ -16,6 +17,7 @@ import Path
 import Scene.Elaborate qualified as Elaborate
 import Scene.Initialize qualified as Initialize
 import Scene.Load qualified as Load
+import Scene.Module.Reflect (getAllDependencies)
 import Scene.Parse qualified as Parse
 import Scene.Unravel qualified as Unravel
 import UnliftIO.Async
@@ -43,3 +45,10 @@ _check target baseModule = do
     forM_ contentSeq $ \(source, cacheOrContent) -> do
       Initialize.initializeForSource source
       void $ Parse.parse source cacheOrContent >>= Elaborate.elaborate
+
+checkAll :: App [Remark]
+checkAll = do
+  mainModule <- getMainModule
+  deps <- getAllDependencies mainModule
+  forM_ deps $ \(_, m) -> checkModule m
+  checkModule mainModule

--- a/src/Scene/Fetch.hs
+++ b/src/Scene/Fetch.hs
@@ -33,7 +33,6 @@ import Entity.ModuleURL
 import Entity.Syntax.Series (Series (hasOptionalSeparator))
 import Entity.Syntax.Series qualified as SE
 import Path
-import Scene.Check (checkModule)
 import Scene.Ens.Reflect qualified as Ens
 import Scene.Module.Reflect qualified as Module
 import UnliftIO.Async
@@ -93,7 +92,6 @@ insertDependency aliasName url = do
               dependencyDigest = digest,
               dependencyPresetEnabled = False
             }
-    void $ getLibraryModule alias digest >>= checkModule
 
 insertCoreDependency :: App ()
 insertCoreDependency = do
@@ -106,7 +104,6 @@ insertCoreDependency = do
         dependencyDigest = digest,
         dependencyPresetEnabled = True
       }
-  void $ getLibraryModule coreModuleAlias digest >>= checkModule
 
 installIfNecessary :: ModuleAlias -> [ModuleURL] -> MD.ModuleDigest -> App ()
 installIfNecessary alias mirrorList digest = do

--- a/src/Scene/LSP/Complete.hs
+++ b/src/Scene/LSP/Complete.hs
@@ -4,6 +4,7 @@ import Context.Antecedent qualified as Antecedent
 import Context.App
 import Context.AppM
 import Context.Cache qualified as Cache
+import Context.External (getClangDigest)
 import Context.Path qualified as Path
 import Control.Monad
 import Control.Monad.Trans
@@ -41,6 +42,7 @@ complete uri pos = do
   lift registerShiftMap
   pathString <- liftMaybe $ uriToFilePath uri
   currentSource <- lift (Source.reflect pathString) >>= liftMaybe
+  _ <- lift getClangDigest -- cache
   let loc = positionToLoc pos
   lift $ fmap concat $ forConcurrently itemGetterList $ \itemGetter -> itemGetter currentSource loc
 


### PR DESCRIPTION
- added a option: `neut check --full`
  - this checks all the dependencies and the main module to generate completion caches
- added a code action that performs `neut check --full`
- performance fix: cache the clang digest in textDocument/completion 
  - see below

## the effect of the performance fix on `textDocument/completion`

```sh
# before
❯ hyperfine "neut bench-completion"
Benchmark 1: neut bench-completion
  Time (mean ± σ):     215.8 ms ±   8.9 ms    [User: 725.7 ms, System: 680.6 ms]
  Range (min … max):   207.4 ms … 242.3 ms    14 runs

# after
❯ hyperfine "neut bench-completion"
Benchmark 1: neut bench-completion
  Time (mean ± σ):      45.7 ms ±   1.4 ms    [User: 26.2 ms, System: 25.0 ms]
  Range (min … max):    41.8 ms …  48.9 ms    63 runs
```

The subcommand `bench-completion` is only for this performance comparison (not commited to `main`); The internal of the subcommand is essentially as follows:

```hs
benchCompletion :: App ()
benchCompletion = do
  result <- runAppM $ complete (Uri "file:///path/to/some/file.nt") (Position 10 0)
  case result of
    Left es -> do
      printErrorList es
      printNote' "err"
    Right _ ->
      printNote' "pass"
  return ()
```