### PR TITLE
relax unnecessarily strict constraints on free variables

### DIFF
--- a/book/src/modality-and-memory.md
+++ b/book/src/modality-and-memory.md
@@ -624,7 +624,7 @@ and this is why the type of `e1` must be restricted to some extent. Now we can s
 
 ## Layer Closedness of Functions
 
-There's one last condition that we must require: every free variable in a `function` must be at the layer of `function`. For example, the following is not a valid term:
+There's one last condition: for any free variable `x` of a function `f`, `layer(x) <= layer(f)` must hold. For example, the following is not a valid term:
 
 ```neut
 define use-function(x: meta int): meta () -> int {
@@ -640,7 +640,7 @@ define use-function(x: meta int): meta () -> int {
 }
 ```
 
-This is because the function is at layer -1, but the free variable `x` is at layer 0.
+since `layer(x) = 0 > -1 = layer(f)`, where `f` is the anonymous function.
 
 If it were not for this condition, the following would be well-typed and well-layered:
 

--- a/src/Scene/Parse/Discern.hs
+++ b/src/Scene/Parse/Discern.hs
@@ -1081,7 +1081,7 @@ findExternalVariable :: Hint -> Axis -> WT.WeakTerm -> App (Maybe (Ident, Layer)
 findExternalVariable m axis e = do
   let fvs = S.toList $ freeVars e
   ls <- mapM (getLayer m axis) fvs
-  return $ List.find (\(_, l) -> l /= currentLayer axis) $ zip fvs ls
+  return $ List.find (\(_, l) -> l > currentLayer axis) $ zip fvs ls
 
 ensureLayerClosedness :: Hint -> Axis -> WT.WeakTerm -> App ()
 ensureLayerClosedness mClosure axis e = do
@@ -1091,13 +1091,13 @@ ensureLayerClosedness mClosure axis e = do
       return ()
     Just (x, l) -> do
       Throw.raiseError mClosure $
-        "This closure is at the layer "
+        "This function is at the layer "
           <> T.pack (show (currentLayer axis))
           <> ", but the free variable `"
           <> Ident.toText x
           <> "` is at the layer "
           <> T.pack (show l)
-          <> " (≠ "
+          <> " (> "
           <> T.pack (show (currentLayer axis))
           <> ")"
 


### PR DESCRIPTION
## Input:

```neut
define yo(): meta unit {
  let x = box {Unit} in
  letbox v =
    let f =
      function () { // (*)
        box {x}
      }
    in
    f()
  in
  v
}
```

## Output (Before):

```
Error at (*): "This closure is at layer 1, but the free variable `x` is at the layer 0 (≠ 1)"
```

## Output (After):
```
(No error)
```