### PR TITLE
fix: avoid `withBinaryFile: does not exist`

### DIFF
--- a/src/Scene/Unravel.hs
+++ b/src/Scene/Unravel.hs
@@ -148,7 +148,10 @@ unravelModule' axis currentModule = do
       let children = map (MID.Library . dependencyDigest . snd) $ Map.toList $ moduleDependency currentModule
       arrows <- fmap concat $ forM children $ \moduleID -> do
         path' <- Module.getModuleFilePath Nothing moduleID
-        Module.fromFilePath path' >>= unravelModule' axis
+        b <- Path.doesFileExist path'
+        if b
+          then Module.fromFilePath path' >>= unravelModule' axis
+          else return []
       liftIO $ modifyIORef' (visitMapRef axis) $ Map.insert path VI.Finish
       liftIO $ modifyIORef' (traceListRef axis) tail
       return $ currentModule : arrows


### PR DESCRIPTION
## Script

```sh
neut create yo
cd yo
rm -rf ./cache
neut clean
```

## Output (before)

```
Error: /path/to/yo/cache/dependency/3PRPyylEh5TJ7GbaO-eGj3SZaFAa9vSaDur94E09s88/module.ens: withBinaryFile: does not exist (No such file or directory)
```

## Output (after)

```
(no output)
```