### PR TITLE
remove an unnecessary operation in `getLocationTree` for better LSP performance

### DIFF
--- a/src/Scene/LSP/GetLocationTree.hs
+++ b/src/Scene/LSP/GetLocationTree.hs
@@ -1,25 +1,19 @@
-module Scene.LSP.GetLocationTree (getLocationTree) where
+module Scene.LSP.GetLocationTree
+  ( getLocationTree,
+  )
+where
 
 import Context.AppM
 import Context.Cache qualified as Cache
-import Context.Throw qualified as Throw
-import Context.Unravel qualified as Unravel
 import Control.Monad.Trans
 import Entity.Cache qualified as Cache
 import Entity.LocationTree qualified as LT
 import Entity.Source
 import Entity.Target (Target (Peripheral))
-import Scene.Unravel
 
 getLocationTree ::
   Source ->
   AppM LT.LocationTree
 getLocationTree src = do
-  lift Unravel.initialize
-  resultOrError <- lift $ Throw.execute $ unravel' Peripheral src
-  case resultOrError of
-    Left _ ->
-      liftMaybe Nothing
-    Right _ -> do
-      cache <- lift (Cache.loadLocationCache Peripheral src) >>= liftMaybe
-      return $ Cache.locationTree cache
+  cache <- lift (Cache.loadLocationCache Peripheral src) >>= liftMaybe
+  return $ Cache.locationTree cache


### PR DESCRIPTION
The following are benchmarks of a command that executes `textDocument/documentHighlight` five times:

```
// Before this PR
Benchmark 1: neut foo
  Time (mean ± σ):     480.3 ms ±   6.0 ms    [User: 390.0 ms, System: 196.8 ms]
  Range (min … max):   471.9 ms … 489.5 ms    10 runs

↓

// After this PR
Benchmark 1: neut foo
  Time (mean ± σ):      47.5 ms ±   1.5 ms    [User: 17.1 ms, System: 18.9 ms]
  Range (min … max):    44.2 ms …  50.8 ms    57 runs
```