### PR TITLE
fix: ensure file existence before running the formatter

### DIFF
--- a/src/Act/Format.hs
+++ b/src/Act/Format.hs
@@ -1,7 +1,7 @@
 module Act.Format (format) where
 
 import Context.App
-import Context.Parse (readTextFile)
+import Context.Parse (ensureExistence', readTextFile)
 import Context.Parse qualified as Parse
 import Entity.Config.Format
 import Path.IO
@@ -14,6 +14,7 @@ format cfg = do
   Initialize.initializeCompiler (remarkCfg cfg)
   Initialize.initializeForTarget
   path <- resolveFile' $ filePathString cfg
+  ensureExistence' path Nothing
   content <- readTextFile path
   content' <- Format.format (shouldMinimizeImports cfg) (inputFileType cfg) path content
   if mustUpdateInPlace cfg

--- a/src/Context/Parse.hs
+++ b/src/Context/Parse.hs
@@ -3,6 +3,7 @@ module Context.Parse
     writeTextFile,
     printTextFile,
     ensureExistence,
+    ensureExistence',
   )
 where
 
@@ -13,6 +14,7 @@ import Control.Monad.IO.Class
 import Data.ByteString qualified as B
 import Data.Text qualified as T
 import Data.Text.Encoding
+import Entity.Hint
 import Entity.Source
 import Path
 import Path.IO
@@ -39,10 +41,15 @@ printTextFile content = do
 ensureExistence :: Source -> App ()
 ensureExistence source = do
   let path = sourceFilePath source
+  ensureExistence' path (sourceHint source)
+
+ensureExistence' :: Path Abs File -> Maybe Hint -> App ()
+ensureExistence' path mHint = do
   fileExists <- doesFileExist path
   unless fileExists $ do
-    case sourceHint source of
+    let message = T.pack $ "No such file exists: " <> toFilePath path
+    case mHint of
       Just m ->
-        Throw.raiseError m $ T.pack $ "No such file exists: " <> toFilePath path
+        Throw.raiseError m message
       Nothing ->
-        Throw.raiseError' $ T.pack $ "No such file exists: " <> toFilePath path
+        Throw.raiseError' message

--- a/src/Scene/Unravel.hs
+++ b/src/Scene/Unravel.hs
@@ -12,6 +12,7 @@ import Context.App
 import Context.Env qualified as Env
 import Context.Locator qualified as Locator
 import Context.Module qualified as Module
+import Context.Parse (ensureExistence')
 import Context.Parse qualified as Parse
 import Context.Path qualified as Path
 import Context.Throw qualified as Throw
@@ -156,10 +157,8 @@ unravelImportItem t importItem = do
     StaticKey staticFileList -> do
       let pathList = map snd staticFileList
       itemModTime <- forM pathList $ \(m, p) -> do
-        b <- Path.doesFileExist p
-        if b
-          then Path.getModificationTime p
-          else Throw.raiseError m $ "No such file exists: " <> T.pack (toFilePath p)
+        ensureExistence' p (Just m)
+        Path.getModificationTime p
       let newestArtifactTime = maximum $ map A.inject itemModTime
       return (newestArtifactTime, Seq.empty)
 


### PR DESCRIPTION
Before:

```sh
❯ neut format-source source/foobarbuz.nt
Error: /path/to/source/foobarbuz.nt: withBinaryFile: does not exist (No such file or directory)
```

After:

```sh
❯ neut format-source source/foobarbuz.nt
Error: No such file exists: /path/to/source/foobarbuz.nt
```