### PR TITLE
fix: don't suppress the names of resource types when printing terms

### DIFF
--- a/src/Entity/RawTerm.hs
+++ b/src/Entity/RawTerm.hs
@@ -33,6 +33,7 @@ import Entity.Attr.Data qualified as AttrD
 import Entity.Attr.DataIntro qualified as AttrDI
 import Entity.BaseName qualified as BN
 import Entity.C
+import Entity.DefiniteDescription qualified as DD
 import Entity.ExternalName qualified as EN
 import Entity.Hint
 import Entity.HoleID
@@ -78,7 +79,7 @@ data RawTermF a
   | Magic C RawMagic -- (magic kind arg-1 ... arg-n)
   | Hole HoleID
   | Annotation RemarkLevel (Annot.Annotation ()) a
-  | Resource C (a, C) (a, C) -- DD is only for printing
+  | Resource DD.DefiniteDescription C (a, C) (a, C) -- DD is only for printing
   | Use C a C (Args a) C a Loc
   | If (KeywordClause a) [KeywordClause a] (EL a)
   | When (KeywordClause a)

--- a/src/Entity/RawTerm/Decode.hs
+++ b/src/Entity/RawTerm/Decode.hs
@@ -20,6 +20,7 @@ import Data.Text qualified as T
 import Entity.BaseName qualified as BN
 import Entity.C
 import Entity.C.Decode qualified as C
+import Entity.DefiniteDescription qualified as DD
 import Entity.Doc qualified as D
 import Entity.ExternalName qualified as EN
 import Entity.Hint
@@ -246,8 +247,8 @@ toDoc term =
       D.text "_"
     _ :< Annotation {} -> do
       D.text "<annot>"
-    _ :< Resource {} -> do
-      D.text "<resource>"
+    _ :< Resource dd _ _ _ -> do
+      D.text $ DD.localLocator dd
     _ :< Use c1 trope c2 (args, c3) c4 cont _ -> do
       D.join
         [ PI.arrange

--- a/src/Entity/Term.hs
+++ b/src/Entity/Term.hs
@@ -40,7 +40,7 @@ data TermF a
   | Let O.Opacity (BinderF a) a a
   | Prim (P.Prim a)
   | Magic (Magic a)
-  | Resource ID a a
+  | Resource DD.DefiniteDescription ID a a
   deriving (Show, Generic)
 
 instance (Binary a) => Binary (TermF a)

--- a/src/Entity/Term/Chain.hs
+++ b/src/Entity/Term/Chain.hs
@@ -69,7 +69,7 @@ chainOf' tenv term =
       []
     _ :< TM.Magic der ->
       foldMap (chainOf' tenv) der
-    _ :< TM.Resource _ discarder copier -> do
+    _ :< TM.Resource _ _ discarder copier -> do
       let xs1 = chainOf' tenv discarder
       let xs2 = chainOf' tenv copier
       xs1 ++ xs2

--- a/src/Entity/Term/Compress.hs
+++ b/src/Entity/Term/Compress.hs
@@ -66,8 +66,8 @@ compress term =
       () :< TM.Prim (compressPrim prim)
     _ :< TM.Magic der -> do
       () :< TM.Magic (fmap compress der)
-    _ :< TM.Resource resourceID discarder copier -> do
-      () :< TM.Resource resourceID (compress discarder) (compress copier)
+    _ :< TM.Resource dd resourceID discarder copier -> do
+      () :< TM.Resource dd resourceID (compress discarder) (compress copier)
 
 compressBinder :: (Hint, Ident, TM.Term) -> (Hint, Ident, Cofree TM.TermF ())
 compressBinder (m, x, t) =

--- a/src/Entity/Term/Extend.hs
+++ b/src/Entity/Term/Extend.hs
@@ -73,8 +73,8 @@ extend term =
       _m :< TM.Prim (extendPrim prim)
     _ :< TM.Magic der -> do
       _m :< TM.Magic (fmap extend der)
-    _ :< TM.Resource resourceID discarder copier -> do
-      _m :< TM.Resource resourceID (extend discarder) (extend copier)
+    _ :< TM.Resource dd resourceID discarder copier -> do
+      _m :< TM.Resource dd resourceID (extend discarder) (extend copier)
 
 extendBinder :: (Hint, Ident, Cofree TM.TermF ()) -> (Hint, Ident, TM.Term)
 extendBinder (m, x, t) =

--- a/src/Entity/Term/FreeVars.hs
+++ b/src/Entity/Term/FreeVars.hs
@@ -60,7 +60,7 @@ freeVars term =
           S.empty
     _ :< TM.Magic der ->
       foldMap freeVars der
-    _ :< TM.Resource _ discarder copier -> do
+    _ :< TM.Resource _ _ discarder copier -> do
       let xs1 = freeVars discarder
       let xs2 = freeVars copier
       S.union xs1 xs2

--- a/src/Entity/Term/Weaken.hs
+++ b/src/Entity/Term/Weaken.hs
@@ -96,8 +96,8 @@ weaken term =
       m :< WT.Prim (weakenPrim m prim)
     m :< TM.Magic der -> do
       m :< WT.Magic (fmap weaken der)
-    m :< TM.Resource resourceID discarder copier -> do
-      m :< WT.Resource resourceID (weaken discarder) (weaken copier)
+    m :< TM.Resource dd resourceID discarder copier -> do
+      m :< WT.Resource dd resourceID (weaken discarder) (weaken copier)
 
 weakenBinder :: (Hint, Ident, TM.Term) -> (Hint, Ident, WT.WeakTerm)
 weakenBinder (m, x, t) =

--- a/src/Entity/WeakTerm.hs
+++ b/src/Entity/WeakTerm.hs
@@ -47,7 +47,7 @@ data WeakTermF a
   | Magic (Magic a) -- (magic kind arg-1 ... arg-n)
   | Hole HoleID [WeakTerm] -- ?M @ (e1, ..., en)
   | Annotation RemarkLevel (AN.Annotation a) a
-  | Resource Int a a
+  | Resource DD.DefiniteDescription Int a a
   | Use a [BinderF a] a
 
 type SubstWeakTerm =

--- a/src/Entity/WeakTerm/Eq.hs
+++ b/src/Entity/WeakTerm/Eq.hs
@@ -113,8 +113,8 @@ eq (_ :< term1) (_ :< term2)
   | WT.Annotation _ _ e1 <- term1,
     WT.Annotation _ _ e2 <- term2 =
       eq e1 e2
-  | WT.Resource id1 _ _ <- term1,
-    WT.Resource id2 _ _ <- term2 =
+  | WT.Resource _ id1 _ _ <- term1,
+    WT.Resource _ id2 _ _ <- term2 =
       id1 == id2
   | WT.Use trope1 xts1 cont1 <- term1,
     WT.Use trope2 xts2 cont2 <- term2 = do

--- a/src/Entity/WeakTerm/FreeVars.hs
+++ b/src/Entity/WeakTerm/FreeVars.hs
@@ -69,7 +69,7 @@ freeVars term =
         AN.Type t -> do
           let xs2 = freeVars t
           S.union xs1 xs2
-    _ :< WT.Resource _ discarder copier -> do
+    _ :< WT.Resource _ _ discarder copier -> do
       let xs1 = freeVars discarder
       let xs2 = freeVars copier
       S.union xs1 xs2

--- a/src/Entity/WeakTerm/Holes.hs
+++ b/src/Entity/WeakTerm/Holes.hs
@@ -67,7 +67,7 @@ holes term =
         AN.Type t -> do
           let xs2 = holes t
           S.union xs1 xs2
-    _ :< WT.Resource _ discarder copier -> do
+    _ :< WT.Resource _ _ discarder copier -> do
       S.unions $ map holes [discarder, copier]
     _ :< WT.Use e _ cont ->
       S.unions $ map holes [e, cont]

--- a/src/Entity/WeakTerm/ToText.hs
+++ b/src/Entity/WeakTerm/ToText.hs
@@ -111,8 +111,8 @@ toText term =
       "<magic>"
     _ :< WT.Annotation _ _ e ->
       toText e
-    _ :< WT.Resource {} -> do
-      "<resource>"
+    _ :< WT.Resource dd _ _ _ -> do
+      showGlobalVariable dd
     _ :< WT.Use e xts cont -> do
       let xs = map (\(_, x, _) -> x) xts
       let varSeq = inBrace $ T.intercalate "," $ map showVariable xs

--- a/src/Scene/Clarify.hs
+++ b/src/Scene/Clarify.hs
@@ -260,7 +260,7 @@ clarifyTerm tenv term =
               clarifyTerm tenv $ m :< TM.Prim (P.Value (PV.Int (PNS.IntSize 32) (RU.asInt r)))
     _ :< TM.Magic der -> do
       clarifyMagic tenv der
-    m :< TM.Resource resourceID discarder copier -> do
+    m :< TM.Resource _ resourceID discarder copier -> do
       liftedName <- Locator.attachCurrentLocator $ BN.resourceName resourceID
       switchValue <- Gensym.newIdentFromText "switchValue"
       value <- Gensym.newIdentFromText "value"

--- a/src/Scene/Elaborate.hs
+++ b/src/Scene/Elaborate.hs
@@ -340,10 +340,10 @@ elaborate' term =
           let typeRemark = Remark.newRemark m remarkLevel message
           Remark.insertRemark typeRemark
           return e'
-    m :< WT.Resource resourceID discarder copier -> do
+    m :< WT.Resource dd resourceID discarder copier -> do
       discarder' <- elaborate' discarder
       copier' <- elaborate' copier
-      return $ m :< TM.Resource resourceID discarder' copier'
+      return $ m :< TM.Resource dd resourceID discarder' copier'
     m :< WT.Use {} -> do
       Throw.raiseCritical m "Scene.Elaborate.elaborate': found a remaining `use`"
 

--- a/src/Scene/Elaborate/Infer.hs
+++ b/src/Scene/Elaborate/Infer.hs
@@ -369,7 +369,7 @@ infer axis term =
       case annot of
         Annotation.Type _ -> do
           return (m :< WT.Annotation logLevel (Annotation.Type t) e', t)
-    m :< WT.Resource resourceID discarder copier -> do
+    m :< WT.Resource dd resourceID discarder copier -> do
       empty1 <- createNewAxis
       (discarder', td) <- infer empty1 discarder
       empty2 <- createNewAxis
@@ -380,7 +380,7 @@ infer axis term =
       let tCopy = m :< WT.Pi [] [(m, x, intType)] intType
       insConstraintEnv tDiscard td
       insConstraintEnv tCopy tc
-      return (m :< WT.Resource resourceID discarder' copier', m :< WT.Tau)
+      return (m :< WT.Resource dd resourceID discarder' copier', m :< WT.Tau)
     m :< WT.Use e@(mt :< _) xts cont -> do
       (e', t') <- infer axis e
       t'' <- resolveType t'

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -125,7 +125,7 @@ discernStmt mo stmt = do
       let dd = nameLifter name
       registerTopLevelName nameLifter stmt
       t' <- discern (emptyAxis mo 0) $ m :< RT.Tau
-      e' <- discern (emptyAxis mo 0) $ m :< RT.Resource [] (discarder, []) (copier, [])
+      e' <- discern (emptyAxis mo 0) $ m :< RT.Resource dd [] (discarder, []) (copier, [])
       Tag.insertGlobalVar m dd True m
       TopCandidate.insert $ TopCandidate {loc = metaLocation m, dd = dd, kind = Constant}
       return [WeakStmtDefineConst m dd t' e']
@@ -425,11 +425,11 @@ discern axis term =
       case annot of
         AN.Type _ ->
           return $ m :< WT.Annotation remarkLevel (AN.Type (doNotCare m)) e'
-    m :< RT.Resource _ (discarder, _) (copier, _) -> do
+    m :< RT.Resource dd _ (discarder, _) (copier, _) -> do
       resourceID <- Gensym.newCount
       discarder' <- discern axis discarder
       copier' <- discern axis copier
-      return $ m :< WT.Resource resourceID discarder' copier'
+      return $ m :< WT.Resource dd resourceID discarder' copier'
     m :< RT.Use _ e _ xs _ cont endLoc -> do
       e' <- discern axis e
       (xs', axis') <- discernBinder axis (RT.extractArgs xs) endLoc

--- a/src/Scene/Term/Refresh.hs
+++ b/src/Scene/Term/Refresh.hs
@@ -83,10 +83,10 @@ refresh term =
     m :< TM.Magic der -> do
       der' <- traverse refresh der
       return (m :< TM.Magic der')
-    m :< TM.Resource resourceID discarder copier -> do
+    m :< TM.Resource dd resourceID discarder copier -> do
       discarder' <- refresh discarder
       copier' <- refresh copier
-      return $ m :< TM.Resource resourceID discarder' copier'
+      return $ m :< TM.Resource dd resourceID discarder' copier'
 
 refreshBinder ::
   [BinderF TM.Term] ->

--- a/src/Scene/Term/Subst.hs
+++ b/src/Scene/Term/Subst.hs
@@ -104,10 +104,10 @@ subst sub term =
     m :< TM.Magic der -> do
       der' <- traverse (subst sub) der
       return (m :< TM.Magic der')
-    m :< TM.Resource resourceID discarder copier -> do
+    m :< TM.Resource dd resourceID discarder copier -> do
       discarder' <- subst sub discarder
       copier' <- subst sub copier
-      return $ m :< TM.Resource resourceID discarder' copier'
+      return $ m :< TM.Resource dd resourceID discarder' copier'
 
 substBinder ::
   SubstTerm ->

--- a/src/Scene/WeakTerm/Fill.hs
+++ b/src/Scene/WeakTerm/Fill.hs
@@ -119,10 +119,10 @@ fill sub term =
         AN.Type t -> do
           t' <- fill sub t
           return $ m :< WT.Annotation logLevel (AN.Type t') e'
-    m :< WT.Resource resourceID discarder copier -> do
+    m :< WT.Resource dd resourceID discarder copier -> do
       discarder' <- fill sub discarder
       copier' <- fill sub copier
-      return $ m :< WT.Resource resourceID discarder' copier'
+      return $ m :< WT.Resource dd resourceID discarder' copier'
     m :< WT.Use e xts cont -> do
       e' <- fill sub e
       xts' <- fillBinder sub xts

--- a/src/Scene/WeakTerm/Subst.hs
+++ b/src/Scene/WeakTerm/Subst.hs
@@ -121,10 +121,10 @@ subst sub term =
         AN.Type t -> do
           t' <- subst sub t
           return $ m :< WT.Annotation logLevel (AN.Type t') e'
-    m :< WT.Resource resourceID discarder copier -> do
+    m :< WT.Resource dd resourceID discarder copier -> do
       discarder' <- subst sub discarder
       copier' <- subst sub copier
-      return $ m :< WT.Resource resourceID discarder' copier'
+      return $ m :< WT.Resource dd resourceID discarder' copier'
     m :< WT.Use e xts cont -> do
       e' <- subst sub e
       (xts', sub') <- subst' sub xts


### PR DESCRIPTION
This PR replaces `<resource>` with the name of a resource type when printing terms.

---

Consider the following program:

```neut
resource some-type {..}

define make(): some-type {..}

define main(): unit {
  let x: binary = make() in
  Unit
}
```

The output of `neut check` before the fix is:

```sh
Expected:
  <resource>
Found:
  some-type
```

The output of `neut check` after the fix is:

```sh
Expected:
  binary
Found:
  some-type
```