### PR TITLE
specify implicit arguments in `of`

### DIFF
--- a/src/Kernel/Common/Rule/Handle/Global/KeyArg.hs
+++ b/src/Kernel/Common/Rule/Handle/Global/KeyArg.hs
@@ -1,5 +1,7 @@
 module Kernel.Common.Rule.Handle.Global.KeyArg
   ( Handle (..),
+    ExpKey,
+    ImpKey,
     _eqKeys,
     _showKeys,
     _showKeyList,
@@ -10,16 +12,21 @@ import Data.HashMap.Strict qualified as Map
 import Data.IORef
 import Data.Text qualified as T
 import Kernel.Common.Rule.Module
-import Language.Common.Rule.ArgNum qualified as AN
 import Language.Common.Rule.Const (holeVarPrefix)
 import Language.Common.Rule.DefiniteDescription qualified as DD
 import Language.Common.Rule.IsConstLike
 import Language.RawTerm.Rule.Key
 import Prelude hiding (lookup, read)
 
+type ExpKey =
+  Key
+
+type ImpKey =
+  Key
+
 data Handle = Handle
   { _mainModule :: MainModule,
-    _keyArgMapRef :: IORef (Map.HashMap DD.DefiniteDescription (IsConstLike, (AN.ArgNum, [Key])))
+    _keyArgMapRef :: IORef (Map.HashMap DD.DefiniteDescription (IsConstLike, ([ImpKey], [ExpKey])))
   }
 
 isHole :: Key -> Bool

--- a/src/Kernel/Parse/Move/Internal/RawTerm.hs
+++ b/src/Kernel/Parse/Move/Internal/RawTerm.hs
@@ -156,16 +156,14 @@ rawTerm' h m headSymbol c = do
             ]
         else do
           name <- interpretVarName m headSymbol
-          mImpArgs <- parseImplicitArgs h
+
           choice
             [ do
                 (kvs, c') <- keyValueArgs $ rawTermKeyValuePair h
-                case mImpArgs of
-                  Just (impArgs, cImp) ->
-                    return (m :< RT.PiElimByKey name (c ++ cImp) (Just impArgs) kvs, c')
-                  Nothing ->
-                    return (m :< RT.PiElimByKey name c Nothing kvs, c'),
-              rawTermPiElimCont h (m :< RT.Var name, c) mImpArgs
+                return (m :< RT.PiElimByKey name c kvs, c'),
+              do
+                mImpArgs <- parseImplicitArgs h
+                rawTermPiElimCont h (m :< RT.Var name, c) mImpArgs
             ]
 
 rawTermPiElimCont :: Handle -> (RT.RawTerm, C) -> Maybe (SE.Series RT.RawTerm, C) -> Parser (RT.RawTerm, C)

--- a/src/Kernel/Parse/Move/Parse.hs
+++ b/src/Kernel/Parse/Move/Parse.hs
@@ -5,15 +5,13 @@ module Kernel.Parse.Move.Parse
 where
 
 import CodeParser.Move.Parse (runParser)
-import Error.Move.Run (forP, forP_)
-import Error.Rule.EIO (EIO)
-import Logger.Rule.Hint
-import SyntaxTree.Rule.Series qualified as SE
 import Control.Monad
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Bifunctor (Bifunctor (first))
 import Data.HashMap.Strict qualified as Map
 import Data.Text qualified as T
+import Error.Move.Run (forP, forP_)
+import Error.Rule.EIO (EIO)
 import Kernel.Common.Move.CreateGlobalHandle qualified as Global
 import Kernel.Common.Move.CreateLocalHandle qualified as Local
 import Kernel.Common.Move.Handle.Global.KeyArg qualified as KeyArg
@@ -41,6 +39,8 @@ import Language.Common.Rule.StmtKind qualified as SK
 import Language.RawTerm.Rule.RawStmt
 import Language.RawTerm.Rule.RawTerm qualified as RT
 import Language.Term.Rule.Stmt
+import Logger.Rule.Hint
+import SyntaxTree.Rule.Series qualified as SE
 
 data Handle = Handle
   { parseHandle :: ParseRT.Handle,
@@ -179,9 +179,9 @@ registerKeyArg h stmt = do
       let expArgs = RT.extractArgs $ RT.expArgs geist
       let isConstLike = RT.isConstLike geist
       let m = RT.loc geist
-      let allArgNum = AN.fromInt $ length $ impArgs ++ expArgs
-      let expArgNames = map (\(_, x, _, _, _) -> x) expArgs
-      KeyArg.insert (keyArgHandle h) m name isConstLike allArgNum expArgNames
+      let impKeys = map (\(_, x, _, _, _) -> x) impArgs
+      let expKeys = map (\(_, x, _, _, _) -> x) expArgs
+      KeyArg.insert (keyArgHandle h) m name isConstLike impKeys expKeys
     PostRawStmtNominal {} -> do
       return ()
     PostRawStmtDefineResource {} -> do
@@ -193,9 +193,9 @@ registerKeyArg' :: Handle -> Stmt -> EIO ()
 registerKeyArg' h stmt = do
   case stmt of
     StmtDefine isConstLike _ (SavedHint m) name impArgs expArgs _ _ -> do
-      let expArgNames = map (\(_, x, _) -> toText x) expArgs
-      let allArgNum = AN.fromInt $ length $ impArgs ++ expArgs
-      KeyArg.insert (keyArgHandle h) m name isConstLike allArgNum expArgNames
+      let impKeys = map (\(_, x, _) -> toText x) impArgs
+      let expKeys = map (\(_, x, _) -> toText x) expArgs
+      KeyArg.insert (keyArgHandle h) m name isConstLike impKeys expKeys
     StmtForeign {} ->
       return ()
 

--- a/src/Language/RawTerm/Rule/RawTerm.hs
+++ b/src/Language/RawTerm/Rule/RawTerm.hs
@@ -60,7 +60,7 @@ data RawTermF a
   | PiIntro C FuncInfo
   | PiIntroFix C DefInfo
   | PiElim a C (Maybe (SE.Series a)) (SE.Series a)
-  | PiElimByKey Name C (Maybe (SE.Series a)) (SE.Series (Hint, Key, C, C, a)) -- auxiliary syntax for key-call
+  | PiElimByKey Name C (SE.Series (Hint, Key, C, C, a)) -- auxiliary syntax for key-call
   | PiElimExact C a
   | Data (AttrD.Attr DD.DefiniteDescription) DD.DefiniteDescription [a]
   | DataIntro (AttrDI.Attr DD.DefiniteDescription) DD.DefiniteDescription [a] [a] -- (attr, consName, dataArgs, consArgs)

--- a/src/Language/RawTerm/Rule/RawTerm/ToDoc.hs
+++ b/src/Language/RawTerm/Rule/RawTerm/ToDoc.hs
@@ -67,10 +67,9 @@ toDoc term =
           PI.inject $ decodeImpArgs impArgs,
           PI.inject $ attachComment c $ SE.decodeHorizontallyIfPossible $ fmap toDoc expArgs
         ]
-    _ :< PiElimByKey name c impArgs kvs -> do
+    _ :< PiElimByKey name c kvs -> do
       PI.arrange
         [ PI.inject $ nameToDoc name,
-          PI.inject $ decodeImpArgs impArgs,
           PI.inject $ attachComment c $ decPiElimKey kvs
         ]
     _ :< PiElimExact c e ->


### PR DESCRIPTION
before:

```
define id<a>(x: a): a {
  x
}

define use-id(): unit {
  let x = id<unit> of {x := Unit};
  Unit
}
```

after:

```
define id<a>(x: a): a {
  x
}

define use-id(): unit {
  let x = id of {a := unit, x := Unit};
  Unit
}
```
