### PR TITLE
allow specifying implicit arguments explicitly

### DIFF
--- a/src/Kernel/Elaborate/Move/Internal/WeakTerm/Fill.hs
+++ b/src/Kernel/Elaborate/Move/Internal/WeakTerm/Fill.hs
@@ -59,10 +59,11 @@ fill h holeSubst term =
         _ -> do
           e' <- fill h holeSubst e
           return $ m :< WT.PiIntro attr impArgs' expArgs' e'
-    m :< WT.PiElim b e es -> do
+    m :< WT.PiElim b e impArgs expArgs -> do
       e' <- fill h holeSubst e
-      es' <- mapM (fill h holeSubst) es
-      return $ m :< WT.PiElim b e' es'
+      impArgs' <- mapM (mapM (fill h holeSubst)) impArgs
+      expArgs' <- mapM (fill h holeSubst) expArgs
+      return $ m :< WT.PiElim b e' impArgs' expArgs'
     m :< WT.PiElimExact e -> do
       e' <- fill h holeSubst e
       return $ m :< WT.PiElimExact e'

--- a/src/Kernel/Parse/Move/Internal/Discern/Name.hs
+++ b/src/Kernel/Parse/Move/Internal/Discern/Name.hs
@@ -140,7 +140,7 @@ interpretGlobalName h m dd gn = do
       let attr = AttrVG.Attr {..}
       let e = m :< WT.VarGlobal attr dd
       if isConstLike
-        then return $ m :< WT.PiElim False e []
+        then return $ m :< WT.PiElim False e Nothing []
         else return e
     GN.PrimType primNum ->
       return $ m :< WT.Prim (WP.Type primNum)
@@ -160,7 +160,7 @@ interpretTopLevelFunc ::
 interpretTopLevelFunc m dd argNum isConstLike = do
   let attr = AttrVG.Attr {..}
   if isConstLike
-    then m :< WT.PiElim False (m :< WT.VarGlobal attr dd) []
+    then m :< WT.PiElim False (m :< WT.VarGlobal attr dd) Nothing []
     else m :< WT.VarGlobal attr dd
 
 castFromIntToBool :: H.Handle -> WT.WeakTerm -> EIO WT.WeakTerm

--- a/src/Language/RawTerm/Rule/RawTerm.hs
+++ b/src/Language/RawTerm/Rule/RawTerm.hs
@@ -59,8 +59,8 @@ data RawTermF a
   | Pi (Args a) (Args a) C a Loc
   | PiIntro C FuncInfo
   | PiIntroFix C DefInfo
-  | PiElim a C (SE.Series a)
-  | PiElimByKey Name C (SE.Series (Hint, Key, C, C, a)) -- auxiliary syntax for key-call
+  | PiElim a C (Maybe (SE.Series a)) (SE.Series a)
+  | PiElimByKey Name C (Maybe (SE.Series a)) (SE.Series (Hint, Key, C, C, a)) -- auxiliary syntax for key-call
   | PiElimExact C a
   | Data (AttrD.Attr DD.DefiniteDescription) DD.DefiniteDescription [a]
   | DataIntro (AttrDI.Attr DD.DefiniteDescription) DD.DefiniteDescription [a] [a] -- (attr, consName, dataArgs, consArgs)
@@ -169,7 +169,7 @@ getDefName def =
 
 piElim :: a -> [a] -> RawTermF a
 piElim e es =
-  PiElim e [] (SE.fromList' es)
+  PiElim e [] Nothing (SE.fromList' es)
 
 lam :: Loc -> Hint -> [(RawBinder RawTerm, C)] -> RawTerm -> RawTerm -> RawTerm
 lam loc m varList codType e =

--- a/src/Language/RawTerm/Rule/RawTerm/ToDoc.hs
+++ b/src/Language/RawTerm/Rule/RawTerm/ToDoc.hs
@@ -61,14 +61,16 @@ toDoc term =
       decodeDef lambdaNameToDoc "function" c def
     _ :< PiIntroFix c def -> do
       decodeDef (nameToDoc . N.Var) "define" c def
-    _ :< PiElim e c args -> do
+    _ :< PiElim e c impArgs expArgs -> do
       PI.arrange
         [ PI.inject $ toDoc e,
-          PI.inject $ attachComment c $ SE.decodeHorizontallyIfPossible $ fmap toDoc args
+          PI.inject $ decodeImpArgs impArgs,
+          PI.inject $ attachComment c $ SE.decodeHorizontallyIfPossible $ fmap toDoc expArgs
         ]
-    _ :< PiElimByKey name c kvs -> do
+    _ :< PiElimByKey name c impArgs kvs -> do
       PI.arrange
         [ PI.inject $ nameToDoc name,
+          PI.inject $ decodeImpArgs impArgs,
           PI.inject $ attachComment c $ decPiElimKey kvs
         ]
     _ :< PiElimExact c e ->
@@ -348,6 +350,14 @@ decodeBlock (c1, (body, c2)) = do
       D.line,
       D.text "}"
     ]
+
+decodeImpArgs :: Maybe (SE.Series RawTerm) -> D.Doc
+decodeImpArgs mImpArgs =
+  case mImpArgs of
+    Nothing ->
+      D.Nil
+    Just series -> do
+      SE.decodeHorizontallyIfPossible $ fmap toDoc series
 
 decodeArgs :: Args RawTerm -> D.Doc
 decodeArgs (series, c) = do

--- a/src/Language/Term/Rule/Term/Weaken.hs
+++ b/src/Language/Term/Rule/Term/Weaken.hs
@@ -62,7 +62,7 @@ weaken term =
     m :< TM.PiElim b e es -> do
       let e' = weaken e
       let es' = map weaken es
-      m :< WT.PiElim b e' es'
+      m :< WT.PiElim b e' Nothing es'
     m :< TM.Data attr name es -> do
       let es' = map weaken es
       m :< WT.Data attr name es'

--- a/src/Language/WeakTerm/Move/Subst.hs
+++ b/src/Language/WeakTerm/Move/Subst.hs
@@ -76,10 +76,11 @@ subst h sub term =
               e' <- subst h sub'' e
               let lamAttr = AttrL.Attr {lamKind = LK.Normal mName codType', identity = newLamID}
               return (m :< WT.PiIntro lamAttr impArgs' expArgs' e')
-    m :< WT.PiElim b e es -> do
+    m :< WT.PiElim b e impArgs expArgs -> do
       e' <- subst h sub e
-      es' <- mapM (subst h sub) es
-      return $ m :< WT.PiElim b e' es'
+      impArgs' <- mapM (mapM (subst h sub)) impArgs
+      expArgs' <- mapM (subst h sub) expArgs
+      return $ m :< WT.PiElim b e' impArgs' expArgs'
     m :< WT.PiElimExact e -> do
       e' <- subst h sub e
       return $ m :< WT.PiElimExact e'

--- a/src/Language/WeakTerm/Rule/WeakTerm.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm.hs
@@ -45,7 +45,7 @@ data WeakTermF a
   | VarGlobal AttrVG.Attr DD.DefiniteDescription
   | Pi [BinderF a] [BinderF a] a
   | PiIntro (AttrL.Attr a) [BinderF a] [BinderF a] a
-  | PiElim N.IsNoetic a [a]
+  | PiElim N.IsNoetic a (Maybe [a]) [a]
   | PiElimExact a
   | Data (AttrD.Attr DD.DefiniteDescription) DD.DefiniteDescription [a]
   | DataIntro (AttrDI.Attr DD.DefiniteDescription) DD.DefiniteDescription [a] [a] -- (consName, dataArgs, consArgs)

--- a/src/Language/WeakTerm/Rule/WeakTerm/Eq.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/Eq.hs
@@ -44,12 +44,22 @@ eq (_ :< term1) (_ :< term2)
           b1 && b2
         _ ->
           False
-  | WT.PiElim isNoetic1 f1 args1 <- term1,
-    WT.PiElim isNoetic2 f2 args2 <- term2,
+  | WT.PiElim isNoetic1 f1 Nothing expArgs1 <- term1,
+    WT.PiElim isNoetic2 f2 Nothing expArgs2 <- term2,
+    length expArgs1 == length expArgs2,
     isNoetic1 == isNoetic2 = do
       let b1 = eq f1 f2
-      let b2 = all (uncurry eq) $ zip args1 args2
+      let b2 = all (uncurry eq) $ zip expArgs1 expArgs2
       b1 && b2
+  | WT.PiElim isNoetic1 f1 (Just impArgs1) expArgs1 <- term1,
+    WT.PiElim isNoetic2 f2 (Just impArgs2) expArgs2 <- term2,
+    length impArgs1 == length impArgs2,
+    length expArgs1 == length expArgs2,
+    isNoetic1 == isNoetic2 = do
+      let b1 = eq f1 f2
+      let b2 = all (uncurry eq) $ zip impArgs1 impArgs2
+      let b3 = all (uncurry eq) $ zip expArgs1 expArgs2
+      b1 && b2 && b3
   | WT.PiElimExact f1 <- term1,
     WT.PiElimExact f2 <- term2 =
       eq f1 f2

--- a/src/Language/WeakTerm/Rule/WeakTerm/FreeVars.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/FreeVars.hs
@@ -23,9 +23,9 @@ freeVars term =
       freeVars' (impArgs ++ expArgs) (freeVars t)
     _ :< WT.PiIntro k impArgs expArgs e ->
       freeVars' (impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVars e)
-    _ :< WT.PiElim _ e es -> do
+    _ :< WT.PiElim _ e impArgs expArgs -> do
       let xs = freeVars e
-      let ys = S.unions $ map freeVars es
+      let ys = S.unions $ map freeVars (fromMaybe [] impArgs ++ expArgs)
       S.union xs ys
     _ :< WT.PiElimExact e -> do
       freeVars e

--- a/src/Language/WeakTerm/Rule/WeakTerm/Holes.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/Holes.hs
@@ -23,8 +23,8 @@ holes term =
       holes' (impArgs ++ expArgs) (holes t)
     _ :< WT.PiIntro k impArgs expArgs e ->
       holes' (impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (holes e)
-    _ :< WT.PiElim _ e es ->
-      S.unions $ map holes $ e : es
+    _ :< WT.PiElim _ e impArgs expArgs ->
+      S.unions $ map holes $ e : (fromMaybe [] impArgs ++ expArgs)
     _ :< WT.PiElimExact e ->
       holes e
     _ :< WT.Data _ _ es ->

--- a/src/Language/WeakTerm/Rule/WeakTerm/ToText.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/ToText.hs
@@ -56,13 +56,17 @@ toText term =
             <> toText codType
             <> " "
             <> inBrace (toText e)
-    _ :< WT.PiElim _ e es -> do
+    _ :< WT.PiElim _ e impArgs expArgs -> do
       case e of
         _ :< WT.VarGlobal attr _
           | AttrVG.isConstLike attr ->
               toText e
         _ -> do
-          showApp (toText e) (map toText es)
+          case impArgs of
+            Just impArgs' ->
+              showApp' (toText e) (map toText impArgs') (map toText expArgs)
+            Nothing ->
+              showApp (toText e) (map toText expArgs)
     _ :< WT.PiElimExact e -> do
       "exact " <> toText e
     _ :< WT.Data (AttrD.Attr {..}) name es -> do
@@ -177,6 +181,10 @@ showDomArgList mxts =
 showApp :: T.Text -> [T.Text] -> T.Text
 showApp e es =
   e <> inParen (T.intercalate ", " es)
+
+showApp' :: T.Text -> [T.Text] -> [T.Text] -> T.Text
+showApp' e impArgs expArgs =
+  e <> inAngleBracket (T.intercalate ", " impArgs) <> inParen (T.intercalate ", " expArgs)
 
 showVariable :: Ident -> T.Text
 showVariable x =


### PR DESCRIPTION
example:

```
define id<a>(x: a): a {
  x
}

define use-id(): unit {
  let x = id(Unit);
  let x = id<unit>(Unit);          // new
  let x = id<unit> of {x := Unit}; // new
  Unit
}
```
