### PR TITLE
allow statements like `define foo: t {e}`,  `inline foo<a>: t {e}`, etc.

### DIFF
--- a/bench/action/bubble/module.ens
+++ b/bench/action/bubble/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/bench/action/dictionary/module.ens
+++ b/bench/action/dictionary/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/bench/action/dictionary/source/dictionary-nt.nt
+++ b/bench/action/dictionary/source/dictionary-nt.nt
@@ -8,12 +8,12 @@ import {
   core.text.io {print-int},
 }
 
-constant intdict: Dict.trope(int) {
+inline intdict: Dict.trope(int) {
   Dict.from-ord(core.int.ord.as-ord-N)
 }
 
 define make-big-dict(size: int): dictionary(int, int) {
-  grow(Dict.empty(), size, function (acc, _) {
+  grow(Dict.empty, size, function (acc, _) {
     let key = random-int(1000000) in
     let val = random-int(1000000) in
     intdict::insert(acc, key, val)

--- a/bench/action/intmap/module.ens
+++ b/bench/action/intmap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/bench/action/intmap/source/intmap-nt.nt
+++ b/bench/action/intmap/source/intmap-nt.nt
@@ -9,7 +9,7 @@ import {
 }
 
 define make-big-dict(size: int): intmap(int) {
-  grow(IntMap.empty(), size, function (acc, _) {
+  grow(IntMap.empty, size, function (acc, _) {
     let key = random-int(1000000) in
     let val = random-int(1000000) in
     insert(acc, key, val)

--- a/book/src/statements.md
+++ b/book/src/statements.md
@@ -5,7 +5,6 @@
 - [import](#import)
 - [define](#define)
 - [inline](#inline)
-- [constant](#constant)
 - [data](#data)
 - [resource](#resource)
 - [nominal](#nominal)
@@ -155,6 +154,49 @@ define use-func-with-implicit-arg(): int {
 }
 ```
 
+You can also use `define` without any explicit arguments:
+
+```neut
+define foo: int {
+  10
+}
+
+define empty-list<a>: list(a) {
+  Nil
+}
+
+define use-constants(): list(int) {
+  let x = foo in
+  empty-list
+}
+```
+
+The above code is translated into the following during compile time:
+
+```neut
+define foo(): int {
+  10
+}
+
+define empty-list<a>(): list(a) {
+  Nil
+}
+
+define use-constants(): list(int) {
+  let x = foo() in
+  empty-list()
+}
+```
+
+The compiler tries to reduce the body of a `define` into a value at compile time if the `define` doesn't have any explicit arguments. The compiler reports an error if it can't get a value. For example, the following should result in an error:
+
+```neut
+define bar: int {
+  print("hello");
+  123
+}
+```
+
 A function with the same name can't be defined in the same file.
 
 All the tail-recursions in Neut are optimized into loops (thanks to geniuses in the LLVM team).
@@ -209,39 +251,46 @@ define use-inline-foo(): int {
 }
 ```
 
-## `constant`
-
-`constant` defines a constant. It should look like the following:
+You can also use `inline` without any explicit arguments:
 
 ```neut
-constant some-number: int {
-  123
+inline foo: int {
+  10
+}
+
+inline empty-list<a>: list(a) {
+  Nil
+}
+
+define use-constants(): list(int) {
+  let x = foo in
+  empty-list
 }
 ```
 
-The compiler tries to reduce the body of a constant at compile time. The compiler reports an error if it can't reduce the body into a value. For example, the following should raise an error:
+The above code is translated into the following during compile time:
 
 ```neut
-constant some-number: int {
+inline foo(): int {
+  10
+}
+
+inline empty-list<a>(): list(a) {
+  Nil
+}
+
+define use-constants(): list(int) {
+  let x = foo() in
+  empty-list()
+}
+```
+
+The compiler tries to reduce the body of an `inline` into a value at compile time if the `inline` doesn't have any explicit arguments. The compiler reports an error if it can't get a value. For example, the following should result in an error:
+
+```neut
+inline bar: int {
   print("hello");
   123
-}
-```
-
-The compiler can't reduce `print("hello"); 123` into a value, so it raises an error.
-
-You can use constants just like ordinary variables:
-
-```neut
-// define a constant
-constant some-number: int {
-  123
-}
-
-define use-constant(): int {
-  // ... and use it
-  print-int(some-number);
-  456
 }
 ```
 
@@ -463,7 +512,7 @@ foreign {
 Here, the definition of `c-int` is as follows:
 
 ```neut
-constant _c-int: type {
+inline _c-int: type {
   introspect architecture {
   | amd64 =>
     int32

--- a/src/Entity/RawProgram.hs
+++ b/src/Entity/RawProgram.hs
@@ -37,8 +37,10 @@ data RawStmt
       C
       Hint
       (BN.BaseName, C)
+      (RT.Args RT.RawTerm)
       (C, (RT.RawTerm, C))
       (C, (RT.RawTerm, C))
+      Loc
   | RawStmtDefineData
       C
       Hint

--- a/src/Entity/RawProgram.hs
+++ b/src/Entity/RawProgram.hs
@@ -33,14 +33,6 @@ data RawStmt
       C
       (SK.RawStmtKind BN.BaseName)
       RT.TopDef
-  | RawStmtDefineConst
-      C
-      Hint
-      (BN.BaseName, C)
-      (RT.Args RT.RawTerm)
-      (C, (RT.RawTerm, C))
-      (C, (RT.RawTerm, C))
-      Loc
   | RawStmtDefineData
       C
       Hint

--- a/src/Entity/RawProgram/Decode.hs
+++ b/src/Entity/RawProgram/Decode.hs
@@ -187,12 +187,13 @@ decStmt stmt =
           RT.decodeDef (RT.nameToDoc . N.Var) "inline" c (fmap BN.reify def)
         _ ->
           RT.decodeDef (RT.nameToDoc . N.Var) "define" c (fmap BN.reify def)
-    RawStmtDefineConst c1 _ (name, c2) cod body -> do
+    RawStmtDefineConst c1 _ (name, c2) impArgs cod body _ -> do
       let constClause = RT.mapKeywordClause RT.toDoc (cod, body)
       RT.attachComment (c1 ++ c2) $
         D.join
           [ D.text "constant ",
             D.text (BN.reify name),
+            RT.decodeArgs' impArgs,
             RT.decodeKeywordClause ":" constClause
           ]
     RawStmtDefineData c1 _ (dataName, c2) argsOrNone consInfo _ -> do

--- a/src/Entity/RawProgram/Decode.hs
+++ b/src/Entity/RawProgram/Decode.hs
@@ -187,15 +187,6 @@ decStmt stmt =
           RT.decodeDef (RT.nameToDoc . N.Var) "inline" c (fmap BN.reify def)
         _ ->
           RT.decodeDef (RT.nameToDoc . N.Var) "define" c (fmap BN.reify def)
-    RawStmtDefineConst c1 _ (name, c2) impArgs cod body _ -> do
-      let constClause = RT.mapKeywordClause RT.toDoc (cod, body)
-      RT.attachComment (c1 ++ c2) $
-        D.join
-          [ D.text "constant ",
-            D.text (BN.reify name),
-            RT.decodeArgs' impArgs,
-            RT.decodeKeywordClause ":" constClause
-          ]
     RawStmtDefineData c1 _ (dataName, c2) argsOrNone consInfo _ -> do
       RT.attachComment (c1 ++ c2) $
         D.join

--- a/src/Entity/RawTerm.hs
+++ b/src/Entity/RawTerm.hs
@@ -218,6 +218,7 @@ data RawMagic
   | Alloca C (EL RawTerm) (EL RawTerm) (Maybe C)
   | External C EN.ExternalName C (SE.Series RawTerm) (Maybe (C, SE.Series VarArg))
   | Global C (EL EN.ExternalName) (EL RawTerm) (Maybe C)
+  | OpaqueValue C (EL RawTerm)
 
 -- elem
 type EL a =

--- a/src/Entity/RawTerm/Decode.hs
+++ b/src/Entity/RawTerm/Decode.hs
@@ -243,6 +243,11 @@ toDoc term =
                       RT.mapEL toDoc t
                     ]
             ]
+        OpaqueValue c1 (c2, (e, c3)) -> do
+          D.join
+            [ attachComment (c ++ c1) $ D.text "magic opaque-value ",
+              decodeBrace True c2 e c3
+            ]
     _ :< Hole {} ->
       D.text "_"
     _ :< Annotation {} -> do

--- a/src/Entity/RawTerm/Decode.hs
+++ b/src/Entity/RawTerm/Decode.hs
@@ -52,7 +52,7 @@ toDoc term =
       nameToDoc varOrLocator
     _ :< Pi (impArgs, c1) (expArgs, c2) c cod _ -> do
       PI.arrange
-        [ PI.container $ SE.decode $ fmap piIntroArgToDoc impArgs,
+        [ PI.container $ decodeImpParams impArgs,
           PI.container $ attachComment c1 $ SE.decode $ fmap piArgToDoc expArgs,
           PI.delimiter $ attachComment c2 $ D.text "->",
           PI.inject $ attachComment c $ toDoc cod

--- a/src/Entity/Stmt.hs
+++ b/src/Entity/Stmt.hs
@@ -49,7 +49,6 @@ data WeakStmt
       [BinderF WT.WeakTerm]
       WT.WeakTerm
       WT.WeakTerm
-  | WeakStmtDefineConst Hint DD.DefiniteDescription WT.WeakTerm WT.WeakTerm
   | WeakStmtNominal Hint [G.Geist WT.WeakTerm]
   | WeakStmtForeign [F.WeakForeign]
 
@@ -66,7 +65,6 @@ data StmtF a
       [BinderF a]
       a
       a
-  | StmtDefineConst SavedHint DD.DefiniteDescription a a
   | StmtForeign [F.Foreign]
   deriving (Generic)
 
@@ -90,10 +88,6 @@ compress stmt =
       let codType' = TM.compress codType
       let e' = TM.compress e
       StmtDefine isConstLike stmtKind' m functionName impArgs' expArgs' codType' e'
-    StmtDefineConst m dd t e -> do
-      let t' = TM.compress t
-      let e' = TM.compress e
-      StmtDefineConst m dd t' e'
     StmtForeign foreignList ->
       StmtForeign foreignList
 
@@ -107,10 +101,6 @@ extend stmt =
       let codType' = TM.extend codType
       let e' = TM.extend e
       StmtDefine isConstLike stmtKind' m functionName impArgs' expArgs' codType' e'
-    StmtDefineConst m dd t e -> do
-      let t' = TM.extend t
-      let e' = TM.extend e
-      StmtDefineConst m dd t' e'
     StmtForeign foreignList ->
       StmtForeign foreignList
 
@@ -123,8 +113,6 @@ getStmtName' stmt =
   case stmt of
     StmtDefine _ _ (SavedHint m) name _ _ _ _ ->
       return (m, name)
-    StmtDefineConst (SavedHint m) name _ _ ->
-      return (m, name)
     StmtForeign _ ->
       Nothing
 
@@ -136,8 +124,6 @@ getWeakStmtName' :: WeakStmt -> [(Hint, DD.DefiniteDescription)]
 getWeakStmtName' stmt =
   case stmt of
     WeakStmtDefine _ _ m name _ _ _ _ ->
-      [(m, name)]
-    WeakStmtDefineConst m name _ _ ->
       [(m, name)]
     WeakStmtNominal {} ->
       []

--- a/src/Entity/Syntax/Series/Decode.hs
+++ b/src/Entity/Syntax/Series/Decode.hs
@@ -29,8 +29,6 @@ _decode forceVertical series = do
         [ PI.inject prefix',
           PI.inject $ PI.arrange $ intercalate sep (elems series) isVertical (trailingComment series)
         ]
-    (Just Angle, True) ->
-      D.Nil
     (Just k, _) -> do
       let (open, close) = getContainerPair k
       let isVertical = forceVertical || hasOptionalSeparator series

--- a/src/Entity/Term.hs
+++ b/src/Entity/Term.hs
@@ -89,6 +89,8 @@ isValue term =
       True
     _ :< Void ->
       True
+    _ :< Magic (OpaqueValue _) ->
+      True
     _ ->
       False
 

--- a/src/Entity/Term/Weaken.hs
+++ b/src/Entity/Term/Weaken.hs
@@ -38,10 +38,6 @@ weakenStmt stmt = do
       let codType' = weaken codType
       let e' = weaken e
       WeakStmtDefine isConstLike stmtKind' m name impArgs' expArgs' codType' e'
-    StmtDefineConst (SavedHint m) dd t v -> do
-      let t' = weaken t
-      let v' = weaken v
-      WeakStmtDefineConst m dd t' v'
     StmtForeign foreignList ->
       WeakStmtForeign $ map weakenForeign foreignList
 

--- a/src/Entity/Term/Weaken.hs
+++ b/src/Entity/Term/Weaken.hs
@@ -120,6 +120,8 @@ weakenMagic m magic = do
       M.WeakMagic $ M.External domList' cod' extFunName (fmap weaken args) varArgs'
     M.Global name t ->
       M.WeakMagic $ M.Global name (WT.fromBaseLowType m t)
+    M.OpaqueValue e ->
+      M.WeakMagic $ M.OpaqueValue (weaken e)
 
 weakenBinder :: (Hint, Ident, TM.Term) -> (Hint, Ident, WT.WeakTerm)
 weakenBinder (m, x, t) =

--- a/src/Entity/WeakTerm/Eq.hs
+++ b/src/Entity/WeakTerm/Eq.hs
@@ -259,6 +259,9 @@ eqM (M.WeakMagic m1) (M.WeakMagic m2)
       let b1 = name1 == name2
       let b2 = eq t1 t2
       b1 && b2
+  | M.OpaqueValue e1 <- m1,
+    M.OpaqueValue e2 <- m2 = do
+      eq e1 e2
   | otherwise =
       False
 

--- a/src/Scene/Clarify.hs
+++ b/src/Scene/Clarify.hs
@@ -480,6 +480,8 @@ clarifyMagic tenv der =
           C.Primitive (C.Magic (M.External domList cod extFunName xsAsVars (zip ysAsVarArgs varTypes)))
     M.Global name lt -> do
       return $ C.Primitive (C.Magic (M.Global name lt))
+    M.OpaqueValue e ->
+      clarifyTerm tenv e
 
 clarifyLambda ::
   TM.TypeEnv ->

--- a/src/Scene/Clarify.hs
+++ b/src/Scene/Clarify.hs
@@ -49,7 +49,6 @@ import Entity.PrimValue qualified as PV
 import Entity.Rune qualified as RU
 import Entity.Stmt
 import Entity.StmtKind
-import Entity.StmtKind qualified as SK
 import Entity.Term qualified as TM
 import Entity.Term.Chain (nubFreeVariables)
 import Entity.Term.Chain qualified as TM
@@ -133,8 +132,6 @@ clarifyStmt stmt =
         _ -> do
           e' <- clarifyStmtDefineBody tenv xts' e
           return $ C.Def f (toLowOpacity stmtKind) (map fst xts') e'
-    StmtDefineConst m dd t' v' ->
-      clarifyStmt $ StmtDefine True (SK.Normal O.Clear) m dd [] [] t' v'
     StmtForeign foreignList ->
       return $ C.Foreign foreignList
 

--- a/src/Scene/Clarify/Linearize.hs
+++ b/src/Scene/Clarify/Linearize.hs
@@ -143,3 +143,6 @@ distinguishPrimitive z term =
           return (concat vss ++ concat vss2, C.Magic (M.External domList cod extFunName args' (zip varArgs' varTypes)))
         M.Global name lt -> do
           return ([], C.Magic (M.Global name lt))
+        M.OpaqueValue e -> do
+          (vs, e') <- distinguishValue z e
+          return (vs, C.Magic (M.OpaqueValue e'))

--- a/src/Scene/Elaborate.hs
+++ b/src/Scene/Elaborate.hs
@@ -356,6 +356,9 @@ elaborate' term =
         M.Global name t -> do
           t' <- strictify t
           return $ m :< TM.Magic (M.Global name t')
+        M.OpaqueValue e -> do
+          e' <- elaborate' e
+          return $ m :< TM.Magic (M.OpaqueValue e')
     m :< WT.Annotation remarkLevel annot e -> do
       e' <- elaborate' e
       case annot of

--- a/src/Scene/Elaborate.hs
+++ b/src/Scene/Elaborate.hs
@@ -137,6 +137,9 @@ elaborateStmt stmt = do
       remarks2 <- ensureAffinity v'
       t'' <- TM.inline m t'
       v'' <- TM.inline m v'
+      unless (TM.isValue v'') $ do
+        Throw.raiseError m $
+          "Could not reduce this term into a constant, but got:\n" <> toText (weaken v'')
       let result = StmtDefineConst (SavedHint m) dd t'' v''
       insertStmt result
       return ([result], remarks1 ++ remarks2)

--- a/src/Scene/Elaborate.hs
+++ b/src/Scene/Elaborate.hs
@@ -127,6 +127,10 @@ elaborateStmt stmt = do
       remarks <- ensureAffinity $ m :< TM.PiIntro dummyAttr impArgs' expArgs' e'
       e'' <- TM.inline m e'
       codType'' <- TM.inline m codType'
+      when isConstLike $ do
+        unless (TM.isValue e'') $ do
+          Throw.raiseError m $
+            "Could not reduce the body of this definition into a constant, but got:\n" <> toText (weaken e'')
       let result = StmtDefine isConstLike stmtKind' (SavedHint m) x impArgs' expArgs' codType'' e''
       insertStmt result
       return ([result], remarks)

--- a/src/Scene/Elaborate.hs
+++ b/src/Scene/Elaborate.hs
@@ -43,7 +43,6 @@ import Entity.Ident.Reify qualified as Ident
 import Entity.IsConstLike (IsConstLike)
 import Entity.LamKind qualified as LK
 import Entity.Magic qualified as M
-import Entity.Opacity qualified as O
 import Entity.Prim qualified as P
 import Entity.PrimNumSize
 import Entity.PrimType qualified as PT
@@ -134,19 +133,6 @@ elaborateStmt stmt = do
       let result = StmtDefine isConstLike stmtKind' (SavedHint m) x impArgs' expArgs' codType'' e''
       insertStmt result
       return ([result], remarks)
-    WeakStmtDefineConst m dd t v -> do
-      t' <- elaborate' t
-      v' <- elaborate' v
-      remarks1 <- ensureAffinity t'
-      remarks2 <- ensureAffinity v'
-      t'' <- TM.inline m t'
-      v'' <- TM.inline m v'
-      unless (TM.isValue v'') $ do
-        Throw.raiseError m $
-          "Could not reduce this term into a constant, but got:\n" <> toText (weaken v'')
-      let result = StmtDefineConst (SavedHint m) dd t'' v''
-      insertStmt result
-      return ([result], remarks1 ++ remarks2)
     WeakStmtNominal _ geistList -> do
       mapM_ elaborateGeist geistList
       return ([], [])
@@ -170,9 +156,6 @@ insertStmt stmt = do
     StmtDefine _ stmtKind (SavedHint m) f impArgs expArgs t e -> do
       Type.insert f $ weaken $ m :< TM.Pi impArgs expArgs t
       Definition.insert (toOpacity stmtKind) f (impArgs ++ expArgs) e
-    StmtDefineConst (SavedHint m) dd t v -> do
-      Type.insert dd $ weaken $ m :< TM.Pi [] [] t
-      Definition.insert O.Clear dd [] v
     StmtForeign foreignList -> do
       forM_ foreignList $ \(F.Foreign m externalName domList cod) -> do
         activateForeign $ F.Foreign m externalName domList cod
@@ -184,8 +167,6 @@ insertWeakStmt stmt = do
   case stmt of
     WeakStmtDefine _ stmtKind m f impArgs expArgs codType e -> do
       WeakDefinition.insert (toOpacity stmtKind) m f impArgs expArgs codType e
-    WeakStmtDefineConst m dd codType v -> do
-      WeakDefinition.insert O.Clear m dd [] [] codType v
     WeakStmtNominal {} -> do
       return ()
     WeakStmtForeign foreignList ->
@@ -205,8 +186,6 @@ insertStmtKindInfo stmt = do
           DataDefinition.insert dataName dataArgs consInfoList
         DataIntro {} ->
           return ()
-    StmtDefineConst {} ->
-      return ()
     StmtForeign {} ->
       return ()
 

--- a/src/Scene/Elaborate/EnsureAffinity.hs
+++ b/src/Scene/Elaborate/EnsureAffinity.hs
@@ -210,6 +210,8 @@ analyze axis term = do
           concat <$> mapM (analyze axis) args
         M.Global _ _ ->
           return []
+        M.OpaqueValue e ->
+          analyze axis e
     _ :< TM.Resource _ _ unitType discarder copier -> do
       cs1 <- analyze axis unitType
       cs2 <- analyze axis discarder

--- a/src/Scene/Elaborate/Infer.hs
+++ b/src/Scene/Elaborate/Infer.hs
@@ -81,14 +81,6 @@ inferStmt stmt =
         unitType <- getUnitType _m
         insConstraintEnv (m :< WT.Pi [] [] unitType) (m :< WT.Pi impArgs' expArgs' codType')
       return $ WeakStmtDefine isConstLike stmtKind' m x impArgs' expArgs' codType' e'
-    WeakStmtDefineConst m dd t v -> do
-      axis1 <- createNewAxis
-      t' <- inferType axis1 t
-      insertType dd $ m :< WT.Pi [] [] t'
-      axis2 <- createNewAxis
-      (v', tv) <- infer axis2 v
-      insConstraintEnv t' tv
-      return $ WeakStmtDefineConst m dd t' v'
     WeakStmtNominal m geistList -> do
       geistList' <- mapM inferGeist geistList
       return $ WeakStmtNominal m geistList'

--- a/src/Scene/Elaborate/Infer.hs
+++ b/src/Scene/Elaborate/Infer.hs
@@ -346,6 +346,9 @@ infer axis term =
         M.Global name t -> do
           t' <- inferType axis t
           return (m :< WT.Magic (M.WeakMagic $ M.Global name t'), t')
+        M.OpaqueValue e -> do
+          (e', t) <- infer axis e
+          return (m :< WT.Magic (M.WeakMagic $ M.OpaqueValue e'), t)
     m :< WT.Annotation logLevel annot e -> do
       (e', t) <- infer axis e
       case annot of

--- a/src/Scene/Lower.hs
+++ b/src/Scene/Lower.hs
@@ -269,6 +269,8 @@ lowerCompPrimitive codeOp =
         M.Global name t -> do
           let t' = LT.fromBaseLowType t
           uncast (LC.VarExternal name) t'
+        M.OpaqueValue e ->
+          lowerValue e
 
 lowerCompPrimOp :: PrimOp -> [C.Value] -> Lower LC.Value
 lowerCompPrimOp op vs = do

--- a/src/Scene/Parse.hs
+++ b/src/Scene/Parse.hs
@@ -21,11 +21,9 @@ import Entity.Cache qualified as Cache
 import Entity.DefiniteDescription qualified as DD
 import Entity.Hint
 import Entity.Ident.Reify
-import Entity.Opacity qualified as O
 import Entity.RawProgram
 import Entity.Source qualified as Source
 import Entity.Stmt
-import Entity.StmtKind qualified as SK
 import Scene.Parse.Core qualified as P
 import Scene.Parse.Discern qualified as Discern
 import Scene.Parse.Import
@@ -59,8 +57,6 @@ parseCachedStmtList stmtList = do
         let expArgNames = map (\(_, x, _) -> toText x) expArgs
         let allArgNum = AN.fromInt $ length $ impArgs ++ expArgs
         Global.registerStmtDefine isConstLike m stmtKind name allArgNum expArgNames
-      StmtDefineConst (SavedHint m) dd _ _ ->
-        Global.registerStmtDefine True m (SK.Normal O.Clear) dd AN.zero []
       StmtForeign {} ->
         return ()
 

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -625,6 +625,9 @@ discernMagic axis m magic =
     RT.Global _ (_, (name, _)) (_, (t, _)) _ -> do
       t' <- discern axis t
       return $ M.WeakMagic $ M.Global name t'
+    RT.OpaqueValue _ (_, (e, _)) -> do
+      e' <- discern axis e
+      return $ M.WeakMagic $ M.OpaqueValue e'
 
 modifyLetContinuation :: (Hint, RP.RawPattern) -> Loc -> N.IsNoetic -> RT.RawTerm -> App (RawIdent, RT.RawTerm)
 modifyLetContinuation pat endLoc isNoetic cont@(mCont :< _) =

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -107,15 +107,6 @@ discernStmt mo stmt = do
       TopCandidate.insert $ TopCandidate {loc = metaLocation m, dd = functionName, kind = toCandidateKind stmtKind'}
       forM_ expArgs' Tag.insertBinder
       return [WeakStmtDefine isConstLike stmtKind' m functionName impArgs' expArgs' codType' body']
-    RawStmtDefineConst _ m (name, _) impArgs (_, (t, _)) (_, (v, _)) endLoc -> do
-      let dd = nameLifter name
-      registerTopLevelName nameLifter stmt
-      (impArgs', nenv) <- discernBinder (emptyAxis mo 0) (RT.extractArgs impArgs) endLoc
-      t' <- discern nenv t
-      v' <- discern nenv v
-      Tag.insertGlobalVar m dd True m
-      TopCandidate.insert $ TopCandidate {loc = metaLocation m, dd = dd, kind = Constant}
-      return [WeakStmtDefine True (SK.Normal O.Clear) m dd impArgs' [] t' v']
     RawStmtDefineData _ m (dd, _) args consInfo loc -> do
       stmtList <- defineData m dd args (SE.extract consInfo) loc
       discernStmtList mo stmtList
@@ -174,9 +165,6 @@ registerTopLevelName nameLifter stmt =
       let expArgNames = map (\(_, x, _, _, _) -> x) expArgs
       stmtKind' <- liftStmtKind stmtKind
       Global.registerStmtDefine isConstLike m stmtKind' functionName allArgNum expArgNames
-    RawStmtDefineConst _ m (name, _) impArgs _ _ _ -> do
-      let allArgNum = AN.fromInt $ length impArgs
-      Global.registerStmtDefine True m (SK.Normal O.Clear) (nameLifter name) allArgNum []
     RawStmtNominal {} -> do
       return ()
     RawStmtDefineData _ m (dd, _) args consInfo loc -> do

--- a/src/Scene/Parse/Program.hs
+++ b/src/Scene/Parse/Program.hs
@@ -61,7 +61,6 @@ parseStmt = do
     [ parseDefine,
       parseData,
       parseInline,
-      parseConstant,
       parseNominal,
       parseResource,
       parseForeign
@@ -198,14 +197,3 @@ parseResource = do
       return (RawStmtDefineResource c1 m (name, c2) discarder copier (SE.trailingComment handlers), c)
     _ ->
       failure Nothing (S.fromList [asLabel "discarder and copier"])
-
-parseConstant :: P.Parser (RawStmt, C)
-parseConstant = do
-  c1 <- P.keyword "constant"
-  m <- P.getCurrentHint
-  (constName, c2) <- P.baseName
-  impArgs <- parseImplicitArgs
-  t <- parseDefInfoCod m
-  (c3, (v, c4)) <- P.betweenBrace rawExpr
-  endLoc <- P.getCurrentLoc
-  return (RawStmtDefineConst c1 m (constName, c2) impArgs t (c3, v) endLoc, c4)

--- a/src/Scene/Parse/Program.hs
+++ b/src/Scene/Parse/Program.hs
@@ -204,6 +204,8 @@ parseConstant = do
   c1 <- P.keyword "constant"
   m <- P.getCurrentHint
   (constName, c2) <- P.baseName
+  impArgs <- parseImplicitArgs
   t <- parseDefInfoCod m
   (c3, (v, c4)) <- P.betweenBrace rawExpr
-  return (RawStmtDefineConst c1 m (constName, c2) t (c3, v), c4)
+  endLoc <- P.getCurrentLoc
+  return (RawStmtDefineConst c1 m (constName, c2) impArgs t (c3, v) endLoc, c4)

--- a/src/Scene/Parse/RawTerm.hs
+++ b/src/Scene/Parse/RawTerm.hs
@@ -337,19 +337,16 @@ parseDef :: Parser (a, C) -> Parser (RT.RawDef a, C)
 parseDef nameParser = do
   (geist, c1) <- parseGeist nameParser
   (c2, ((e, c3), loc, c)) <- betweenBrace' rawExpr
-  if RT.isConstLike geist
-    then lift $ Throw.raiseError (RT.loc geist) "The argument list is missing"
-    else
-      return
-        ( RT.RawDef
-            { geist,
-              leadingComment = c1 ++ c2,
-              body = e,
-              trailingComment = c3,
-              endLoc = loc
-            },
-          c
-        )
+  return
+    ( RT.RawDef
+        { geist,
+          leadingComment = c1 ++ c2,
+          body = e,
+          trailingComment = c3,
+          endLoc = loc
+        },
+      c
+    )
 
 parseGeist :: Parser (a, C) -> Parser (RT.RawGeist a, C)
 parseGeist nameParser = do

--- a/src/Scene/Parse/RawTerm.hs
+++ b/src/Scene/Parse/RawTerm.hs
@@ -428,6 +428,7 @@ rawTermMagic = do
       rawTermMagicLoad m c,
       rawTermMagicAlloca m c,
       rawTermMagicExternal m c,
+      rawTermMagicOpaqueValue m c,
       rawTermMagicGlobal m c
     ]
 
@@ -506,6 +507,12 @@ rawTermMagicGlobal m c = do
     lt <- rawExpr
     c5 <- optional $ delimiter ","
     return $ \c1 c2 -> m :< RT.Magic c (RT.Global c1 (c2, (EN.ExternalName globalVarName, c3)) (c4, lt) c5)
+
+rawTermMagicOpaqueValue :: Hint -> C -> Parser (RT.RawTerm, C)
+rawTermMagicOpaqueValue m c0 = do
+  c1 <- keyword "opaque-value"
+  (c2, (e, c)) <- betweenBrace rawExpr
+  return (m :< RT.Magic c0 (RT.OpaqueValue c1 (c2, e)), c)
 
 rawTermMatch :: Parser (RT.RawTerm, C)
 rawTermMatch = do

--- a/src/Scene/Parse/RawTerm.hs
+++ b/src/Scene/Parse/RawTerm.hs
@@ -8,6 +8,7 @@ module Scene.Parse.RawTerm
     parseGeist,
     parseDefInfoCod,
     typeWithoutIdent,
+    parseImplicitArgs,
   )
 where
 

--- a/test/misc/adder/module.ens
+++ b/test/misc/adder/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/args/module.ens
+++ b/test/misc/args/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/calc/module.ens
+++ b/test/misc/calc/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/check/module.ens
+++ b/test/misc/check/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/codata-basic/module.ens
+++ b/test/misc/codata-basic/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/complex-cancel/module.ens
+++ b/test/misc/complex-cancel/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/ex-falso/module.ens
+++ b/test/misc/ex-falso/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/fact/module.ens
+++ b/test/misc/fact/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/file/module.ens
+++ b/test/misc/file/module.ens
@@ -13,9 +13,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/fix-and-free-vars/module.ens
+++ b/test/misc/fix-and-free-vars/module.ens
@@ -13,9 +13,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/fold-tails/module.ens
+++ b/test/misc/fold-tails/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/foreign/module.ens
+++ b/test/misc/foreign/module.ens
@@ -20,9 +20,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/hello/module.ens
+++ b/test/misc/hello/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/lambda-list/module.ens
+++ b/test/misc/lambda-list/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/loop-and-resource/module.ens
+++ b/test/misc/loop-and-resource/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/multi-targets/module.ens
+++ b/test/misc/multi-targets/module.ens
@@ -12,9 +12,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/mutable/module.ens
+++ b/test/misc/mutable/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/nat-fact/module.ens
+++ b/test/misc/nat-fact/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/nat-list/module.ens
+++ b/test/misc/nat-list/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/nested-enums/module.ens
+++ b/test/misc/nested-enums/module.ens
@@ -6,9 +6,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/num-literals/module.ens
+++ b/test/misc/num-literals/module.ens
@@ -6,9 +6,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/print-float/module.ens
+++ b/test/misc/print-float/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/static-file/module.ens
+++ b/test/misc/static-file/module.ens
@@ -12,9 +12,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/binary-search-tree/module.ens
+++ b/test/pfds/binary-search-tree/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/binomial-heap/module.ens
+++ b/test/pfds/binomial-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/binomial-heap/source/binomial-heap.nt
+++ b/test/pfds/binomial-heap/source/binomial-heap.nt
@@ -96,7 +96,7 @@ define find-min(a: type, !cmp: (a, a) -> ordering, h: &heap(a)): ?a {
   in
   case h {
   | Nil =>
-    none()
+    none
   | Cons(t, ts) =>
     let r = root(a, t) in
     Right(helper(r, ts))
@@ -106,7 +106,7 @@ define find-min(a: type, !cmp: (a, a) -> ordering, h: &heap(a)): ?a {
 define remove-min-tree(a: type, !cmp: (a, a) -> ordering, h: heap(a)): ?pair(tree(a), heap(a)) {
   match h {
   | Nil =>
-    none()
+    none
   | Cons(t, Nil) =>
     Right(Pair(t, Nil))
   | Cons(t, ts) =>

--- a/test/pfds/custom-stack/module.ens
+++ b/test/pfds/custom-stack/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
     },
   },

--- a/test/pfds/custom-stack/source/custom-stack.nt
+++ b/test/pfds/custom-stack/source/custom-stack.nt
@@ -29,7 +29,7 @@ define is-empty(a: type, xs: &custom-stack(a)): bool {
 define head(a: type, xs: &custom-stack(a)): ?&pair(a, a) {
   case xs {
   | Nil =>
-    none()
+    none
   | Cons(a, _) =>
     Right(a)
   }
@@ -38,7 +38,7 @@ define head(a: type, xs: &custom-stack(a)): ?&pair(a, a) {
 define tail(a: type, xs: &custom-stack(a)): ?&custom-stack(a) {
   case xs {
   | Nil =>
-    none()
+    none
   | Cons(_, rest) =>
     Right(rest)
   }

--- a/test/pfds/finite-map/module.ens
+++ b/test/pfds/finite-map/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/finite-map/source/finite-map.nt
+++ b/test/pfds/finite-map/source/finite-map.nt
@@ -39,7 +39,7 @@ define make-finite-map(a: type, b: type, !compare: (a, a) -> ordering): finite-m
       define lookup(!key: a, haystack: &finite-map(a, b)): ?b {
         case haystack {
         | Leaf =>
-          none()
+          none
         | Node(left, k, v, right) =>
           match !compare(!key, *k) {
           | LT =>

--- a/test/pfds/leftist-heap/module.ens
+++ b/test/pfds/leftist-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/leftist-heap/source/leftist-heap.nt
+++ b/test/pfds/leftist-heap/source/leftist-heap.nt
@@ -81,7 +81,7 @@ define make-heap-signature(a: type, !compare: (a, a) -> ordering): heap-signatur
       function (h: &heap(a)) {
         case h {
         | Leaf =>
-          none()
+          none
         | Node(_, value, _, _) =>
           Right(*value)
         }
@@ -91,7 +91,7 @@ define make-heap-signature(a: type, !compare: (a, a) -> ordering): heap-signatur
       function (h: heap(a)) {
         match h {
         | Leaf =>
-          none()
+          none
         | Node(_, _, left, right) =>
           Right(!merge(left, right))
         }

--- a/test/pfds/naive-queue/module.ens
+++ b/test/pfds/naive-queue/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/naive-queue/source/naive-queue.nt
+++ b/test/pfds/naive-queue/source/naive-queue.nt
@@ -16,7 +16,7 @@ define head(a: type, q: &queue(a)): ?a {
   | Queue(Cons(x, _), _) =>
     Right(*x)
   | _ =>
-    none()
+    none
   }
 }
 
@@ -34,7 +34,7 @@ define tail(a: type, q: queue(a)): ?queue(a) {
   | Queue(Cons(_, rest), ys) =>
     Right(sanitize(_, Queue(rest, ys)))
   | _ =>
-    none()
+    none
   }
 }
 

--- a/test/pfds/pairing-heap/module.ens
+++ b/test/pfds/pairing-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/pairing-heap/source/pairing-heap.nt
+++ b/test/pfds/pairing-heap/source/pairing-heap.nt
@@ -10,7 +10,7 @@ data heap(a) {
 define find-min(a: type, h: &heap(a)): ?a {
   case h {
   | Leaf =>
-    none()
+    none
   | Node(v, _) =>
     Right(*v)
   }
@@ -50,7 +50,7 @@ define merge-pairs(a: type, !cmp: (a, a) -> ordering, hs: list(heap(a))): heap(a
 define delete-min(a: type, cmp: (a, a) -> ordering, h: heap(a)): ?heap(a) {
   match h {
   | Leaf =>
-    none()
+    none
   | Node(_, hs) =>
     Right(merge-pairs(_, cmp, hs))
   }

--- a/test/pfds/random-access-list/module.ens
+++ b/test/pfds/random-access-list/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/random-access-list/source/random-access-list.nt
+++ b/test/pfds/random-access-list/source/random-access-list.nt
@@ -53,7 +53,7 @@ define uncons-tree(a: type, ts: R-list(a)): ?pair(tree(a), R-list(a)) {
   let New(xs) = ts in
   match xs {
   | Nil =>
-    none()
+    none
   | Cons(DigitOne(y), Nil) =>
     Right(Pair(y, New([])))
   | Cons(DigitOne(y), rest) =>
@@ -61,11 +61,11 @@ define uncons-tree(a: type, ts: R-list(a)): ?pair(tree(a), R-list(a)) {
   | Cons(DigitZero, rest) =>
     match uncons-tree(_, New(rest)) {
     | Left(_) =>
-      none()
+      none
     | Right(Pair(new-tree, New(new-ts))) =>
       match new-tree {
       | Leaf(_) =>
-        none()
+        none
       | Node(_, t1, t2) =>
         Right(Pair(t1, New(Cons(DigitOne(t2), new-ts))))
       }
@@ -79,7 +79,7 @@ define lookup-tree(a: type, i: int, t: &tree(a)): ?a {
     if eq-int(i, 0) {
       Right(*v)
     } else {
-      none()
+      none
     }
   | Node(w, t1, t2) =>
     let w-div-2 = div-int(*w, 2) in
@@ -94,7 +94,7 @@ define lookup-tree(a: type, i: int, t: &tree(a)): ?a {
 define lookup-list(a: type, i: int, xs: &list(digit(a))): ?a {
   case xs {
   | [] =>
-    none()
+    none
   | Cons(DigitZero, rest) =>
     lookup-list(_, i, rest)
   | Cons(DigitOne(t), rest) =>

--- a/test/pfds/red-black-tree/module.ens
+++ b/test/pfds/red-black-tree/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/splay-heap/module.ens
+++ b/test/pfds/splay-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/splay-heap/source/splay-heap.nt
+++ b/test/pfds/splay-heap/source/splay-heap.nt
@@ -59,7 +59,7 @@ define insert(a: type, cmp: (a, a) -> ordering, !x: a, t: heap(a)): heap(a) {
 define find-min(a: type, t: &heap(a)): ?a {
   case t {
   | Leaf =>
-    none()
+    none
   | Node(Leaf, x, _) =>
     Right(*x)
   | Node(left, _, _) =>
@@ -70,7 +70,7 @@ define find-min(a: type, t: &heap(a)): ?a {
 define delete-min(a: type, t: heap(a)): ?heap(a) {
   match t {
   | Leaf =>
-    none()
+    none
   | Node(Leaf, _, right) =>
     Right(right)
   | Node(Node(Leaf, _, t12), y, t2) =>

--- a/test/pfds/stack/module.ens
+++ b/test/pfds/stack/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
     },
   },

--- a/test/pfds/stack/source/stack.nt
+++ b/test/pfds/stack/source/stack.nt
@@ -27,7 +27,7 @@ define is-empty(a: type, xs: &stack(a)): bool {
 define head(a: type, xs: &stack(a)): ?&a {
   case xs {
   | Nil =>
-    none()
+    none
   | Cons(a, _) =>
     Right(a)
   }
@@ -36,7 +36,7 @@ define head(a: type, xs: &stack(a)): ?&a {
 define tail(a: type, xs: &stack(a)): ?&stack(a) {
   case xs {
   | Nil =>
-    none()
+    none
   | Cons(_, rest) =>
     Right(rest)
   }

--- a/test/pfds/stream/module.ens
+++ b/test/pfds/stream/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
     },
   },

--- a/test/statement/define/module.ens
+++ b/test/statement/define/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/import-names/module.ens
+++ b/test/statement/import-names/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/resource-basic/module.ens
+++ b/test/statement/resource-basic/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/variant-struct/module.ens
+++ b/test/statement/variant-struct/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/box/module.ens
+++ b/test/term/box/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/flow/module.ens
+++ b/test/term/flow/module.ens
@@ -12,9 +12,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/noema/module.ens
+++ b/test/term/noema/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/pi/module.ens
+++ b/test/term/pi/module.ens
@@ -13,9 +13,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/prim/module.ens
+++ b/test/term/prim/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/rune/module.ens
+++ b/test/term/rune/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/tau/module.ens
+++ b/test/term/tau/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/unary/module.ens
+++ b/test/term/unary/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/var/module.ens
+++ b/test/term/var/module.ens
@@ -12,9 +12,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/variant/module.ens
+++ b/test/term/variant/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/with/module.ens
+++ b/test/term/with/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "hFXWeucJITnON8dMMMSTAtlkD2FV6ea1fRdBQUspgTM",
+      digest "BUewAg9Hlxq8P3gmtqAQ_nMu8uGww_OfgHK512lsjCw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-39.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-50-40.tar.zst",
       ],
       enable-preset true,
     },


### PR DESCRIPTION
This PR generalizes `define` and `inline` to incorporate `constant`.

More specifically, this PR:

- allows statements like `define foo: t {e}`,  `inline foo<a>: t {e}`, etc.
- resurrects the value checking stuff during elaboration
- adds `magic opaque-value {e}` to tell the compiler to treat `e` as a value
- removes `constant foo: t {e}`

The `magic opaque-value {e}` is useful when, for example, defining a constant via FFI:

```neut
inline O_RDONLY: c-int {
  magic opaque-value {
    magic external get_O_RDONLY()
  }
}
```