### PR TITLE
Fix: `clang -v` => `clang --version`

### DIFF
--- a/src/Context/External.hs
+++ b/src/Context/External.hs
@@ -113,18 +113,18 @@ getClangDigest = do
 calculateClangDigest :: App T.Text
 calculateClangDigest = do
   clang <- liftIO getClang
-  let clangCmd = proc clang ["-v"]
+  let clangCmd = proc clang ["--version"]
   withRunInIO $ \runInIO ->
-    withCreateProcess clangCmd {std_err = CreatePipe} $
-      \_ _ mStdErr clangProcessHandler -> do
-        case mStdErr of
-          Just stdErr -> do
-            value <- B.hGetContents stdErr
+    withCreateProcess clangCmd {std_out = CreatePipe} $
+      \_ mStdOut _ clangProcessHandler -> do
+        case mStdOut of
+          Just stdOut -> do
+            value <- B.hGetContents stdOut
             clangExitCode <- waitForProcess clangProcessHandler
-            runInIO $ raiseIfProcessFailed (T.pack clang) clangExitCode stdErr
+            runInIO $ raiseIfProcessFailed (T.pack clang) clangExitCode stdOut
             return $ decodeUtf8 $ hashAndEncode value
           Nothing ->
-            runInIO $ Throw.raiseError' "Could not obtain stderr"
+            runInIO $ Throw.raiseError' "Could not obtain stdout"
 
 ensureExecutables :: App ()
 ensureExecutables = do

--- a/src/Context/External.hs
+++ b/src/Context/External.hs
@@ -113,15 +113,15 @@ getClangDigest = do
 calculateClangDigest :: App T.Text
 calculateClangDigest = do
   clang <- liftIO getClang
-  let printfCmd = proc clang ["-v"]
+  let clangCmd = proc clang ["-v"]
   withRunInIO $ \runInIO ->
-    withCreateProcess printfCmd {std_err = CreatePipe} $
-      \_ _ mStdErr printfProcessHandler -> do
+    withCreateProcess clangCmd {std_err = CreatePipe} $
+      \_ _ mStdErr clangProcessHandler -> do
         case mStdErr of
           Just stdErr -> do
             value <- B.hGetContents stdErr
-            printfExitCode <- waitForProcess printfProcessHandler
-            runInIO $ raiseIfProcessFailed (T.pack clang) printfExitCode stdErr
+            clangExitCode <- waitForProcess clangProcessHandler
+            runInIO $ raiseIfProcessFailed (T.pack clang) clangExitCode stdErr
             return $ decodeUtf8 $ hashAndEncode value
           Nothing ->
             runInIO $ Throw.raiseError' "Could not obtain stderr"


### PR DESCRIPTION
The command to get the version information of Clang is `clang --version`, not `clang -v`.
Hopefully addresses #268.