### PR TITLE
avoid abbreviations in `introspect`

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -66,9 +66,12 @@ test-arm64-linux-single target:
 test-arm64-darwin:
     @NEUT={{justfile_directory()}}/bin/neut-arm64-darwin TARGET_ARCH=arm64 CLANG_PATH=${NEUT_ARM64_DARWIN_CLANG_PATH} ./test/test-darwin.sh ./test/term ./test/statement ./test/pfds ./test/misc
 
+test-bench-darwin:
+    @NEUT={{justfile_directory()}}/bin/neut-arm64-darwin PLATFORM=arm64-darwin {{justfile_directory()}}/bench/script/bench-darwin-mini.sh
+
 update-core new-version:
-    @cd ./test/meta && neut get core https://github.com/vekatze/neut-core/raw/main/archive/{{new-version}}.tar.zst
-    @NEW_VERSION={{new-version}} ./test/update-core.sh ./test/statement ./test/term ./test/misc ./test/pfds
+    # @cd ./test/meta && neut get core https://github.com/vekatze/neut-core/raw/main/archive/{{new-version}}.tar.zst
+    @NEW_VERSION={{new-version}} ./test/update-core.sh ./test/meta ./test/statement ./test/term ./test/misc ./test/pfds ./bench/action
 
 release:
     @echo "creating a release: $VERSION"

--- a/bench/action/bubble/module.ens
+++ b/bench/action/bubble/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/bench/action/dictionary/module.ens
+++ b/bench/action/dictionary/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/bench/action/intmap/module.ens
+++ b/bench/action/intmap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/bench/script/bench-darwin-mini.sh
+++ b/bench/script/bench-darwin-mini.sh
@@ -1,0 +1,12 @@
+#!/bin/zsh
+
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+
+for target_dir in $(find "$SCRIPT_DIR/../action" -maxdepth 1 -mindepth 1 -type d | sort); do
+  cd $target_dir
+  echo $target_dir
+  size=$(cat ./test-size.txt)
+  $NEUT clean
+  $NEUT build "$(basename ${target_dir})-nt" --execute $((size / 10))
+  echo ""
+done

--- a/book/src/manual-installation.md
+++ b/book/src/manual-installation.md
@@ -11,8 +11,8 @@ Add the below to your `.bashrc`, `.zshrc`, etc.
 
 ```sh
 # this sets the core module (or "prelude") that is used in `neut create`
-export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst"
-export NEUT_CORE_MODULE_DIGEST="dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc"
+export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst"
+export NEUT_CORE_MODULE_DIGEST="oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M"
 ```
 
 Then, get the compiler:

--- a/book/src/statements.md
+++ b/book/src/statements.md
@@ -465,7 +465,7 @@ Here, the definition of `c-int` is as follows:
 
 ```neut
 constant _c-int: type {
-  introspect arch {
+  introspect architecture {
   | amd64 =>
     int32
   | arm64 =>

--- a/book/src/terms.md
+++ b/book/src/terms.md
@@ -2350,7 +2350,7 @@ You can use `introspect key {..}` to introspect the compiler's configuration.
 
 ```neut
 define arch-dependent-constant(): int {
-  introspect arch {
+  introspect architecture {
   | arm64 =>
     1
   | amd64 =>
@@ -2359,7 +2359,7 @@ define arch-dependent-constant(): int {
 }
 
 define os-dependent-constant(): int {
-  introspect os {
+  introspect operating-system {
   | linux =>
     1
   | default =>

--- a/book/src/terms.md
+++ b/book/src/terms.md
@@ -2383,12 +2383,11 @@ introspect key {
 
 You can use the following configuration `key`s and configuration `value`s:
 
-| Configuration Key | Configuration Value            |
-| ----------------- | ------------------------------ |
-| `platform`        | `{amd64,arm64}-{linux,darwin}` |
-| `arch`            | `amd64` or `arm64`             |
-| `os`              | `linux` or `darwin`            |
-| `build-mode`      | `develop` or `release`         |
+| Configuration Key  | Configuration Value    |
+| ------------------ | ---------------------- |
+| `architecture`     | `amd64` or `arm64`     |
+| `operating-system` | `linux` or `darwin`    |
+| `build-mode`       | `develop` or `release` |
 
 You can also use `default` as a configuration value to represent a fallback case.
 

--- a/book/src/terms.md
+++ b/book/src/terms.md
@@ -2273,7 +2273,7 @@ A "lowtype" is one of the following:
 - `float16`, `float32`, `float64`
 - `pointer`
 
-You can also use `int` and `float` as a lowtype. These are platform-dependent lowtypes. If the target architecture is 64-bit, `int` is interpreted as `int64`.
+You can also use `int` and `float` as a lowtype. These are just syntax sugar for `int64` and `float64`, respectively.
 
 ### Semantics
 

--- a/install.sh
+++ b/install.sh
@@ -142,8 +142,8 @@ printf $BLUE "note: "
 echo "please restart your shell after adding the following environment variables to your shell config:"
 
 echo ""
-echo "export NEUT_CORE_MODULE_URL=\"https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst\""
-echo "export NEUT_CORE_MODULE_DIGEST=\"dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc\""
+echo "export NEUT_CORE_MODULE_URL=\"https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst\""
+echo "export NEUT_CORE_MODULE_DIGEST=\"oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M\""
 
 if command -v apt-get >/dev/null 2>&1; then
   echo "export NEUT_CLANG=$CLANG"

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -702,8 +702,6 @@ getIntrospectiveValue m key = do
   bm <- Env.getBuildMode
   p <- getPlatform (Just m)
   case key of
-    "platform" -> do
-      return $ Platform.reify p
     "architecture" ->
       return $ Arch.reify (Platform.arch p)
     "operating-system" ->

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -704,9 +704,9 @@ getIntrospectiveValue m key = do
   case key of
     "platform" -> do
       return $ Platform.reify p
-    "arch" ->
+    "architecture" ->
       return $ Arch.reify (Platform.arch p)
-    "os" ->
+    "operating-system" ->
       return $ OS.reify (Platform.os p)
     "build-mode" ->
       return $ BM.reify bm

--- a/test/meta/module.ens
+++ b/test/meta/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/adder/module.ens
+++ b/test/misc/adder/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/args/module.ens
+++ b/test/misc/args/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/calc/module.ens
+++ b/test/misc/calc/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/check/module.ens
+++ b/test/misc/check/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/codata-basic/module.ens
+++ b/test/misc/codata-basic/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/complex-cancel/module.ens
+++ b/test/misc/complex-cancel/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/ex-falso/module.ens
+++ b/test/misc/ex-falso/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/fact/module.ens
+++ b/test/misc/fact/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/file/module.ens
+++ b/test/misc/file/module.ens
@@ -13,9 +13,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/fix-and-free-vars/module.ens
+++ b/test/misc/fix-and-free-vars/module.ens
@@ -13,9 +13,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/fold-tails/module.ens
+++ b/test/misc/fold-tails/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/foreign/module.ens
+++ b/test/misc/foreign/module.ens
@@ -20,9 +20,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/hello/module.ens
+++ b/test/misc/hello/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/lambda-list/module.ens
+++ b/test/misc/lambda-list/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/loop-and-resource/module.ens
+++ b/test/misc/loop-and-resource/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/multi-targets/module.ens
+++ b/test/misc/multi-targets/module.ens
@@ -12,9 +12,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/mutable/module.ens
+++ b/test/misc/mutable/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/nat-fact/module.ens
+++ b/test/misc/nat-fact/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/nat-list/module.ens
+++ b/test/misc/nat-list/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/nested-enums/module.ens
+++ b/test/misc/nested-enums/module.ens
@@ -6,9 +6,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/num-literals/module.ens
+++ b/test/misc/num-literals/module.ens
@@ -6,9 +6,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/print-float/module.ens
+++ b/test/misc/print-float/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/static-file/module.ens
+++ b/test/misc/static-file/module.ens
@@ -12,9 +12,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/binary-search-tree/module.ens
+++ b/test/pfds/binary-search-tree/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/binomial-heap/module.ens
+++ b/test/pfds/binomial-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/custom-stack/module.ens
+++ b/test/pfds/custom-stack/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
     },
   },

--- a/test/pfds/finite-map/module.ens
+++ b/test/pfds/finite-map/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/leftist-heap/module.ens
+++ b/test/pfds/leftist-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/naive-queue/module.ens
+++ b/test/pfds/naive-queue/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/pairing-heap/module.ens
+++ b/test/pfds/pairing-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/random-access-list/module.ens
+++ b/test/pfds/random-access-list/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/red-black-tree/module.ens
+++ b/test/pfds/red-black-tree/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/splay-heap/module.ens
+++ b/test/pfds/splay-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/stack/module.ens
+++ b/test/pfds/stack/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
     },
   },

--- a/test/pfds/stream/module.ens
+++ b/test/pfds/stream/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
     },
   },

--- a/test/statement/define/module.ens
+++ b/test/statement/define/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/import-names/module.ens
+++ b/test/statement/import-names/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/resource-basic/module.ens
+++ b/test/statement/resource-basic/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/variant-struct/module.ens
+++ b/test/statement/variant-struct/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/box/module.ens
+++ b/test/term/box/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/flow/module.ens
+++ b/test/term/flow/module.ens
@@ -12,9 +12,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/noema/module.ens
+++ b/test/term/noema/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/pi/module.ens
+++ b/test/term/pi/module.ens
@@ -13,9 +13,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/prim/module.ens
+++ b/test/term/prim/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/rune/module.ens
+++ b/test/term/rune/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/tau/module.ens
+++ b/test/term/tau/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/unary/module.ens
+++ b/test/term/unary/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/var/module.ens
+++ b/test/term/var/module.ens
@@ -12,9 +12,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/variant/module.ens
+++ b/test/term/variant/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/with/module.ens
+++ b/test/term/with/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "dCgsuKr4LkLpOi-oAO4RVoeWEI21htuBYXrIpcoauvc",
+      digest "oG2BshtL5GL_wPIoM0QU_nWeJ8Sm0LHAyt8Nfo2jO0M",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-33.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-34.tar.zst",
       ],
       enable-preset true,
     },


### PR DESCRIPTION
Before:

```neut
constant _c-int: type {
  introspect arch {
  | amd64 =>
    int32
  | arm64 =>
    int32
  }
}

define some-func(): unit {
  introspect os {
  | darwin =>
    foo()
  | linux =>
    bar()
  }
}
```

After:

```neut
constant _c-int: type {
  introspect architecture {
  | amd64 =>
    int32
  | arm64 =>
    int32
  }
}

define some-func(): unit {
  introspect operating-system {
  | darwin =>
    foo()
  | linux =>
    bar()
  }
}
```