### PR TITLE
add support for default arguments in functions

### DIFF
--- a/bench/action/bubble/module.ens
+++ b/bench/action/bubble/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/bench/action/dictionary/module.ens
+++ b/bench/action/dictionary/module.ens
@@ -6,9 +6,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/bench/action/intmap/module.ens
+++ b/bench/action/intmap/module.ens
@@ -6,9 +6,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/book/src/manual-installation.md
+++ b/book/src/manual-installation.md
@@ -11,8 +11,8 @@ Add the below to your `.bashrc`, `.zshrc`, etc.
 
 ```sh
 # this sets the core module (or "prelude") that is used in `neut create`
-export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst"
-export NEUT_CORE_MODULE_DIGEST="8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64"
+export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst"
+export NEUT_CORE_MODULE_DIGEST="ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ"
 ```
 
 Then, get the compiler:

--- a/install.sh
+++ b/install.sh
@@ -142,8 +142,8 @@ printf $BLUE "note: "
 echo "please restart your shell after adding the following environment variables to your shell config:"
 
 echo ""
-echo "export NEUT_CORE_MODULE_URL=\"https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst\""
-echo "export NEUT_CORE_MODULE_DIGEST=\"8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64\""
+echo "export NEUT_CORE_MODULE_URL=\"https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst\""
+echo "export NEUT_CORE_MODULE_DIGEST=\"ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ\""
 
 if command -v apt-get >/dev/null 2>&1; then
   echo "export NEUT_CLANG=$CLANG"

--- a/src/Kernel/Clarify/Move/Clarify.hs
+++ b/src/Kernel/Clarify/Move/Clarify.hs
@@ -170,7 +170,7 @@ clarifyStmt :: Handle -> Stmt -> EIO C.CompStmt
 clarifyStmt h stmt =
   case stmt of
     StmtDefine _ stmtKind (SavedHint m) f impArgs expArgs _ e -> do
-      let xts = impArgs ++ expArgs
+      let xts = map fst impArgs ++ expArgs
       xts' <- dropFst <$> clarifyBinder h IntMap.empty xts
       envArg <- liftIO $ makeEnvArg h
       switchArg <- liftIO $ makeSwitchArg h

--- a/src/Kernel/Clarify/Move/Clarify.hs
+++ b/src/Kernel/Clarify/Move/Clarify.hs
@@ -264,7 +264,7 @@ clarifyTerm h tenv term =
     _ :< TM.Pi {} ->
       return Sigma.returnClosureS4
     _ :< TM.PiIntro attr impArgs expArgs e -> do
-      clarifyLambda h tenv attr (TM.chainOf tenv [term]) (impArgs ++ expArgs) e
+      clarifyLambda h tenv attr (TM.chainOf tenv [term]) (map fst impArgs ++ expArgs) e
     _ :< TM.PiElim b e es -> do
       es' <- mapM (clarifyPlus h tenv) es
       case e of

--- a/src/Kernel/Common/Rule/Cache.hs
+++ b/src/Kernel/Common/Rule/Cache.hs
@@ -8,7 +8,7 @@ module Kernel.Common.Rule.Cache
   )
 where
 
-import Logger.Rule.Log
+import Data.Bifunctor
 import Data.Binary
 import GHC.Generics
 import Kernel.Common.Rule.LocalVarTree qualified as LVT
@@ -18,6 +18,7 @@ import Kernel.Common.Rule.TopCandidate (TopCandidate)
 import Language.Term.Rule.Stmt qualified as Stmt
 import Language.Term.Rule.Term.Compress qualified as TM
 import Language.Term.Rule.Term.Extend qualified as TM
+import Logger.Rule.Log
 
 data Cache = Cache
   { stmtList :: [Stmt.Stmt],
@@ -72,7 +73,7 @@ compressStmt stmt =
   case stmt of
     Stmt.StmtDefine isConstLike stmtKind m functionName impArgs expArgs codType e -> do
       let stmtKind' = TM.compressStmtKind stmtKind
-      let impArgs' = map TM.compressBinder impArgs
+      let impArgs' = map (bimap TM.compressBinder (fmap TM.compress)) impArgs
       let expArgs' = map TM.compressBinder expArgs
       let codType' = TM.compress codType
       let e' = TM.compress e
@@ -85,7 +86,7 @@ extendStmt stmt =
   case stmt of
     Stmt.StmtDefine isConstLike stmtKind m functionName impArgs expArgs codType e -> do
       let stmtKind' = TM.extendStmtKind stmtKind
-      let impArgs' = map TM.extendBinder impArgs
+      let impArgs' = map (bimap TM.extendBinder (fmap TM.extend)) impArgs
       let expArgs' = map TM.extendBinder expArgs
       let codType' = TM.extend codType
       let e' = TM.extend e

--- a/src/Kernel/Elaborate/Move/Elaborate.hs
+++ b/src/Kernel/Elaborate/Move/Elaborate.hs
@@ -423,7 +423,7 @@ strictifyFloatType h m x t = do
     _ :< TM.Data (AttrD.Attr {consNameList = [(consName, _)]}) _ [] -> do
       consType <- Type.lookup' (typeHandle h) m consName
       case consType of
-        _ :< WT.Pi _ impArgs expArgs _
+        _ :< WT.Pi (PK.DataIntro False) _ [] (_ :< WT.Pi _ impArgs expArgs _)
           | [(_, _, arg)] <- map fst impArgs ++ expArgs -> do
               strictifyFloatType h m x arg
         _ ->

--- a/src/Kernel/Elaborate/Move/Elaborate.hs
+++ b/src/Kernel/Elaborate/Move/Elaborate.hs
@@ -237,9 +237,10 @@ elaborate' h term =
       return $ m :< TM.PiIntro kind' impArgs' expArgs' e'
     m :< WT.PiElim b e impArgs expArgs -> do
       e' <- elaborate' h e
-      let es = ImpArgs.extract impArgs ++ expArgs
-      es' <- mapM (elaborate' h) es
-      return $ m :< TM.PiElim b e' es'
+      let impArgs' = ImpArgs.extract impArgs
+      impArgs'' <- mapM (elaborate' h) impArgs'
+      expArgs' <- mapM (elaborate' h) expArgs
+      return $ m :< TM.PiElim b e' impArgs'' expArgs'
     m :< WT.PiElimExact {} -> do
       raiseCritical m "Scene.Elaborate.elaborate': found a remaining `exact`"
     m :< WT.Data attr name es -> do

--- a/src/Kernel/Elaborate/Move/Internal/EnsureAffinity.hs
+++ b/src/Kernel/Elaborate/Move/Internal/EnsureAffinity.hs
@@ -160,10 +160,11 @@ analyze h term = do
           cs3 <- analyze h'' codType
           cs4 <- analyze h'' e
           return $ cs1 ++ cs2 ++ cs3 ++ cs4
-    _ :< TM.PiElim _ e es -> do
+    _ :< TM.PiElim _ e impArgs expArgs -> do
       cs <- analyze h e
-      css <- mapM (analyze h) es
-      return $ cs ++ concat css
+      css1 <- mapM (analyze h) impArgs
+      css2 <- mapM (analyze h) expArgs
+      return $ cs ++ concat css1 ++ concat css2
     _ :< TM.Data _ _ es -> do
       css <- mapM (analyze $ deactivateExpCheck h) es
       return $ concat css

--- a/src/Kernel/Elaborate/Move/Internal/EnsureAffinity.hs
+++ b/src/Kernel/Elaborate/Move/Internal/EnsureAffinity.hs
@@ -145,17 +145,17 @@ analyze h term = do
     m :< TM.PiIntro (AttrL.Attr {lamKind}) impArgs expArgs e -> do
       case lamKind of
         LK.Fix (mx, x, codType) -> do
-          (cs1, h') <- analyzeBinder h impArgs
+          (cs1, h') <- analyzeBinder h (map fst impArgs)
           (cs2, h'') <- analyzeBinder h' expArgs
           cs3 <- analyze h'' codType
-          let impArgsWithDefaults = map (,Nothing) impArgs
+          let impArgsWithDefaults = impArgs
           let piType = m :< TM.Pi PK.normal impArgsWithDefaults expArgs codType
           liftIO $ insertRelevantVar x h''
           cs4 <- analyze (extendHandle (mx, x, piType) h'') e
           css <- forM (S.toList $ freeVarsWithHints term) $ uncurry (analyzeVar h)
           return $ cs1 ++ cs2 ++ cs3 ++ cs4 ++ concat css
         LK.Normal _ codType -> do
-          (cs1, h') <- analyzeBinder h impArgs
+          (cs1, h') <- analyzeBinder h (map fst impArgs)
           (cs2, h'') <- analyzeBinder h' expArgs
           cs3 <- analyze h'' codType
           cs4 <- analyze h'' e

--- a/src/Kernel/Elaborate/Move/Internal/Handle/WeakDef.hs
+++ b/src/Kernel/Elaborate/Move/Internal/Handle/WeakDef.hs
@@ -50,7 +50,7 @@ insert' h opacity m name impArgs expArgs codType e =
   when (opacity == O.Clear) $ do
     i <- Gensym.newCount (gensymHandle h)
     modifyIORef' (weakDefMapRef h) $
-      Map.insert name (m :< WT.PiIntro (AttrL.normal' (Just $ DD.localLocator name) i codType) impArgs expArgs e)
+      Map.insert name (m :< WT.PiIntro (AttrL.normal' (Just $ DD.localLocator name) i codType) (map (,Nothing) impArgs) expArgs e)
 
 read' :: Handle -> IO DefMap
 read' h =

--- a/src/Kernel/Elaborate/Move/Internal/Infer.hs
+++ b/src/Kernel/Elaborate/Move/Internal/Infer.hs
@@ -684,7 +684,7 @@ inferClause h cursorType@(_ :< cursorTypeInner) decisionCase = do
       let m = mCons
       let (dataTermList, _) = unzip dataArgs
       typedDataArgs' <- mapM (infer h) dataTermList
-      (consArgs', extendedVarEnv) <- inferBinder' h consArgs
+      consArgs' <- inferBinder'' h consArgs
       let argNum = AN.fromInt $ length dataArgs + length consArgs
       let attr = AttrVG.Attr {..}
       let dataArgs' = ImpArgs.FullySpecified $ map fst typedDataArgs'
@@ -697,7 +697,7 @@ inferClause h cursorType@(_ :< cursorTypeInner) decisionCase = do
         else do
           (_, tPat) <- inferPiElim h m consTerm impConsArgs expConsArgs
           liftIO $ Constraint.insert (constraintHandle h) cursorType tPat
-      (cont', tCont) <- inferDecisionTree m extendedVarEnv cont
+      (cont', tCont) <- inferDecisionTree m h cont
       return
         ( DT.ConsCase
             record

--- a/src/Kernel/Elaborate/Move/Internal/Infer.hs
+++ b/src/Kernel/Elaborate/Move/Internal/Infer.hs
@@ -525,11 +525,10 @@ inferPiElim h m (e, t) impArgs expArgs = do
             return impArgs'
           ImpArgs.PartiallySpecified impArgs' -> do
             resolvePartiallySpecifiedArgs h m impArgs' impParams
-      let args = impArgs' ++ expArgs
       let impBinders = map fst impParams
       let piArgs = impBinders ++ expParams
-      _ :< cod' <- inferArgs h IntMap.empty m args piArgs cod
-      return (m :< WT.PiElim False e ImpArgs.Unspecified (map fst args), m :< cod')
+      _ :< cod' <- inferArgs h IntMap.empty m (impArgs' ++ expArgs) piArgs cod
+      return (m :< WT.PiElim False e (ImpArgs.FullySpecified (map fst impArgs')) (map fst expArgs), m :< cod')
     _ :< WT.BoxNoema (_ :< WT.Pi _ impParams expParams cod) -> do
       ensureArityCorrectness h e (length expParams) (length expArgs)
       impArgs' <- do
@@ -541,11 +540,10 @@ inferPiElim h m (e, t) impArgs expArgs = do
             return impArgs'
           ImpArgs.PartiallySpecified impArgs' -> do
             resolvePartiallySpecifiedArgs h m impArgs' impParams
-      let args = impArgs' ++ expArgs
       let impBinders = map fst impParams
       let piArgs = impBinders ++ expParams
-      _ :< cod' <- inferArgs h IntMap.empty m args piArgs cod
-      return (m :< WT.PiElim True e ImpArgs.Unspecified (map fst args), m :< cod')
+      _ :< cod' <- inferArgs h IntMap.empty m (impArgs' ++ expArgs) piArgs cod
+      return (m :< WT.PiElim True e (ImpArgs.FullySpecified (map fst impArgs')) (map fst expArgs), m :< cod')
     _ ->
       raiseError m $ "Expected a function type, but got: " <> toText t'
 
@@ -770,6 +768,6 @@ createImpArgValueFromParam h m ((_, _, paramType), maybeDefault) =
     Just defaultValue -> do
       (defaultValue', defaultType) <- infer h defaultValue
       liftIO $ Constraint.insert (constraintHandle h) paramType defaultType
-      return (defaultValue', paramType) -- Return parameter type, not inferred type
+      return (defaultValue', defaultType)
     Nothing -> do
       liftIO $ newTypedHole h m (varEnv h)

--- a/src/Kernel/Elaborate/Move/Internal/Infer.hs
+++ b/src/Kernel/Elaborate/Move/Internal/Infer.hs
@@ -684,7 +684,7 @@ inferClause h cursorType@(_ :< cursorTypeInner) decisionCase = do
       let m = mCons
       let (dataTermList, _) = unzip dataArgs
       typedDataArgs' <- mapM (infer h) dataTermList
-      consArgs' <- inferBinder'' h consArgs
+      (consArgs', extendedVarEnv) <- inferBinder' h consArgs
       let argNum = AN.fromInt $ length dataArgs + length consArgs
       let attr = AttrVG.Attr {..}
       let dataArgs' = ImpArgs.FullySpecified $ map fst typedDataArgs'
@@ -697,7 +697,7 @@ inferClause h cursorType@(_ :< cursorTypeInner) decisionCase = do
         else do
           (_, tPat) <- inferPiElim h m consTerm impConsArgs expConsArgs
           liftIO $ Constraint.insert (constraintHandle h) cursorType tPat
-      (cont', tCont) <- inferDecisionTree m h cont
+      (cont', tCont) <- inferDecisionTree m extendedVarEnv cont
       return
         ( DT.ConsCase
             record

--- a/src/Kernel/Elaborate/Move/Internal/Unify.hs
+++ b/src/Kernel/Elaborate/Move/Internal/Unify.hs
@@ -152,7 +152,7 @@ simplify h susList constraintList =
         then simplify h susList cs
         else do
           case (expected', actual') of
-            (m1 :< WT.Pi impArgs1 expArgs1 cod1, m2 :< WT.Pi impArgs2 expArgs2 cod2)
+            (m1 :< WT.Pi _ impArgs1 expArgs1 cod1, m2 :< WT.Pi _ impArgs2 expArgs2 cod2)
               | length impArgs1 == length impArgs2,
                 length expArgs1 == length expArgs2 -> do
                   xt1 <- liftIO $ asWeakBinder h m1 cod1
@@ -430,7 +430,7 @@ getConsArgTypes ::
 getConsArgTypes h m consName = do
   t <- Type.lookup' (typeHandle h) m consName
   case t of
-    _ :< WT.Pi impArgs expArgs _ -> do
+    _ :< WT.Pi _ impArgs expArgs _ -> do
       return $ impArgs ++ expArgs
     _ ->
       raiseCritical m $ "The type of a constructor must be a Π-type, but it's not:\n" <> toText t

--- a/src/Kernel/Elaborate/Move/Internal/Unify.hs
+++ b/src/Kernel/Elaborate/Move/Internal/Unify.hs
@@ -157,7 +157,9 @@ simplify h susList constraintList =
                 length expArgs1 == length expArgs2 -> do
                   xt1 <- liftIO $ asWeakBinder h m1 cod1
                   xt2 <- liftIO $ asWeakBinder h m2 cod2
-                  cs' <- liftIO $ simplifyBinder h orig (impArgs1 ++ expArgs1 ++ [xt1]) (impArgs2 ++ expArgs2 ++ [xt2])
+                  let impBinders1 = map fst impArgs1
+                  let impBinders2 = map fst impArgs2
+                  cs' <- liftIO $ simplifyBinder h orig (impBinders1 ++ expArgs1 ++ [xt1]) (impBinders2 ++ expArgs2 ++ [xt2])
                   simplify h susList $ cs' ++ cs
             (m1 :< WT.PiIntro kind1 impArgs1 expArgs1 e1, m2 :< WT.PiIntro kind2 impArgs2 expArgs2 e2)
               | AttrL.Attr {lamKind = LK.Fix xt1@(_, x1, _)} <- kind1,
@@ -431,7 +433,8 @@ getConsArgTypes h m consName = do
   t <- Type.lookup' (typeHandle h) m consName
   case t of
     _ :< WT.Pi _ impArgs expArgs _ -> do
-      return $ impArgs ++ expArgs
+      let impBinders = map fst impArgs
+      return $ impBinders ++ expArgs
     _ ->
       raiseCritical m $ "The type of a constructor must be a Π-type, but it's not:\n" <> toText t
 

--- a/src/Kernel/Elaborate/Move/Internal/Unify.hs
+++ b/src/Kernel/Elaborate/Move/Internal/Unify.hs
@@ -169,7 +169,7 @@ simplify h susList constraintList =
                 length expArgs1 == length expArgs2 -> do
                   yt1 <- liftIO $ asWeakBinder h m1 e1
                   yt2 <- liftIO $ asWeakBinder h m2 e2
-                  cs' <- liftIO $ simplifyBinder h orig (xt1 : impArgs1 ++ expArgs1 ++ [yt1]) (xt2 : impArgs2 ++ expArgs2 ++ [yt2])
+                  cs' <- liftIO $ simplifyBinder h orig (xt1 : map fst impArgs1 ++ expArgs1 ++ [yt1]) (xt2 : map fst impArgs2 ++ expArgs2 ++ [yt2])
                   simplify h susList $ cs' ++ cs
               | AttrL.Attr {lamKind = LK.Normal _ codType1} <- kind1,
                 AttrL.Attr {lamKind = LK.Normal _ codType2} <- kind2,
@@ -179,7 +179,7 @@ simplify h susList constraintList =
                   xt1 <- liftIO $ asWeakBinder h m1 e1
                   cod2 <- liftIO $ asWeakBinder h m2 codType2
                   xt2 <- liftIO $ asWeakBinder h m2 e2
-                  cs' <- liftIO $ simplifyBinder h orig (impArgs1 ++ expArgs1 ++ [cod1, xt1]) (impArgs2 ++ expArgs2 ++ [cod2, xt2])
+                  cs' <- liftIO $ simplifyBinder h orig (map fst impArgs1 ++ expArgs1 ++ [cod1, xt1]) (map fst impArgs2 ++ expArgs2 ++ [cod2, xt2])
                   simplify h susList $ cs' ++ cs
             (_ :< WT.Data _ name1 es1, _ :< WT.Data _ name2 es2)
               | name1 == name2,

--- a/src/Kernel/Elaborate/Move/Internal/WeakTerm/Fill.hs
+++ b/src/Kernel/Elaborate/Move/Internal/WeakTerm/Fill.hs
@@ -49,7 +49,7 @@ fill h holeSubst term =
       t' <- fill h holeSubst t
       return $ m :< WT.Pi piKind impArgs' expArgs' t'
     m :< WT.PiIntro attr@(AttrL.Attr {lamKind}) impArgs expArgs e -> do
-      impArgs' <- fillBinder h holeSubst impArgs
+      impArgs' <- fillBinderWithMaybeType h holeSubst impArgs
       expArgs' <- fillBinder h holeSubst expArgs
       case lamKind of
         LK.Fix xt -> do

--- a/src/Kernel/Elaborate/Move/Internal/WeakTerm/Fill.hs
+++ b/src/Kernel/Elaborate/Move/Internal/WeakTerm/Fill.hs
@@ -22,6 +22,7 @@ import Language.Common.Rule.LamKind qualified as LK
 import Language.WeakTerm.Move.Reduce qualified as Reduce
 import Language.WeakTerm.Move.Subst qualified as Subst
 import Language.WeakTerm.Rule.WeakTerm qualified as WT
+import Language.Common.Rule.ImpArgs qualified as ImpArgs
 import Language.WeakTerm.Rule.WeakTerm.ToText (toText)
 import Prelude hiding (lookup)
 
@@ -61,7 +62,7 @@ fill h holeSubst term =
           return $ m :< WT.PiIntro attr impArgs' expArgs' e'
     m :< WT.PiElim b e impArgs expArgs -> do
       e' <- fill h holeSubst e
-      impArgs' <- mapM (mapM (fill h holeSubst)) impArgs
+      impArgs' <- ImpArgs.traverseImpArgs (fill h holeSubst) impArgs
       expArgs' <- mapM (fill h holeSubst) expArgs
       return $ m :< WT.PiElim b e' impArgs' expArgs'
     m :< WT.PiElimExact e -> do

--- a/src/Kernel/Elaborate/Move/Internal/WeakTerm/Fill.hs
+++ b/src/Kernel/Elaborate/Move/Internal/WeakTerm/Fill.hs
@@ -43,11 +43,11 @@ fill h holeSubst term =
       return term
     _ :< WT.VarGlobal {} ->
       return term
-    m :< WT.Pi impArgs expArgs t -> do
+    m :< WT.Pi piKind impArgs expArgs t -> do
       impArgs' <- fillBinder h holeSubst impArgs
       expArgs' <- fillBinder h holeSubst expArgs
       t' <- fill h holeSubst t
-      return $ m :< WT.Pi impArgs' expArgs' t'
+      return $ m :< WT.Pi piKind impArgs' expArgs' t'
     m :< WT.PiIntro attr@(AttrL.Attr {lamKind}) impArgs expArgs e -> do
       impArgs' <- fillBinder h holeSubst impArgs
       expArgs' <- fillBinder h holeSubst expArgs

--- a/src/Kernel/Parse/Move/Internal/Discern.hs
+++ b/src/Kernel/Parse/Move/Internal/Discern.hs
@@ -817,7 +817,7 @@ discernBinderWithDefaults h binder endLoc =
       return ([], h)
     ((mx, x, _, _, t), maybeDefault) : xts -> do
       t' <- discern h t
-      maybeDefault' <- traverse (discern h) maybeDefault
+      maybeDefault' <- traverse (discern h {H.nameEnv = []}) maybeDefault -- default values must be closed
       x' <- liftIO $ Gensym.newIdentFromText (H.gensymHandle h) x
       h' <- liftIO $ H.extend' h mx x' VDK.Normal
       (xts', h'') <- discernBinderWithDefaults h' xts endLoc

--- a/src/Kernel/Parse/Move/Internal/Discern.hs
+++ b/src/Kernel/Parse/Move/Internal/Discern.hs
@@ -241,7 +241,8 @@ discern h term =
       (expArgs', h'') <- discernBinder h' (RT.extractArgs expArgs) endLoc
       t' <- discern h'' t
       forM_ (impArgs' ++ expArgs') $ \(_, x, _) -> liftIO (Unused.deleteVariable (H.unusedHandle h'') x)
-      return $ m :< WT.Pi PK.normal impArgs' expArgs' t'
+      let impArgsWithDefaults = map (,Nothing) impArgs'
+      return $ m :< WT.Pi PK.normal impArgsWithDefaults expArgs' t'
     m :< RT.PiIntro _ (RT.RawDef {geist, body, endLoc}) -> do
       lamID <- liftIO $ Gensym.newCount (H.gensymHandle h)
       let (name, _) = RT.name geist

--- a/src/Kernel/Parse/Move/Internal/Discern.hs
+++ b/src/Kernel/Parse/Move/Internal/Discern.hs
@@ -113,7 +113,7 @@ discernStmt h stmt = do
       liftIO $ TopCandidate.insert (H.topCandidateHandle h) $ do
         TopCandidate {loc = metaLocation m, dd = functionName, kind = toCandidateKind stmtKind'}
       liftIO $ forM_ expArgs' $ Tag.insertBinder (H.tagHandle h)
-      return [WeakStmtDefine isConstLike stmtKind' m functionName impArgs' expArgs' codType' body']
+      return [WeakStmtDefine isConstLike stmtKind' m functionName (map (,Nothing) impArgs') expArgs' codType' body']
     PostRawStmtDefineResource _ m (dd, _) (_, discarder) (_, copier) _ -> do
       registerTopLevelName h stmt
       t' <- discern h $ m :< RT.Tau

--- a/src/Kernel/Parse/Move/Internal/Discern.hs
+++ b/src/Kernel/Parse/Move/Internal/Discern.hs
@@ -61,6 +61,7 @@ import Language.Common.Rule.Literal qualified as LI
 import Language.Common.Rule.Magic qualified as M
 import Language.Common.Rule.Noema qualified as N
 import Language.Common.Rule.Opacity qualified as O
+import Language.Common.Rule.PiKind qualified as PK
 import Language.Common.Rule.PrimType qualified as PT
 import Language.Common.Rule.StmtKind qualified as SK
 import Language.Common.Rule.Text.Util
@@ -240,7 +241,7 @@ discern h term =
       (expArgs', h'') <- discernBinder h' (RT.extractArgs expArgs) endLoc
       t' <- discern h'' t
       forM_ (impArgs' ++ expArgs') $ \(_, x, _) -> liftIO (Unused.deleteVariable (H.unusedHandle h'') x)
-      return $ m :< WT.Pi impArgs' expArgs' t'
+      return $ m :< WT.Pi PK.normal impArgs' expArgs' t'
     m :< RT.PiIntro _ (RT.RawDef {geist, body, endLoc}) -> do
       lamID <- liftIO $ Gensym.newCount (H.gensymHandle h)
       let (name, _) = RT.name geist

--- a/src/Kernel/Parse/Move/Internal/Discern/Data.hs
+++ b/src/Kernel/Parse/Move/Internal/Discern/Data.hs
@@ -104,7 +104,7 @@ parseDefineDataConstructor dataType dataName dataArgs consInfoList discriminant 
             if isConstLikeConsInfo consInfo
               then m :< RT.DataIntro attr (name consInfo) dataArgs'' (map fst expConsArgs')
               else
-                RT.genLam (endLoc consInfo) m [] (map (,[]) expConsArgs) dataType $
+                RT.lam (endLoc consInfo) m (map (,[]) expConsArgs) dataType $
                   m :< RT.DataIntro attr (name consInfo) dataArgs'' (map fst expConsArgs')
       let introRule =
             PostRawStmtDefine

--- a/src/Kernel/Parse/Move/Internal/Discern/Data.hs
+++ b/src/Kernel/Parse/Move/Internal/Discern/Data.hs
@@ -26,9 +26,9 @@ defineData ::
 defineData m dataName dataArgsOrNone consInfoList loc = do
   let dataArgs = modifyDataArgs dataArgsOrNone
   let dataArgs' = fromMaybe RT.emptyArgs dataArgsOrNone
+  let consNameList = map (\consInfo -> (name consInfo, isConstLikeConsInfo consInfo)) consInfoList
   let consInfoList' = modifyConsInfo D.zero consInfoList
   let stmtKind = SK.Data dataName dataArgs consInfoList'
-  let consNameList = map (\(_, consName, isConstLike, _, _) -> (consName, isConstLike)) consInfoList'
   let isConstLike = isNothing dataArgsOrNone
   let dataType = constructDataType m dataName isConstLike consNameList dataArgs
   let geist =
@@ -67,8 +67,9 @@ modifyConsInfo d consInfoList =
   case consInfoList of
     [] ->
       []
-    (m, consName, isConstLike, consArgs, _) : rest ->
-      (SavedHint m, consName, isConstLike, SE.extract consArgs, d) : modifyConsInfo (D.increment d) rest
+    consInfo : rest -> do
+      let expArgsExtracted = maybe [] SE.extract (expArgs consInfo)
+      (SavedHint (loc consInfo), name consInfo, isConstLikeConsInfo consInfo, expArgsExtracted, d) : modifyConsInfo (D.increment d) rest
 
 parseDefineDataConstructor ::
   RT.RawTerm ->
@@ -81,31 +82,48 @@ parseDefineDataConstructor dataType dataName dataArgs consInfoList discriminant 
   case consInfoList of
     [] ->
       []
-    (m, consName, isConstLike, consArgs, loc) : rest -> do
+    consInfo : rest -> do
       let dataArgs' = RT.extractArgs dataArgs
-      let consArgs' = SE.extract consArgs
       let dataArgs'' = map identPlusToVar dataArgs'
-      let consArgs'' = map adjustConsArg consArgs'
-      let consNameList = map (\(_, dd, isConstLike', _, _) -> (dd, isConstLike')) consInfoList
-      let geist =
-            RT.RawGeist
-              { loc = m,
-                name = (consName, []),
-                isConstLike = isConstLike,
-                impArgs = let (series, c) = dataArgs in (fmap (,Nothing) series, c),
-                expArgs = (consArgs, []),
-                cod = ([], dataType)
-              }
+      let expConsArgs = maybe [] SE.extract (expArgs consInfo)
+      let expConsArgs' = map adjustExpConsArg expConsArgs
+      let consNameList = map (\ci -> (name ci, isConstLikeConsInfo ci)) consInfoList
+      let m = loc consInfo
+      let attr = AttrDI.Attr {dataName, consNameList, discriminant, isConstLike = isConstLikeConsInfo consInfo}
+      let dataImpArgs = do
+            let (series, c) = dataArgs
+            (fmap (,Nothing) series, c)
+      let consType =
+            if isConstLikeConsInfo consInfo
+              then dataType
+              else do
+                let impArgsWithEmpty = (SE.emptySeriesAC, [])
+                let expArgsWithEmpty = (fromMaybe SE.emptySeriesPC (expArgs consInfo), [])
+                m :< RT.Pi impArgsWithEmpty expArgsWithEmpty [] dataType (endLoc consInfo)
+      let body =
+            if isConstLikeConsInfo consInfo
+              then m :< RT.DataIntro attr (name consInfo) dataArgs'' (map fst expConsArgs')
+              else
+                RT.genLam (endLoc consInfo) m [] (map (,[]) expConsArgs) dataType $
+                  m :< RT.DataIntro attr (name consInfo) dataArgs'' (map fst expConsArgs')
       let introRule =
             PostRawStmtDefine
               []
-              (SK.DataIntro consName dataArgs' consArgs' discriminant)
+              (SK.DataIntro (name consInfo) dataArgs' expConsArgs discriminant)
               ( RT.RawDef
-                  { geist,
+                  { geist =
+                      RT.RawGeist
+                        { loc = loc consInfo,
+                          name = (name consInfo, []),
+                          isConstLike = isConstLikeConsInfo consInfo,
+                          impArgs = dataImpArgs,
+                          expArgs = (SE.emptySeriesPC, []),
+                          cod = ([], consType)
+                        },
                     leadingComment = [],
-                    body = m :< RT.DataIntro (AttrDI.Attr {..}) consName dataArgs'' (map fst consArgs''),
+                    endLoc = endLoc consInfo,
                     trailingComment = [],
-                    endLoc = loc
+                    body = body
                   }
               )
       let introRuleList = parseDefineDataConstructor dataType dataName dataArgs rest (D.increment discriminant)
@@ -125,6 +143,10 @@ identPlusToVar :: RawBinder a -> RT.RawTerm
 identPlusToVar (m, x, _, _, _) =
   m :< RT.Var (Var x)
 
-adjustConsArg :: RawBinder a -> (RT.RawTerm, RawIdent)
-adjustConsArg (m, x, _, _, _) =
+adjustExpConsArg :: RawBinder a -> (RT.RawTerm, RawIdent)
+adjustExpConsArg (m, x, _, _, _) =
   (m :< RT.Var (Var x), x)
+
+isConstLikeConsInfo :: RawConsInfo a -> IsConstLike
+isConstLikeConsInfo consInfo =
+  isNothing (expArgs consInfo)

--- a/src/Kernel/Parse/Move/Internal/Discern/Data.hs
+++ b/src/Kernel/Parse/Move/Internal/Discern/Data.hs
@@ -1,7 +1,5 @@
 module Kernel.Parse.Move.Internal.Discern.Data (defineData) where
 
-import Logger.Rule.Hint
-import SyntaxTree.Rule.Series qualified as SE
 import Control.Comonad.Cofree hiding (section)
 import Data.Maybe
 import Language.Common.Rule.Attr.Data qualified as AttrD
@@ -15,6 +13,8 @@ import Language.RawTerm.Rule.RawBinder
 import Language.RawTerm.Rule.RawIdent
 import Language.RawTerm.Rule.RawStmt
 import Language.RawTerm.Rule.RawTerm qualified as RT
+import Logger.Rule.Hint
+import SyntaxTree.Rule.Series qualified as SE
 
 defineData ::
   Hint ->
@@ -36,7 +36,7 @@ defineData m dataName dataArgsOrNone consInfoList loc = do
           { loc = m,
             name = (dataName, []),
             isConstLike = isConstLike,
-            impArgs = RT.emptyArgs,
+            impArgs = RT.emptyImpArgs,
             expArgs = dataArgs',
             cod = ([], m :< RT.Tau)
           }
@@ -92,7 +92,7 @@ parseDefineDataConstructor dataType dataName dataArgs consInfoList discriminant 
               { loc = m,
                 name = (consName, []),
                 isConstLike = isConstLike,
-                impArgs = dataArgs,
+                impArgs = let (series, c) = dataArgs in (fmap (,Nothing) series, c),
                 expArgs = (consArgs, []),
                 cod = ([], dataType)
               }

--- a/src/Kernel/Parse/Move/Internal/Discern/Name.hs
+++ b/src/Kernel/Parse/Move/Internal/Discern/Name.hs
@@ -138,7 +138,8 @@ interpretGlobalName h m dd gn = do
     GN.DataIntro dataArgNum consArgNum _ isConstLike -> do
       let argNum = AN.add dataArgNum consArgNum
       let attr = AttrVG.Attr {..}
-      let e = m :< WT.VarGlobal attr dd
+      let e = wrapWithExactIfNecessary m dataArgNum $ m :< WT.VarGlobal attr dd
+      -- let e = m :< WT.VarGlobal attr dd
       if isConstLike
         then return $ m :< WT.PiElim False e Nothing []
         else return e
@@ -150,6 +151,12 @@ interpretGlobalName h m dd gn = do
           castFromIntToBool h $ m :< WT.Prim (WP.Value (WPV.Op primOp)) -- i1 to bool
         _ ->
           return $ m :< WT.Prim (WP.Value (WPV.Op primOp))
+
+wrapWithExactIfNecessary :: Hint -> AN.ArgNum -> WT.WeakTerm -> WT.WeakTerm
+wrapWithExactIfNecessary m dataArgNum e =
+  if AN.reify dataArgNum > 0
+    then m :< WT.PiElimExact e
+    else e
 
 interpretTopLevelFunc ::
   Hint ->

--- a/src/Kernel/Parse/Move/Internal/Discern/Name.hs
+++ b/src/Kernel/Parse/Move/Internal/Discern/Name.hs
@@ -33,6 +33,7 @@ import Language.Common.Rule.GlobalLocator qualified as GL
 import Language.Common.Rule.IsConstLike
 import Language.Common.Rule.LocalLocator qualified as LL
 import Language.Common.Rule.Magic qualified as M
+import Language.Common.Rule.PiKind qualified as PK
 import Language.Common.Rule.PrimNumSize qualified as PNS
 import Language.Common.Rule.PrimOp qualified as PO
 import Language.Common.Rule.PrimType qualified as PT
@@ -179,7 +180,7 @@ castFromIntToBool h e@(m :< _) = do
   t <- liftIO $ WT.createHole (H.gensymHandle h) m []
   x1 <- liftIO $ Gensym.newIdentFromText (H.gensymHandle h) "arg"
   x2 <- liftIO $ Gensym.newIdentFromText (H.gensymHandle h) "arg"
-  let cmpOpType cod = m :< WT.Pi [] [(m, x1, t), (m, x2, t)] cod
+  let cmpOpType cod = m :< WT.Pi PK.normal [] [(m, x1, t), (m, x2, t)] cod
   return $ m :< WT.Magic (M.WeakMagic $ M.Cast (cmpOpType i1) (cmpOpType bool) e)
 
 candFilter :: (a, Maybe b) -> Maybe (a, b)

--- a/src/Kernel/Parse/Move/Internal/Discern/Name.hs
+++ b/src/Kernel/Parse/Move/Internal/Discern/Name.hs
@@ -43,6 +43,7 @@ import Language.WeakTerm.Move.CreateHole qualified as WT
 import Language.WeakTerm.Rule.WeakPrim qualified as WP
 import Language.WeakTerm.Rule.WeakPrimValue qualified as WPV
 import Language.WeakTerm.Rule.WeakTerm qualified as WT
+import Language.Common.Rule.ImpArgs qualified as ImpArgs
 import Logger.Rule.Hint
 
 {-# INLINE resolveName #-}
@@ -142,7 +143,7 @@ interpretGlobalName h m dd gn = do
       let e = wrapWithExactIfNecessary m dataArgNum $ m :< WT.VarGlobal attr dd
       -- let e = m :< WT.VarGlobal attr dd
       if isConstLike
-        then return $ m :< WT.PiElim False e Nothing []
+        then return $ m :< WT.PiElim False e ImpArgs.Unspecified []
         else return e
     GN.PrimType primNum ->
       return $ m :< WT.Prim (WP.Type primNum)
@@ -168,7 +169,7 @@ interpretTopLevelFunc ::
 interpretTopLevelFunc m dd argNum isConstLike = do
   let attr = AttrVG.Attr {..}
   if isConstLike
-    then m :< WT.PiElim False (m :< WT.VarGlobal attr dd) Nothing []
+    then m :< WT.PiElim False (m :< WT.VarGlobal attr dd) ImpArgs.Unspecified []
     else m :< WT.VarGlobal attr dd
 
 castFromIntToBool :: H.Handle -> WT.WeakTerm -> EIO WT.WeakTerm

--- a/src/Kernel/Parse/Move/Internal/Handle/NameMap.hs
+++ b/src/Kernel/Parse/Move/Internal/Handle/NameMap.hs
@@ -201,7 +201,8 @@ _getGlobalNames' :: Stmt -> [(DD.DefiniteDescription, (Hint, GN.GlobalName))]
 _getGlobalNames' stmt = do
   case stmt of
     StmtDefine isConstLike stmtKind (SavedHint m) name impArgs expArgs _ _ -> do
-      let allArgNum = AN.fromInt $ length $ impArgs ++ expArgs
+      let impBinders = map fst impArgs
+      let allArgNum = AN.fromInt $ length $ impBinders ++ expArgs
       case stmtKind of
         SK.Normal _ -> do
           [(name, (m, GN.TopLevelFunc allArgNum isConstLike))]

--- a/src/Kernel/Parse/Move/Internal/Handle/NameMap.hs
+++ b/src/Kernel/Parse/Move/Internal/Handle/NameMap.hs
@@ -71,7 +71,7 @@ insert h nameArrowList = do
 registerGeist :: Handle -> RT.RawGeist DD.DefiniteDescription -> EIO ()
 registerGeist h RT.RawGeist {..} = do
   let expArgs' = RT.extractArgs expArgs
-  let impArgs' = RT.extractArgs impArgs
+  let impArgs' = RT.extractImpArgs impArgs
   let argNum = AN.fromInt $ length $ impArgs' ++ expArgs'
   let name' = fst name
   ensureGeistFreshness h loc name'
@@ -170,7 +170,7 @@ _getGlobalNames stmt = do
   case stmt of
     PostRawStmtDefine _ stmtKind (RT.RawDef {geist}) -> do
       let name = fst $ RT.name geist
-      let impArgs = RT.extractArgs $ RT.impArgs geist
+      let impArgs = RT.extractImpArgs $ RT.impArgs geist
       let expArgs = RT.extractArgs $ RT.expArgs geist
       let isConstLike = RT.isConstLike geist
       let m = RT.loc geist

--- a/src/Kernel/Parse/Move/Internal/RawTerm.hs
+++ b/src/Kernel/Parse/Move/Internal/RawTerm.hs
@@ -373,10 +373,12 @@ parseGeist h nameParser = do
   (c2, (cod, c)) <- parseDefInfoCod h m
   return (RT.RawGeist {loc, name = (name', c1), isConstLike, impArgs, expArgs, cod = (c2, cod)}, c)
 
-parseImplicitParams :: Handle -> Parser (SE.Series (RawBinder RT.RawTerm), C)
+parseImplicitParams :: Handle -> Parser (SE.Series (RawBinder RT.RawTerm, Maybe RT.RawTerm), C)
 parseImplicitParams h =
   choice
-    [ seriesAngle $ preBinder h,
+    [ do
+        (s, c) <- seriesAngle $ preBinder h
+        return (fmap (,Nothing) s, c),
       return (SE.emptySeries (Just SE.Angle) SE.Comma, [])
     ]
 

--- a/src/Kernel/Parse/Move/Internal/RawTerm.hs
+++ b/src/Kernel/Parse/Move/Internal/RawTerm.hs
@@ -377,8 +377,8 @@ parseImplicitParams :: Handle -> Parser (SE.Series (RawBinder RT.RawTerm, Maybe 
 parseImplicitParams h =
   choice
     [ do
-        (s, c) <- seriesAngle $ preBinder h
-        return (fmap (,Nothing) s, c),
+        (s, c) <- seriesAngle $ preBinderWithDefault h
+        return (s, c),
       return (SE.emptySeries (Just SE.Angle) SE.Comma, [])
     ]
 
@@ -735,6 +735,17 @@ preBinder h = do
   choice
     [ preAscription h mxc,
       preAscription' h mxc
+    ]
+
+preBinderWithDefault :: Handle -> Parser ((RawBinder RT.RawTerm, Maybe RT.RawTerm), C)
+preBinderWithDefault h = do
+  (binder, c1) <- preBinder h
+  choice
+    [ do
+        c2 <- delimiter ":="
+        (defaultValue, c3) <- rawTerm h
+        return ((binder, Just defaultValue), c1 ++ c2 ++ c3),
+      return ((binder, Nothing), c1)
     ]
 
 preAscription :: Handle -> ((Hint, T.Text), C) -> Parser (RawBinder RT.RawTerm, C)

--- a/src/Kernel/Parse/Move/Internal/RawTerm.hs
+++ b/src/Kernel/Parse/Move/Internal/RawTerm.hs
@@ -11,6 +11,7 @@ module Kernel.Parse.Move.Internal.RawTerm
     parseDefInfoCod,
     typeWithoutIdent,
     parseImplicitParams,
+    parseImplicitParamsMaybe,
     keyword,
     baseName,
   )
@@ -380,6 +381,15 @@ parseImplicitParams h =
         (s, c) <- seriesAngle $ preBinderWithDefault h
         return (s, c),
       return (SE.emptySeries (Just SE.Angle) SE.Comma, [])
+    ]
+
+parseImplicitParamsMaybe :: Handle -> Parser (Maybe (SE.Series (RawBinder RT.RawTerm, Maybe RT.RawTerm)), C)
+parseImplicitParamsMaybe h =
+  choice
+    [ do
+        (s, c) <- seriesAngle $ preBinderWithDefault h
+        return (Just s, c),
+      return (Nothing, [])
     ]
 
 ensureArgumentLinearity :: S.Set RawIdent -> [(Hint, RawIdent)] -> EIO ()

--- a/src/Kernel/Parse/Move/Parse.hs
+++ b/src/Kernel/Parse/Move/Parse.hs
@@ -193,7 +193,7 @@ registerKeyArg' :: Handle -> Stmt -> EIO ()
 registerKeyArg' h stmt = do
   case stmt of
     StmtDefine isConstLike _ (SavedHint m) name impArgs expArgs _ _ -> do
-      let impKeys = map (\(_, x, _) -> toText x) impArgs
+      let impKeys = map (\((_, x, _), _) -> toText x) impArgs
       let expKeys = map (\(_, x, _) -> toText x) expArgs
       KeyArg.insert (keyArgHandle h) m name isConstLike impKeys expKeys
     StmtForeign {} ->

--- a/src/Kernel/Parse/Move/Parse.hs
+++ b/src/Kernel/Parse/Move/Parse.hs
@@ -175,7 +175,7 @@ registerKeyArg h stmt = do
   case stmt of
     PostRawStmtDefine _ _ (RT.RawDef {geist}) -> do
       let name = fst $ RT.name geist
-      let impArgs = RT.extractArgs $ RT.impArgs geist
+      let impArgs = RT.extractImpArgs $ RT.impArgs geist
       let expArgs = RT.extractArgs $ RT.expArgs geist
       let isConstLike = RT.isConstLike geist
       let m = RT.loc geist

--- a/src/Kernel/Parse/Move/Parse.hs
+++ b/src/Kernel/Parse/Move/Parse.hs
@@ -138,14 +138,14 @@ liftStmtKind h stmtKind = do
             let consName' = Locator.attachCurrentLocator h consName
             (m, consName', isConstLike, consArgs, loc)
       SK.Data name' dataArgs (fmap f consInfo)
-    SK.DataIntro name dataArgs consArgs discriminant -> do
+    SK.DataIntro name dataArgs expConsArgs discriminant -> do
       let name' = Locator.attachCurrentLocator h name
-      SK.DataIntro name' dataArgs consArgs discriminant
+      SK.DataIntro name' dataArgs expConsArgs discriminant
 
 liftRawCons :: Locator.Handle -> RawConsInfo BN.BaseName -> RawConsInfo DD.DefiniteDescription
-liftRawCons h (m, name, isConstLike, consArgs, loc) = do
+liftRawCons h (RawConsInfo {loc, name, expArgs, endLoc}) = do
   let name' = Locator.attachCurrentLocator h name
-  (m, name', isConstLike, consArgs, loc)
+  RawConsInfo {loc, name = name', expArgs, endLoc}
 
 registerTopLevelNames ::
   Handle ->
@@ -173,15 +173,20 @@ saveTopLevelNames h source nameArrowList = do
 registerKeyArg :: Handle -> PostRawStmt -> EIO ()
 registerKeyArg h stmt = do
   case stmt of
-    PostRawStmtDefine _ _ (RT.RawDef {geist}) -> do
+    PostRawStmtDefine _ stmtKind (RT.RawDef {geist}) -> do
       let name = fst $ RT.name geist
-      let impArgs = RT.extractImpArgs $ RT.impArgs geist
-      let expArgs = RT.extractArgs $ RT.expArgs geist
       let isConstLike = RT.isConstLike geist
       let m = RT.loc geist
-      let impKeys = map (\(_, x, _, _, _) -> x) impArgs
-      let expKeys = map (\(_, x, _, _, _) -> x) expArgs
-      KeyArg.insert (keyArgHandle h) m name isConstLike impKeys expKeys
+      case stmtKind of
+        SK.DataIntro _ _ expConsArgs _ -> do
+          let expKeys = map (\(_, x, _, _, _) -> x) expConsArgs
+          KeyArg.insert (keyArgHandle h) m name isConstLike [] expKeys
+        _ -> do
+          let impArgs = RT.extractImpArgs $ RT.impArgs geist
+          let expArgs = RT.extractArgs $ RT.expArgs geist
+          let impKeys = map (\(_, x, _, _, _) -> x) impArgs
+          let expKeys = map (\(_, x, _, _, _) -> x) expArgs
+          KeyArg.insert (keyArgHandle h) m name isConstLike impKeys expKeys
     PostRawStmtNominal {} -> do
       return ()
     PostRawStmtDefineResource {} -> do
@@ -192,10 +197,15 @@ registerKeyArg h stmt = do
 registerKeyArg' :: Handle -> Stmt -> EIO ()
 registerKeyArg' h stmt = do
   case stmt of
-    StmtDefine isConstLike _ (SavedHint m) name impArgs expArgs _ _ -> do
-      let impKeys = map (\((_, x, _), _) -> toText x) impArgs
-      let expKeys = map (\(_, x, _) -> toText x) expArgs
-      KeyArg.insert (keyArgHandle h) m name isConstLike impKeys expKeys
+    StmtDefine isConstLike stmtKind (SavedHint m) name impArgs expArgs _ _ -> do
+      case stmtKind of
+        SK.DataIntro _ _ expConsArgs _ -> do
+          let expKeys = map (\(_, x, _) -> toText x) expConsArgs
+          KeyArg.insert (keyArgHandle h) m name isConstLike [] expKeys
+        _ -> do
+          let impKeys = map (\((_, x, _), _) -> toText x) impArgs
+          let expKeys = map (\(_, x, _) -> toText x) expArgs
+          KeyArg.insert (keyArgHandle h) m name isConstLike impKeys expKeys
     StmtForeign {} ->
       return ()
 

--- a/src/Language/Common/Rule/Geist.hs
+++ b/src/Language/Common/Rule/Geist.hs
@@ -9,7 +9,7 @@ data Geist a = Geist
   { loc :: Hint,
     name :: DD.DefiniteDescription,
     isConstLike :: IsConstLike,
-    impArgs :: [(Hint, Ident, a)],
+    impArgs :: [((Hint, Ident, a), Maybe a)],
     expArgs :: [(Hint, Ident, a)],
     cod :: a
   }

--- a/src/Language/Common/Rule/ImpArgs.hs
+++ b/src/Language/Common/Rule/ImpArgs.hs
@@ -1,0 +1,27 @@
+module Language.Common.Rule.ImpArgs
+  ( ImpArgs (..),
+    extract,
+    traverseImpArgs,
+  )
+where
+
+data ImpArgs a
+  = Unspecified
+  | FullySpecified [a]
+  deriving (Eq, Show, Functor, Foldable, Traversable)
+
+extract :: ImpArgs a -> [a]
+extract args =
+  case args of
+    Unspecified ->
+      []
+    FullySpecified xs ->
+      xs
+
+traverseImpArgs :: (Applicative f) => (a -> f b) -> ImpArgs a -> f (ImpArgs b)
+traverseImpArgs f args =
+  case args of
+    Unspecified ->
+      pure Unspecified
+    FullySpecified xs ->
+      FullySpecified <$> traverse f xs

--- a/src/Language/Common/Rule/ImpArgs.hs
+++ b/src/Language/Common/Rule/ImpArgs.hs
@@ -5,9 +5,12 @@ module Language.Common.Rule.ImpArgs
   )
 where
 
+import Data.Maybe (catMaybes)
+
 data ImpArgs a
   = Unspecified
   | FullySpecified [a]
+  | PartiallySpecified [Maybe a]
   deriving (Eq, Show, Functor, Foldable, Traversable)
 
 extract :: ImpArgs a -> [a]
@@ -17,6 +20,8 @@ extract args =
       []
     FullySpecified xs ->
       xs
+    PartiallySpecified xs ->
+      catMaybes xs
 
 traverseImpArgs :: (Applicative f) => (a -> f b) -> ImpArgs a -> f (ImpArgs b)
 traverseImpArgs f args =
@@ -25,3 +30,5 @@ traverseImpArgs f args =
       pure Unspecified
     FullySpecified xs ->
       FullySpecified <$> traverse f xs
+    PartiallySpecified xs ->
+      PartiallySpecified <$> traverse (traverse f) xs

--- a/src/Language/Common/Rule/PiKind.hs
+++ b/src/Language/Common/Rule/PiKind.hs
@@ -1,0 +1,20 @@
+module Language.Common.Rule.PiKind
+  ( PiKind (..),
+    normal,
+  )
+where
+
+import Data.Binary
+import GHC.Generics (Generic)
+import Language.Common.Rule.IsConstLike (IsConstLike)
+
+data PiKind
+  = Normal IsConstLike
+  | DataIntro IsConstLike
+  deriving (Show, Eq, Generic)
+
+instance Binary PiKind
+
+normal :: PiKind
+normal =
+  Normal False

--- a/src/Language/Common/Rule/StmtKind.hs
+++ b/src/Language/Common/Rule/StmtKind.hs
@@ -6,7 +6,6 @@ module Language.Common.Rule.StmtKind
   )
 where
 
-import Logger.Rule.Hint
 import Data.Binary
 import GHC.Generics
 import Language.Common.Rule.Binder
@@ -14,6 +13,7 @@ import Language.Common.Rule.DefiniteDescription qualified as DD
 import Language.Common.Rule.Discriminant qualified as D
 import Language.Common.Rule.IsConstLike
 import Language.Common.Rule.Opacity qualified as O
+import Logger.Rule.Hint
 
 data BaseStmtKind name binder t
   = Normal O.Opacity

--- a/src/Language/RawTerm/Rule/RawStmt.hs
+++ b/src/Language/RawTerm/Rule/RawStmt.hs
@@ -6,7 +6,7 @@ module Language.RawTerm.Rule.RawStmt
     PostRawStmt (..),
     PostRawProgram (..),
     RawStmtKind,
-    RawConsInfo,
+    RawConsInfo (..),
     RawImport (..),
     RawImportItem (..),
     getPostRawStmtName,
@@ -18,19 +18,18 @@ module Language.RawTerm.Rule.RawStmt
   )
 where
 
-import Logger.Rule.Hint
-import SyntaxTree.Rule.C
-import SyntaxTree.Rule.Series qualified as SE
 import Data.Text qualified as T
 import Language.Common.Rule.BaseName qualified as BN
 import Language.Common.Rule.DefiniteDescription qualified as DD
 import Language.Common.Rule.ExternalName qualified as EN
 import Language.Common.Rule.ForeignCodType qualified as F
-import Language.Common.Rule.IsConstLike
 import Language.Common.Rule.LocalLocator qualified as LL
 import Language.Common.Rule.StmtKind qualified as SK
 import Language.RawTerm.Rule.RawBinder
 import Language.RawTerm.Rule.RawTerm qualified as RT
+import Logger.Rule.Hint
+import SyntaxTree.Rule.C
+import SyntaxTree.Rule.Series qualified as SE
 
 data BaseRawProgram a
   = RawProgram Hint [(RawImport, C)] [(BaseRawStmt a, C)]
@@ -38,11 +37,13 @@ data BaseRawProgram a
 type RawProgram =
   BaseRawProgram BN.BaseName
 
--- type PostRawProgram =
---   BaseRawProgram DD.DefiniteDescription
-
-type RawConsInfo a =
-  (Hint, a, IsConstLike, SE.Series (RawBinder RT.RawTerm), Loc)
+data RawConsInfo a
+  = RawConsInfo
+  { loc :: Hint,
+    name :: a,
+    expArgs :: Maybe (SE.Series (RawBinder RT.RawTerm)),
+    endLoc :: Loc
+  }
 
 type RawStmtKind a =
   SK.BaseStmtKind a (RawBinder RT.RawTerm) ()
@@ -75,8 +76,6 @@ type RawStmt =
 data RawImport
   = RawImport C Hint (SE.Series RawImportItem) Loc
 
--- type PostRawStmt =
---   BaseRawStmt DD.DefiniteDescription
 data PostRawProgram
   = PostRawProgram Hint [(RawImport, C)] [PostRawStmt]
 

--- a/src/Language/RawTerm/Rule/RawStmt/ToDoc.hs
+++ b/src/Language/RawTerm/Rule/RawStmt/ToDoc.hs
@@ -1,12 +1,5 @@
 module Language.RawTerm.Rule.RawStmt.ToDoc (pp, ImportInfo (..)) where
 
-import Logger.Rule.Hint
-import PrettyPrinter.Rule.Doc qualified as D
-import PrettyPrinter.Rule.Piece qualified as PI
-import SyntaxTree.Rule.C
-import SyntaxTree.Rule.Series (Series (hasOptionalSeparator))
-import SyntaxTree.Rule.Series qualified as SE
-import SyntaxTree.Rule.Series.ToDoc qualified as SE
 import Control.Monad
 import Data.Bifunctor
 import Data.Text qualified as T
@@ -22,6 +15,13 @@ import Language.RawTerm.Rule.Name qualified as N
 import Language.RawTerm.Rule.RawStmt
 import Language.RawTerm.Rule.RawTerm qualified as RT
 import Language.RawTerm.Rule.RawTerm.ToDoc qualified as RT
+import Logger.Rule.Hint
+import PrettyPrinter.Rule.Doc qualified as D
+import PrettyPrinter.Rule.Piece qualified as PI
+import SyntaxTree.Rule.C
+import SyntaxTree.Rule.Series (Series (hasOptionalSeparator))
+import SyntaxTree.Rule.Series qualified as SE
+import SyntaxTree.Rule.Series.ToDoc qualified as SE
 
 data ImportInfo = ImportInfo
   { presetNames :: [(T.Text, [BN.BaseName])], -- "prelude"
@@ -247,11 +247,9 @@ decDataArgs argsOrNone =
       RT.decodeArgs' args
 
 decConsInfo :: RawConsInfo BN.BaseName -> D.Doc
-decConsInfo (_, consName, isConstLike, args, _) = do
+decConsInfo (RawConsInfo {name = consName, expArgs}) = do
   let consName' = D.text (BN.reify consName)
-  if isConstLike
-    then D.join [consName']
-    else D.join [consName', RT.decodeArgs (args, [])]
+  D.join [consName', RT.decodeArgsMaybe expArgs]
 
 decTopGeist :: RT.TopGeist -> D.Doc
 decTopGeist = do

--- a/src/Language/RawTerm/Rule/RawTerm.hs
+++ b/src/Language/RawTerm/Rule/RawTerm.hs
@@ -20,7 +20,6 @@ module Language.RawTerm.Rule.RawTerm
     extractImpArgs,
     extractImpArgsWithDefaults,
     lam,
-    genLam,
     piElim,
     pushCommentToKeywordClause,
     extractFromKeywordClause,
@@ -200,35 +199,6 @@ lam loc m varList codType e =
                   isConstLike = False,
                   impArgs = (SE.emptySeries (Just SE.Angle) SE.Comma, []),
                   expArgs = (SE.assoc $ SE.fromList SE.Paren SE.Comma varList, []),
-                  cod = ([], codType)
-                },
-            leadingComment = [],
-            body = e,
-            trailingComment = [],
-            endLoc = loc
-          }
-      )
-
-genLam ::
-  Loc ->
-  Hint ->
-  [((RawBinder RawTerm, Maybe RawTerm), C)] ->
-  [(RawBinder RawTerm, C)] ->
-  RawTerm ->
-  RawTerm ->
-  RawTerm
-genLam loc m impParams expParams codType e =
-  m
-    :< PiIntro
-      []
-      ( RawDef
-          { geist =
-              RawGeist
-                { loc = m,
-                  name = (Nothing, []),
-                  isConstLike = False,
-                  impArgs = (SE.assoc $ SE.fromList SE.Paren SE.Comma impParams, []),
-                  expArgs = (SE.assoc $ SE.fromList SE.Paren SE.Comma expParams, []),
                   cod = ([], codType)
                 },
             leadingComment = [],

--- a/src/Language/RawTerm/Rule/RawTerm.hs
+++ b/src/Language/RawTerm/Rule/RawTerm.hs
@@ -20,6 +20,7 @@ module Language.RawTerm.Rule.RawTerm
     extractImpArgs,
     extractImpArgsWithDefaults,
     lam,
+    genLam,
     piElim,
     pushCommentToKeywordClause,
     extractFromKeywordClause,
@@ -199,6 +200,35 @@ lam loc m varList codType e =
                   isConstLike = False,
                   impArgs = (SE.emptySeries (Just SE.Angle) SE.Comma, []),
                   expArgs = (SE.assoc $ SE.fromList SE.Paren SE.Comma varList, []),
+                  cod = ([], codType)
+                },
+            leadingComment = [],
+            body = e,
+            trailingComment = [],
+            endLoc = loc
+          }
+      )
+
+genLam ::
+  Loc ->
+  Hint ->
+  [((RawBinder RawTerm, Maybe RawTerm), C)] ->
+  [(RawBinder RawTerm, C)] ->
+  RawTerm ->
+  RawTerm ->
+  RawTerm
+genLam loc m impParams expParams codType e =
+  m
+    :< PiIntro
+      []
+      ( RawDef
+          { geist =
+              RawGeist
+                { loc = m,
+                  name = (Nothing, []),
+                  isConstLike = False,
+                  impArgs = (SE.assoc $ SE.fromList SE.Paren SE.Comma impParams, []),
+                  expArgs = (SE.assoc $ SE.fromList SE.Paren SE.Comma expParams, []),
                   cod = ([], codType)
                 },
             leadingComment = [],

--- a/src/Language/RawTerm/Rule/RawTerm.hs
+++ b/src/Language/RawTerm/Rule/RawTerm.hs
@@ -15,7 +15,10 @@ module Language.RawTerm.Rule.RawTerm
     VarArg,
     getDefName,
     emptyArgs,
+    emptyImpArgs,
     extractArgs,
+    extractImpArgs,
+    extractImpArgsWithDefaults,
     lam,
     piElim,
     pushCommentToKeywordClause,
@@ -56,7 +59,7 @@ type RawTerm = Cofree RawTermF Hint
 data RawTermF a
   = Tau
   | Var Name
-  | Pi (Args a) (Args a) C a Loc
+  | Pi (SE.Series (RawBinder a, Maybe a), C) (Args a) C a Loc
   | PiIntro C FuncInfo
   | PiIntroFix C DefInfo
   | PiElim a C (Maybe (SE.Series a)) (SE.Series a)
@@ -107,8 +110,20 @@ emptyArgs :: Args a
 emptyArgs =
   (SE.emptySeriesPC, [])
 
+emptyImpArgs :: (SE.Series (RawBinder a, Maybe a), C)
+emptyImpArgs =
+  (SE.emptySeriesPC, [])
+
 extractArgs :: Args a -> [RawBinder a]
 extractArgs (series, _) =
+  SE.extract series
+
+extractImpArgs :: (SE.Series (RawBinder a, Maybe a), C) -> [RawBinder a]
+extractImpArgs (series, _) =
+  map fst $ SE.extract series
+
+extractImpArgsWithDefaults :: (SE.Series (RawBinder a, Maybe a), C) -> [(RawBinder a, Maybe a)]
+extractImpArgsWithDefaults (series, _) =
   SE.extract series
 
 type KeywordClause a =
@@ -130,7 +145,7 @@ data RawGeist a = RawGeist
   { loc :: Hint,
     name :: (a, C),
     isConstLike :: IsConstLike,
-    impArgs :: Args RawTerm,
+    impArgs :: (SE.Series (RawBinder RawTerm, Maybe RawTerm), C),
     expArgs :: Args RawTerm,
     cod :: (C, RawTerm)
   }

--- a/src/Language/RawTerm/Rule/RawTerm/ToDoc.hs
+++ b/src/Language/RawTerm/Rule/RawTerm/ToDoc.hs
@@ -52,7 +52,7 @@ toDoc term =
       nameToDoc varOrLocator
     _ :< Pi (impArgs, c1) (expArgs, c2) c cod _ -> do
       PI.arrange
-        [ PI.container $ decodeImpParams impArgs,
+        [ PI.container $ decodeImpParams (fmap fst impArgs),
           PI.container $ attachComment c1 $ SE.decode $ fmap piArgToDoc expArgs,
           PI.delimiter $ attachComment c2 $ D.text "->",
           PI.inject $ attachComment c $ toDoc cod
@@ -456,13 +456,13 @@ decGeist
       _ :< RT.Hole {} ->
         PI.arrange
           [ PI.inject $ attachComment c0 $ nameDecoder name,
-            PI.inject $ decodeImpParams impArgs,
+            PI.inject $ decodeImpParams (fmap fst impArgs),
             PI.inject $ attachComment c1 $ decodeExpParams isConstLike expArgs
           ]
       _ ->
         PI.arrange
           [ PI.inject $ attachComment c0 $ nameDecoder name,
-            PI.inject $ decodeImpParams impArgs,
+            PI.inject $ decodeImpParams (fmap fst impArgs),
             PI.inject $ attachComment c1 $ decodeExpParams isConstLike expArgs,
             PI.horizontal $ attachComment c2 $ D.text ":",
             PI.inject $ attachComment c3 $ toDoc cod

--- a/src/Language/Term/Move/Inline.hs
+++ b/src/Language/Term/Move/Inline.hs
@@ -81,7 +81,10 @@ inline' h term = do
     _ :< TM.VarGlobal {} ->
       return term
     m :< TM.Pi piKind impArgs expArgs cod -> do
-      impArgs' <- mapM (inlineBinder h) impArgs
+      impArgs' <- mapM (\(binder, maybeType) -> do
+        binder' <- inlineBinder h binder
+        maybeType' <- traverse (inline' h) maybeType
+        return (binder', maybeType')) impArgs
       expArgs' <- mapM (inlineBinder h) expArgs
       cod' <- inline' h cod
       return (m :< TM.Pi piKind impArgs' expArgs' cod')

--- a/src/Language/Term/Move/Inline.hs
+++ b/src/Language/Term/Move/Inline.hs
@@ -102,41 +102,44 @@ inline' h term = do
         LK.Normal mName codType -> do
           codType' <- inline' h codType
           return (m :< TM.PiIntro (attr {AttrL.lamKind = LK.Normal mName codType'}) impArgs' expArgs' e')
-    m :< TM.PiElim isNoetic e es -> do
+    m :< TM.PiElim isNoetic e impArgs expArgs -> do
       e' <- inline' h e
-      es' <- mapM (inline' h) es
+      impArgs' <- mapM (inline' h) impArgs
+      expArgs' <- mapM (inline' h) expArgs
       if isNoetic
-        then return $ m :< TM.PiElim isNoetic e' es'
+        then return $ m :< TM.PiElim isNoetic e' impArgs' expArgs'
         else do
           let Handle {dmap} = h
           case e' of
-            (_ :< TM.PiIntro (AttrL.Attr {lamKind = LK.Normal {}}) impArgs expArgs body)
-              | xts <- map fst impArgs ++ expArgs,
-                length xts == length es' -> do
-                  if all TM.isValue es'
+            (_ :< TM.PiIntro (AttrL.Attr {lamKind = LK.Normal {}}) impArgsBinder expArgsBinder body)
+              | xts <- map fst impArgsBinder ++ expArgsBinder,
+                length xts == length (impArgs' ++ expArgs') -> do
+                  let allArgs = impArgs' ++ expArgs'
+                  if all TM.isValue allArgs
                     then do
                       let (_, xs, _) = unzip3 xts
-                      let sub = IntMap.fromList $ zip (map Ident.toInt xs) (map Right es')
+                      let sub = IntMap.fromList $ zip (map Ident.toInt xs) (map Right allArgs)
                       _ :< body' <- liftIO $ Subst.subst (substHandle h) sub body
                       inline' h $ m :< body'
                     else do
                       (xts', _ :< body') <- liftIO $ Subst.subst' (substHandle h) IntMap.empty xts body
-                      inline' h $ bind (zip xts' es') (m :< body')
+                      inline' h $ bind (zip xts' allArgs) (m :< body')
             (_ :< TM.VarGlobal _ dd)
               | Just (xts, body) <- Map.lookup dd dmap -> do
-                  if all TM.isValue es'
+                  let allArgs = impArgs' ++ expArgs'
+                  if all TM.isValue allArgs
                     then do
                       let (_, xs, _) = unzip3 xts
-                      let sub = IntMap.fromList $ zip (map Ident.toInt xs) (map Right es')
+                      let sub = IntMap.fromList $ zip (map Ident.toInt xs) (map Right allArgs)
                       _ :< body' <- liftIO $ Subst.subst (substHandle h) sub body
                       body'' <- liftIO $ Refresh.refresh (refreshHandle h) $ m :< body'
                       inline' h body''
                     else do
                       (xts', _ :< body') <- liftIO $ Subst.subst' (substHandle h) IntMap.empty xts body
                       body'' <- liftIO $ Refresh.refresh (refreshHandle h) $ m :< body'
-                      inline' h $ bind (zip xts' es') body''
+                      inline' h $ bind (zip xts' allArgs) body''
             _ ->
-              return (m :< TM.PiElim isNoetic e' es')
+              return (m :< TM.PiElim isNoetic e' impArgs' expArgs')
     m :< TM.Data attr name es -> do
       es' <- mapM (inline' h) es
       return $ m :< TM.Data attr name es'

--- a/src/Language/Term/Move/Inline.hs
+++ b/src/Language/Term/Move/Inline.hs
@@ -80,11 +80,11 @@ inline' h term = do
       return term
     _ :< TM.VarGlobal {} ->
       return term
-    m :< TM.Pi impArgs expArgs cod -> do
+    m :< TM.Pi piKind impArgs expArgs cod -> do
       impArgs' <- mapM (inlineBinder h) impArgs
       expArgs' <- mapM (inlineBinder h) expArgs
       cod' <- inline' h cod
-      return (m :< TM.Pi impArgs' expArgs' cod')
+      return (m :< TM.Pi piKind impArgs' expArgs' cod')
     m :< TM.PiIntro attr@(AttrL.Attr {lamKind}) impArgs expArgs e -> do
       impArgs' <- mapM (inlineBinder h) impArgs
       expArgs' <- mapM (inlineBinder h) expArgs

--- a/src/Language/Term/Move/Refresh.hs
+++ b/src/Language/Term/Move/Refresh.hs
@@ -41,14 +41,14 @@ refresh h term =
       newLamID <- liftIO $ Gensym.newCount (gensymHandle h)
       case lamKind of
         LK.Fix xt -> do
-          impArgs' <- refreshBinder h impArgs
+          impArgs' <- refreshBinderWithMaybeType h impArgs
           expArgs' <- refreshBinder h expArgs
           [xt'] <- refreshBinder h [xt]
           e' <- refresh h e
           let fixAttr = AttrL.Attr {lamKind = LK.Fix xt', identity = newLamID}
           return (m :< TM.PiIntro fixAttr impArgs' expArgs' e')
         LK.Normal name codType -> do
-          impArgs' <- refreshBinder h impArgs
+          impArgs' <- refreshBinderWithMaybeType h impArgs
           expArgs' <- refreshBinder h expArgs
           codType' <- refresh h codType
           e' <- refresh h e

--- a/src/Language/Term/Move/Refresh.hs
+++ b/src/Language/Term/Move/Refresh.hs
@@ -54,10 +54,11 @@ refresh h term =
           e' <- refresh h e
           let lamAttr = AttrL.Attr {lamKind = LK.Normal name codType', identity = newLamID}
           return (m :< TM.PiIntro lamAttr impArgs' expArgs' e')
-    m :< TM.PiElim b e es -> do
+    m :< TM.PiElim b e impArgs expArgs -> do
       e' <- refresh h e
-      es' <- mapM (refresh h) es
-      return (m :< TM.PiElim b e' es')
+      impArgs' <- mapM (refresh h) impArgs
+      expArgs' <- mapM (refresh h) expArgs
+      return (m :< TM.PiElim b e' impArgs' expArgs')
     m :< TM.Data attr name es -> do
       es' <- mapM (refresh h) es
       return $ m :< TM.Data attr name es'

--- a/src/Language/Term/Move/Refresh.hs
+++ b/src/Language/Term/Move/Refresh.hs
@@ -32,11 +32,11 @@ refresh h term =
       return term
     _ :< TM.VarGlobal {} ->
       return term
-    m :< TM.Pi impArgs expArgs t -> do
+    m :< TM.Pi piKind impArgs expArgs t -> do
       impArgs' <- refreshBinder h impArgs
       expArgs' <- refreshBinder h expArgs
       t' <- refresh h t
-      return (m :< TM.Pi impArgs' expArgs' t')
+      return (m :< TM.Pi piKind impArgs' expArgs' t')
     m :< TM.PiIntro (AttrL.Attr {lamKind}) impArgs expArgs e -> do
       newLamID <- liftIO $ Gensym.newCount (gensymHandle h)
       case lamKind of

--- a/src/Language/Term/Move/Subst.hs
+++ b/src/Language/Term/Move/Subst.hs
@@ -79,10 +79,11 @@ subst h sub term =
               e' <- subst h sub'' e
               let lamAttr = AttrL.Attr {lamKind = LK.Normal name codType', identity = newLamID}
               return (m :< TM.PiIntro lamAttr impArgs' expArgs' e')
-    m :< TM.PiElim b e es -> do
+    m :< TM.PiElim b e impArgs expArgs -> do
       e' <- subst h sub e
-      es' <- mapM (subst h sub) es
-      return (m :< TM.PiElim b e' es')
+      impArgs' <- mapM (subst h sub) impArgs
+      expArgs' <- mapM (subst h sub) expArgs
+      return (m :< TM.PiElim b e' impArgs' expArgs')
     m :< TM.Data attr name es -> do
       es' <- mapM (subst h sub) es
       return $ m :< TM.Data attr name es'

--- a/src/Language/Term/Move/Subst.hs
+++ b/src/Language/Term/Move/Subst.hs
@@ -52,11 +52,11 @@ subst h sub term =
           return term
     _ :< TM.VarGlobal {} ->
       return term
-    m :< TM.Pi impArgs expArgs t -> do
+    m :< TM.Pi piKind impArgs expArgs t -> do
       (impArgs', sub') <- substBinder h sub impArgs
       (expArgs', sub'') <- substBinder h sub' expArgs
       t' <- subst h sub'' t
-      return (m :< TM.Pi impArgs' expArgs' t')
+      return (m :< TM.Pi piKind impArgs' expArgs' t')
     m :< TM.PiIntro (AttrL.Attr {lamKind}) impArgs expArgs e -> do
       let fvs = S.map Ident.toInt $ TM.freeVars term
       let subDomSet = S.fromList $ IntMap.keys sub

--- a/src/Language/Term/Rule/Stmt.hs
+++ b/src/Language/Term/Rule/Stmt.hs
@@ -29,7 +29,7 @@ data StmtF a
       (SK.StmtKind a)
       SavedHint
       DD.DefiniteDescription
-      [BinderF a]
+      [(BinderF a, Maybe a)]
       [BinderF a]
       a
       a

--- a/src/Language/Term/Rule/Term.hs
+++ b/src/Language/Term/Rule/Term.hs
@@ -38,7 +38,7 @@ data TermF a
   = Tau
   | Var Ident
   | VarGlobal AttrVG.Attr DD.DefiniteDescription
-  | Pi PiKind [BinderF a] [BinderF a] a
+  | Pi PiKind [(BinderF a, Maybe a)] [BinderF a] a
   | PiIntro (AttrL.Attr a) [BinderF a] [BinderF a] a
   | PiElim N.IsNoetic a [a]
   | Data (AttrD.Attr DD.DefiniteDescription) DD.DefiniteDescription [a]

--- a/src/Language/Term/Rule/Term.hs
+++ b/src/Language/Term/Rule/Term.hs
@@ -39,7 +39,7 @@ data TermF a
   | Var Ident
   | VarGlobal AttrVG.Attr DD.DefiniteDescription
   | Pi PiKind [(BinderF a, Maybe a)] [BinderF a] a
-  | PiIntro (AttrL.Attr a) [BinderF a] [BinderF a] a
+  | PiIntro (AttrL.Attr a) [(BinderF a, Maybe a)] [BinderF a] a
   | PiElim N.IsNoetic a [a]
   | Data (AttrD.Attr DD.DefiniteDescription) DD.DefiniteDescription [a]
   | DataIntro (AttrDI.Attr DD.DefiniteDescription) DD.DefiniteDescription [a] [a] -- (consName, dataArgs, consArgs)

--- a/src/Language/Term/Rule/Term.hs
+++ b/src/Language/Term/Rule/Term.hs
@@ -26,6 +26,7 @@ import Language.Common.Rule.Ident.Reify
 import Language.Common.Rule.Magic
 import Language.Common.Rule.Noema qualified as N
 import Language.Common.Rule.Opacity qualified as O
+import Language.Common.Rule.PiKind (PiKind)
 import Language.Term.Rule.Prim qualified as P
 import Logger.Rule.Hint
 
@@ -37,7 +38,7 @@ data TermF a
   = Tau
   | Var Ident
   | VarGlobal AttrVG.Attr DD.DefiniteDescription
-  | Pi [BinderF a] [BinderF a] a
+  | Pi PiKind [BinderF a] [BinderF a] a
   | PiIntro (AttrL.Attr a) [BinderF a] [BinderF a] a
   | PiElim N.IsNoetic a [a]
   | Data (AttrD.Attr DD.DefiniteDescription) DD.DefiniteDescription [a]

--- a/src/Language/Term/Rule/Term.hs
+++ b/src/Language/Term/Rule/Term.hs
@@ -40,7 +40,7 @@ data TermF a
   | VarGlobal AttrVG.Attr DD.DefiniteDescription
   | Pi PiKind [(BinderF a, Maybe a)] [BinderF a] a
   | PiIntro (AttrL.Attr a) [(BinderF a, Maybe a)] [BinderF a] a
-  | PiElim N.IsNoetic a [a]
+  | PiElim N.IsNoetic a [a] [a]
   | Data (AttrD.Attr DD.DefiniteDescription) DD.DefiniteDescription [a]
   | DataIntro (AttrDI.Attr DD.DefiniteDescription) DD.DefiniteDescription [a] [a] -- (consName, dataArgs, consArgs)
   | DataElim N.IsNoetic [(Ident, a, a)] (DT.DecisionTree a)

--- a/src/Language/Term/Rule/Term/Chain.hs
+++ b/src/Language/Term/Rule/Term/Chain.hs
@@ -36,7 +36,7 @@ chainOf' tenv term =
     _ :< TM.Pi {} ->
       []
     _ :< TM.PiIntro attr impArgs expArgs e ->
-      chainOfBinder tenv (impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr attr]) [e]
+      chainOfBinder tenv (map fst impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr attr]) [e]
     _ :< TM.PiElim _ e es -> do
       let xs1 = chainOf' tenv e
       let xs2 = concatMap (chainOf' tenv) es

--- a/src/Language/Term/Rule/Term/Chain.hs
+++ b/src/Language/Term/Rule/Term/Chain.hs
@@ -37,10 +37,11 @@ chainOf' tenv term =
       []
     _ :< TM.PiIntro attr impArgs expArgs e ->
       chainOfBinder tenv (map fst impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr attr]) [e]
-    _ :< TM.PiElim _ e es -> do
+    _ :< TM.PiElim _ e impArgs expArgs -> do
       let xs1 = chainOf' tenv e
-      let xs2 = concatMap (chainOf' tenv) es
-      xs1 ++ xs2
+      let xs2 = concatMap (chainOf' tenv) impArgs
+      let xs3 = concatMap (chainOf' tenv) expArgs
+      xs1 ++ xs2 ++ xs3
     _ :< TM.Data _ _ es ->
       concatMap (chainOf' tenv) es
     _ :< TM.DataIntro _ _ dataArgs consArgs ->

--- a/src/Language/Term/Rule/Term/Compress.hs
+++ b/src/Language/Term/Rule/Term/Compress.hs
@@ -27,7 +27,7 @@ compress term =
       () :< TM.Pi piKind (map (bimap compressBinder (fmap compress)) impArgs) (map compressBinder expArgs) (compress t)
     _ :< TM.PiIntro attr impArgs expArgs e -> do
       let attr' = compressAttr attr
-      let impArgs' = map compressBinder impArgs
+      let impArgs' = map (bimap compressBinder (fmap compress)) impArgs
       let expArgs' = map compressBinder expArgs
       let e' = compress e
       () :< TM.PiIntro attr' impArgs' expArgs' e'

--- a/src/Language/Term/Rule/Term/Compress.hs
+++ b/src/Language/Term/Rule/Term/Compress.hs
@@ -24,7 +24,7 @@ compress term =
     _ :< TM.VarGlobal g argNum ->
       () :< TM.VarGlobal g argNum
     _ :< TM.Pi piKind impArgs expArgs t ->
-      () :< TM.Pi piKind (map compressBinder impArgs) (map compressBinder expArgs) (compress t)
+      () :< TM.Pi piKind (map (bimap compressBinder (fmap compress)) impArgs) (map compressBinder expArgs) (compress t)
     _ :< TM.PiIntro attr impArgs expArgs e -> do
       let attr' = compressAttr attr
       let impArgs' = map compressBinder impArgs

--- a/src/Language/Term/Rule/Term/Compress.hs
+++ b/src/Language/Term/Rule/Term/Compress.hs
@@ -157,7 +157,7 @@ compressStmtKind stmtKind =
       let consArgsList' = map (map compressBinder) consArgsList
       let consInfoList' = zip5 hintList consNameList constLikeList consArgsList' discriminantList
       Data dataName dataArgs' consInfoList'
-    DataIntro dataName dataArgs consArgs discriminant -> do
+    DataIntro dataName dataArgs expConsArgs discriminant -> do
       let dataArgs' = map compressBinder dataArgs
-      let consArgs' = map compressBinder consArgs
-      DataIntro dataName dataArgs' consArgs' discriminant
+      let expConsArgs' = map compressBinder expConsArgs
+      DataIntro dataName dataArgs' expConsArgs' discriminant

--- a/src/Language/Term/Rule/Term/Compress.hs
+++ b/src/Language/Term/Rule/Term/Compress.hs
@@ -23,8 +23,8 @@ compress term =
       () :< TM.Var x
     _ :< TM.VarGlobal g argNum ->
       () :< TM.VarGlobal g argNum
-    _ :< TM.Pi impArgs expArgs t ->
-      () :< TM.Pi (map compressBinder impArgs) (map compressBinder expArgs) (compress t)
+    _ :< TM.Pi piKind impArgs expArgs t ->
+      () :< TM.Pi piKind (map compressBinder impArgs) (map compressBinder expArgs) (compress t)
     _ :< TM.PiIntro attr impArgs expArgs e -> do
       let attr' = compressAttr attr
       let impArgs' = map compressBinder impArgs

--- a/src/Language/Term/Rule/Term/Compress.hs
+++ b/src/Language/Term/Rule/Term/Compress.hs
@@ -31,10 +31,11 @@ compress term =
       let expArgs' = map compressBinder expArgs
       let e' = compress e
       () :< TM.PiIntro attr' impArgs' expArgs' e'
-    _ :< TM.PiElim b e es -> do
+    _ :< TM.PiElim b e impArgs expArgs -> do
       let e' = compress e
-      let es' = map compress es
-      () :< TM.PiElim b e' es'
+      let impArgs' = map compress impArgs
+      let expArgs' = map compress expArgs
+      () :< TM.PiElim b e' impArgs' expArgs'
     _ :< TM.Data attr name es -> do
       let es' = map compress es
       () :< TM.Data attr name es'

--- a/src/Language/Term/Rule/Term/Extend.hs
+++ b/src/Language/Term/Rule/Term/Extend.hs
@@ -36,10 +36,11 @@ extend term =
       let expArgs' = map extendBinder expArgs
       let e' = extend e
       _m :< TM.PiIntro attr' impArgs' expArgs' e'
-    _ :< TM.PiElim b e es -> do
+    _ :< TM.PiElim b e impArgs expArgs -> do
       let e' = extend e
-      let es' = map extend es
-      _m :< TM.PiElim b e' es'
+      let impArgs' = map extend impArgs
+      let expArgs' = map extend expArgs
+      _m :< TM.PiElim b e' impArgs' expArgs'
     _ :< TM.Data attr name es -> do
       let es' = map extend es
       _m :< TM.Data attr name es'

--- a/src/Language/Term/Rule/Term/Extend.hs
+++ b/src/Language/Term/Rule/Term/Extend.hs
@@ -29,7 +29,7 @@ extend term =
     _ :< TM.VarGlobal g argNum ->
       _m :< TM.VarGlobal g argNum
     _ :< TM.Pi piKind impArgs expArgs t ->
-      _m :< TM.Pi piKind (map extendBinder impArgs) (map extendBinder expArgs) (extend t)
+      _m :< TM.Pi piKind (map (bimap extendBinder (fmap extend)) impArgs) (map extendBinder expArgs) (extend t)
     _ :< TM.PiIntro attr impArgs expArgs e -> do
       let attr' = extendAttr attr
       let impArgs' = map extendBinder impArgs

--- a/src/Language/Term/Rule/Term/Extend.hs
+++ b/src/Language/Term/Rule/Term/Extend.hs
@@ -32,7 +32,7 @@ extend term =
       _m :< TM.Pi piKind (map (bimap extendBinder (fmap extend)) impArgs) (map extendBinder expArgs) (extend t)
     _ :< TM.PiIntro attr impArgs expArgs e -> do
       let attr' = extendAttr attr
-      let impArgs' = map extendBinder impArgs
+      let impArgs' = map (bimap extendBinder (fmap extend)) impArgs
       let expArgs' = map extendBinder expArgs
       let e' = extend e
       _m :< TM.PiIntro attr' impArgs' expArgs' e'

--- a/src/Language/Term/Rule/Term/Extend.hs
+++ b/src/Language/Term/Rule/Term/Extend.hs
@@ -164,7 +164,7 @@ extendStmtKind stmtKind =
       let consArgsList' = map (map extendBinder) consArgsList
       let consInfoList' = zip5 hintList consNameList constLikeList consArgsList' discriminantList
       Data dataName dataArgs' consInfoList'
-    DataIntro dataName dataArgs consArgs discriminant -> do
+    DataIntro dataName dataArgs expConsArgs discriminant -> do
       let dataArgs' = map extendBinder dataArgs
-      let consArgs' = map extendBinder consArgs
-      DataIntro dataName dataArgs' consArgs' discriminant
+      let expConsArgs' = map extendBinder expConsArgs
+      DataIntro dataName dataArgs' expConsArgs' discriminant

--- a/src/Language/Term/Rule/Term/Extend.hs
+++ b/src/Language/Term/Rule/Term/Extend.hs
@@ -28,8 +28,8 @@ extend term =
       _m :< TM.Var x
     _ :< TM.VarGlobal g argNum ->
       _m :< TM.VarGlobal g argNum
-    _ :< TM.Pi impArgs expArgs t ->
-      _m :< TM.Pi (map extendBinder impArgs) (map extendBinder expArgs) (extend t)
+    _ :< TM.Pi piKind impArgs expArgs t ->
+      _m :< TM.Pi piKind (map extendBinder impArgs) (map extendBinder expArgs) (extend t)
     _ :< TM.PiIntro attr impArgs expArgs e -> do
       let attr' = extendAttr attr
       let impArgs' = map extendBinder impArgs

--- a/src/Language/Term/Rule/Term/FreeVars.hs
+++ b/src/Language/Term/Rule/Term/FreeVars.hs
@@ -25,10 +25,11 @@ freeVars term =
       freeVars' (impBinders ++ expArgs) (freeVars t)
     _ :< TM.PiIntro k impArgs expArgs e ->
       freeVars' (map fst impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVars e)
-    _ :< TM.PiElim _ e es -> do
+    _ :< TM.PiElim _ e impArgs expArgs -> do
       let xs = freeVars e
-      let ys = S.unions $ map freeVars es
-      S.union xs ys
+      let ys1 = S.unions $ map freeVars impArgs
+      let ys2 = S.unions $ map freeVars expArgs
+      S.unions [xs, ys1, ys2]
     _ :< TM.Data _ _ es ->
       S.unions $ map freeVars es
     _ :< TM.DataIntro _ _ dataArgs consArgs -> do

--- a/src/Language/Term/Rule/Term/FreeVars.hs
+++ b/src/Language/Term/Rule/Term/FreeVars.hs
@@ -20,7 +20,7 @@ freeVars term =
       S.singleton x
     _ :< TM.VarGlobal {} ->
       S.empty
-    _ :< TM.Pi impArgs expArgs t ->
+    _ :< TM.Pi _ impArgs expArgs t ->
       freeVars' (impArgs ++ expArgs) (freeVars t)
     _ :< TM.PiIntro k impArgs expArgs e ->
       freeVars' (impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVars e)

--- a/src/Language/Term/Rule/Term/FreeVars.hs
+++ b/src/Language/Term/Rule/Term/FreeVars.hs
@@ -20,8 +20,9 @@ freeVars term =
       S.singleton x
     _ :< TM.VarGlobal {} ->
       S.empty
-    _ :< TM.Pi _ impArgs expArgs t ->
-      freeVars' (impArgs ++ expArgs) (freeVars t)
+    _ :< TM.Pi _ impArgs expArgs t -> do
+      let impBinders = map fst impArgs
+      freeVars' (impBinders ++ expArgs) (freeVars t)
     _ :< TM.PiIntro k impArgs expArgs e ->
       freeVars' (impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVars e)
     _ :< TM.PiElim _ e es -> do

--- a/src/Language/Term/Rule/Term/FreeVars.hs
+++ b/src/Language/Term/Rule/Term/FreeVars.hs
@@ -24,7 +24,7 @@ freeVars term =
       let impBinders = map fst impArgs
       freeVars' (impBinders ++ expArgs) (freeVars t)
     _ :< TM.PiIntro k impArgs expArgs e ->
-      freeVars' (impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVars e)
+      freeVars' (map fst impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVars e)
     _ :< TM.PiElim _ e es -> do
       let xs = freeVars e
       let ys = S.unions $ map freeVars es

--- a/src/Language/Term/Rule/Term/FreeVarsWithHints.hs
+++ b/src/Language/Term/Rule/Term/FreeVarsWithHints.hs
@@ -21,8 +21,9 @@ freeVarsWithHints term =
       S.singleton (m, x)
     _ :< TM.VarGlobal {} ->
       S.empty
-    _ :< TM.Pi _ impArgs expArgs t ->
-      freeVarsWithHints' (impArgs ++ expArgs) (freeVarsWithHints t)
+    _ :< TM.Pi _ impArgs expArgs t -> do
+      let impBinders = map fst impArgs
+      freeVarsWithHints' (impBinders ++ expArgs) (freeVarsWithHints t)
     _ :< TM.PiIntro k impArgs expArgs e ->
       freeVarsWithHints' (impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVarsWithHints e)
     _ :< TM.PiElim _ e es -> do

--- a/src/Language/Term/Rule/Term/FreeVarsWithHints.hs
+++ b/src/Language/Term/Rule/Term/FreeVarsWithHints.hs
@@ -25,7 +25,7 @@ freeVarsWithHints term =
       let impBinders = map fst impArgs
       freeVarsWithHints' (impBinders ++ expArgs) (freeVarsWithHints t)
     _ :< TM.PiIntro k impArgs expArgs e ->
-      freeVarsWithHints' (impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVarsWithHints e)
+      freeVarsWithHints' (map fst impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVarsWithHints e)
     _ :< TM.PiElim _ e es -> do
       let xs = freeVarsWithHints e
       let ys = S.unions $ map freeVarsWithHints es

--- a/src/Language/Term/Rule/Term/FreeVarsWithHints.hs
+++ b/src/Language/Term/Rule/Term/FreeVarsWithHints.hs
@@ -21,7 +21,7 @@ freeVarsWithHints term =
       S.singleton (m, x)
     _ :< TM.VarGlobal {} ->
       S.empty
-    _ :< TM.Pi impArgs expArgs t ->
+    _ :< TM.Pi _ impArgs expArgs t ->
       freeVarsWithHints' (impArgs ++ expArgs) (freeVarsWithHints t)
     _ :< TM.PiIntro k impArgs expArgs e ->
       freeVarsWithHints' (impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVarsWithHints e)

--- a/src/Language/Term/Rule/Term/FreeVarsWithHints.hs
+++ b/src/Language/Term/Rule/Term/FreeVarsWithHints.hs
@@ -26,10 +26,11 @@ freeVarsWithHints term =
       freeVarsWithHints' (impBinders ++ expArgs) (freeVarsWithHints t)
     _ :< TM.PiIntro k impArgs expArgs e ->
       freeVarsWithHints' (map fst impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVarsWithHints e)
-    _ :< TM.PiElim _ e es -> do
+    _ :< TM.PiElim _ e impArgs expArgs -> do
       let xs = freeVarsWithHints e
-      let ys = S.unions $ map freeVarsWithHints es
-      S.union xs ys
+      let ys1 = S.unions $ map freeVarsWithHints impArgs
+      let ys2 = S.unions $ map freeVarsWithHints expArgs
+      S.unions [xs, ys1, ys2]
     _ :< TM.Data _ _ es ->
       S.unions $ map freeVarsWithHints es
     _ :< TM.DataIntro _ _ dataArgs consArgs -> do

--- a/src/Language/Term/Rule/Term/Weaken.hs
+++ b/src/Language/Term/Rule/Term/Weaken.hs
@@ -15,6 +15,7 @@ import Language.Common.Rule.Binder
 import Language.Common.Rule.DecisionTree qualified as DT
 import Language.Common.Rule.Foreign qualified as F
 import Language.Common.Rule.Ident
+import Language.Common.Rule.ImpArgs qualified as ImpArgs
 import Language.Common.Rule.LamKind qualified as LK
 import Language.Common.Rule.Magic qualified as M
 import Language.Common.Rule.StmtKind
@@ -27,7 +28,6 @@ import Language.WeakTerm.Rule.WeakPrimValue qualified as WPV
 import Language.WeakTerm.Rule.WeakStmt
 import Language.WeakTerm.Rule.WeakTerm (reflectOpacity)
 import Language.WeakTerm.Rule.WeakTerm qualified as WT
-import Language.Common.Rule.ImpArgs qualified as ImpArgs
 import Logger.Rule.Hint
 
 weakenStmt :: Stmt -> WeakStmt
@@ -206,10 +206,10 @@ weakenStmtKind stmtKind =
       let consArgsList' = map (map weakenBinder) consArgsList
       let consInfoList' = List.zip5 hintList consNameList constLikeList consArgsList' discriminantList
       Data dataName dataArgs' consInfoList'
-    DataIntro dataName dataArgs consArgs discriminant -> do
+    DataIntro dataName dataArgs expConsArgs discriminant -> do
       let dataArgs' = map weakenBinder dataArgs
-      let consArgs' = map weakenBinder consArgs
-      DataIntro dataName dataArgs' consArgs' discriminant
+      let expConsArgs' = map weakenBinder expConsArgs
+      DataIntro dataName dataArgs' expConsArgs' discriminant
 
 weakenForeign :: F.Foreign -> WT.WeakForeign
 weakenForeign foreignItem@(F.Foreign m _ _ _) =

--- a/src/Language/Term/Rule/Term/Weaken.hs
+++ b/src/Language/Term/Rule/Term/Weaken.hs
@@ -52,7 +52,7 @@ weaken term =
     m :< TM.VarGlobal g argNum ->
       m :< WT.VarGlobal g argNum
     m :< TM.Pi piKind impArgs expArgs t ->
-      m :< WT.Pi piKind (map weakenBinder impArgs) (map weakenBinder expArgs) (weaken t)
+      m :< WT.Pi piKind (map (bimap weakenBinder (fmap weaken)) impArgs) (map weakenBinder expArgs) (weaken t)
     m :< TM.PiIntro attr impArgs expArgs e -> do
       let attr' = weakenAttr attr
       let impArgs' = map weakenBinder impArgs

--- a/src/Language/Term/Rule/Term/Weaken.hs
+++ b/src/Language/Term/Rule/Term/Weaken.hs
@@ -27,6 +27,7 @@ import Language.WeakTerm.Rule.WeakPrimValue qualified as WPV
 import Language.WeakTerm.Rule.WeakStmt
 import Language.WeakTerm.Rule.WeakTerm (reflectOpacity)
 import Language.WeakTerm.Rule.WeakTerm qualified as WT
+import Language.Common.Rule.ImpArgs qualified as ImpArgs
 import Logger.Rule.Hint
 
 weakenStmt :: Stmt -> WeakStmt
@@ -62,7 +63,7 @@ weaken term =
     m :< TM.PiElim b e es -> do
       let e' = weaken e
       let es' = map weaken es
-      m :< WT.PiElim b e' Nothing es'
+      m :< WT.PiElim b e' ImpArgs.Unspecified es'
     m :< TM.Data attr name es -> do
       let es' = map weaken es
       m :< WT.Data attr name es'

--- a/src/Language/Term/Rule/Term/Weaken.hs
+++ b/src/Language/Term/Rule/Term/Weaken.hs
@@ -34,7 +34,7 @@ weakenStmt stmt = do
   case stmt of
     StmtDefine isConstLike stmtKind (SavedHint m) name impArgs expArgs codType e -> do
       let stmtKind' = weakenStmtKind stmtKind
-      let impArgs' = map weakenBinder impArgs
+      let impArgs' = map (bimap weakenBinder (fmap weaken)) impArgs
       let expArgs' = map weakenBinder expArgs
       let codType' = weaken codType
       let e' = weaken e

--- a/src/Language/Term/Rule/Term/Weaken.hs
+++ b/src/Language/Term/Rule/Term/Weaken.hs
@@ -55,7 +55,7 @@ weaken term =
       m :< WT.Pi piKind (map (bimap weakenBinder (fmap weaken)) impArgs) (map weakenBinder expArgs) (weaken t)
     m :< TM.PiIntro attr impArgs expArgs e -> do
       let attr' = weakenAttr attr
-      let impArgs' = map weakenBinder impArgs
+      let impArgs' = map (bimap weakenBinder (fmap weaken)) impArgs
       let expArgs' = map weakenBinder expArgs
       let e' = weaken e
       m :< WT.PiIntro attr' impArgs' expArgs' e'

--- a/src/Language/Term/Rule/Term/Weaken.hs
+++ b/src/Language/Term/Rule/Term/Weaken.hs
@@ -51,8 +51,8 @@ weaken term =
       m :< WT.Var x
     m :< TM.VarGlobal g argNum ->
       m :< WT.VarGlobal g argNum
-    m :< TM.Pi impArgs expArgs t ->
-      m :< WT.Pi (map weakenBinder impArgs) (map weakenBinder expArgs) (weaken t)
+    m :< TM.Pi piKind impArgs expArgs t ->
+      m :< WT.Pi piKind (map weakenBinder impArgs) (map weakenBinder expArgs) (weaken t)
     m :< TM.PiIntro attr impArgs expArgs e -> do
       let attr' = weakenAttr attr
       let impArgs' = map weakenBinder impArgs

--- a/src/Language/Term/Rule/Term/Weaken.hs
+++ b/src/Language/Term/Rule/Term/Weaken.hs
@@ -60,10 +60,11 @@ weaken term =
       let expArgs' = map weakenBinder expArgs
       let e' = weaken e
       m :< WT.PiIntro attr' impArgs' expArgs' e'
-    m :< TM.PiElim b e es -> do
+    m :< TM.PiElim b e impArgs expArgs -> do
       let e' = weaken e
-      let es' = map weaken es
-      m :< WT.PiElim b e' ImpArgs.Unspecified es'
+      let impArgs' = ImpArgs.FullySpecified $ map weaken impArgs
+      let expArgs' = map weaken expArgs
+      m :< WT.PiElim b e' impArgs' expArgs'
     m :< TM.Data attr name es -> do
       let es' = map weaken es
       m :< WT.Data attr name es'

--- a/src/Language/WeakTerm/Move/Reduce.hs
+++ b/src/Language/WeakTerm/Move/Reduce.hs
@@ -72,9 +72,13 @@ reduce' h term = do
       return $ m :< WT.Pi piKind impArgs' expArgs' cod'
     m :< WT.PiIntro attr@(AttrL.Attr {lamKind}) impArgs expArgs e -> do
       impArgs' <- do
-        let (ms, xs, ts) = unzip3 impArgs
+        let binders = map fst impArgs
+        let maybeTypes = map snd impArgs
+        let (ms, xs, ts) = unzip3 binders
         ts' <- mapM (reduce' h) ts
-        return $ zip3 ms xs ts'
+        maybeTypes' <- mapM (traverse (reduce' h)) maybeTypes
+        let binders' = zip3 ms xs ts'
+        return $ zip binders' maybeTypes'
       expArgs' <- do
         let (ms, xs, ts) = unzip3 expArgs
         ts' <- mapM (reduce' h) ts
@@ -95,17 +99,17 @@ reduce' h term = do
         else do
           case e' of
             (_ :< WT.PiIntro AttrL.Attr {lamKind = LK.Normal {}} impParams expParams body)
-              | xts <- impParams ++ expParams,
+              | xts <- map fst impParams ++ expParams,
                 Nothing <- impArgs',
                 length xts == length expArgs' -> do
                   let xs = map (\(_, x, _) -> Ident.toInt x) xts
                   let sub = IntMap.fromList $ zip xs (map Right expArgs')
                   liftIO (Subst.subst (substHandle h) sub body) >>= reduce' h
             (_ :< WT.PiIntro AttrL.Attr {lamKind = LK.Normal {}} impParams expParams body)
-              | xts <- impParams ++ expParams,
+              | xts <- map fst impParams ++ expParams,
                 Just impArgs'' <- impArgs',
                 args <- impArgs'' ++ expArgs',
-                length impArgs'' == length impParams,
+                length impArgs'' == length (map fst impParams),
                 length xts == length args -> do
                   let xs = map (\(_, x, _) -> Ident.toInt x) xts
                   let sub = IntMap.fromList $ zip xs (map Right args)

--- a/src/Language/WeakTerm/Move/Reduce.hs
+++ b/src/Language/WeakTerm/Move/Reduce.hs
@@ -55,7 +55,7 @@ reduce' h term = do
   detectPossibleInfiniteLoop h
   liftIO $ incrementStep h
   case term of
-    m :< WT.Pi impArgs expArgs cod -> do
+    m :< WT.Pi piKind impArgs expArgs cod -> do
       impArgs' <- do
         let (ms, xs, ts) = unzip3 impArgs
         ts' <- mapM (reduce' h) ts
@@ -65,7 +65,7 @@ reduce' h term = do
         ts' <- mapM (reduce' h) ts
         return $ zip3 ms xs ts'
       cod' <- reduce' h cod
-      return $ m :< WT.Pi impArgs' expArgs' cod'
+      return $ m :< WT.Pi piKind impArgs' expArgs' cod'
     m :< WT.PiIntro attr@(AttrL.Attr {lamKind}) impArgs expArgs e -> do
       impArgs' <- do
         let (ms, xs, ts) = unzip3 impArgs

--- a/src/Language/WeakTerm/Move/Reduce.hs
+++ b/src/Language/WeakTerm/Move/Reduce.hs
@@ -57,9 +57,13 @@ reduce' h term = do
   case term of
     m :< WT.Pi piKind impArgs expArgs cod -> do
       impArgs' <- do
-        let (ms, xs, ts) = unzip3 impArgs
+        let binders = map fst impArgs
+        let maybeTypes = map snd impArgs
+        let (ms, xs, ts) = unzip3 binders
         ts' <- mapM (reduce' h) ts
-        return $ zip3 ms xs ts'
+        maybeTypes' <- mapM (traverse (reduce' h)) maybeTypes
+        let binders' = zip3 ms xs ts'
+        return $ zip binders' maybeTypes'
       expArgs' <- do
         let (ms, xs, ts) = unzip3 expArgs
         ts' <- mapM (reduce' h) ts

--- a/src/Language/WeakTerm/Move/Subst.hs
+++ b/src/Language/WeakTerm/Move/Subst.hs
@@ -49,11 +49,11 @@ subst h sub term =
           return term
     _ :< WT.VarGlobal {} ->
       return term
-    m :< WT.Pi impArgs expArgs t -> do
+    m :< WT.Pi piKind impArgs expArgs t -> do
       (impArgs', sub') <- subst' h sub impArgs
       (expArgs', sub'') <- subst' h sub' expArgs
       t' <- subst h sub'' t
-      return $ m :< WT.Pi impArgs' expArgs' t'
+      return $ m :< WT.Pi piKind impArgs' expArgs' t'
     m :< WT.PiIntro (AttrL.Attr {lamKind}) impArgs expArgs e -> do
       let fvs = S.map Ident.toInt $ WT.freeVars term
       let subDomSet = S.fromList $ IntMap.keys sub

--- a/src/Language/WeakTerm/Move/Subst.hs
+++ b/src/Language/WeakTerm/Move/Subst.hs
@@ -24,6 +24,7 @@ import Language.Common.Rule.Ident
 import Language.Common.Rule.Ident.Reify qualified as Ident
 import Language.Common.Rule.LamKind qualified as LK
 import Language.WeakTerm.Rule.WeakTerm qualified as WT
+import Language.Common.Rule.ImpArgs qualified as ImpArgs
 import Language.WeakTerm.Rule.WeakTerm.FreeVars qualified as WT
 
 newtype Handle = Handle
@@ -79,7 +80,7 @@ subst h sub term =
               return (m :< WT.PiIntro lamAttr impArgs' expArgs' e')
     m :< WT.PiElim b e impArgs expArgs -> do
       e' <- subst h sub e
-      impArgs' <- mapM (mapM (subst h sub)) impArgs
+      impArgs' <- ImpArgs.traverseImpArgs (subst h sub) impArgs
       expArgs' <- mapM (subst h sub) expArgs
       return $ m :< WT.PiElim b e' impArgs' expArgs'
     m :< WT.PiElimExact e -> do

--- a/src/Language/WeakTerm/Rule/WeakStmt.hs
+++ b/src/Language/WeakTerm/Rule/WeakStmt.hs
@@ -26,7 +26,7 @@ data WeakStmt
       WeakStmtKind
       Hint
       DD.DefiniteDescription
-      [BinderF WT.WeakTerm]
+      [(BinderF WT.WeakTerm, Maybe WT.WeakTerm)]
       [BinderF WT.WeakTerm]
       WT.WeakTerm
       WT.WeakTerm

--- a/src/Language/WeakTerm/Rule/WeakTerm.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm.hs
@@ -31,6 +31,7 @@ import Language.Common.Rule.Ident
 import Language.Common.Rule.Magic
 import Language.Common.Rule.Noema qualified as N
 import Language.Common.Rule.Opacity qualified as O
+import Language.Common.Rule.PiKind (PiKind)
 import Language.Common.Rule.PrimNumSize
 import Language.Common.Rule.PrimType qualified as PT
 import Language.WeakTerm.Rule.WeakPrim qualified as WP
@@ -43,7 +44,7 @@ data WeakTermF a
   = Tau
   | Var Ident
   | VarGlobal AttrVG.Attr DD.DefiniteDescription
-  | Pi [BinderF a] [BinderF a] a
+  | Pi PiKind [BinderF a] [BinderF a] a
   | PiIntro (AttrL.Attr a) [BinderF a] [BinderF a] a
   | PiElim N.IsNoetic a (Maybe [a]) [a]
   | PiElimExact a

--- a/src/Language/WeakTerm/Rule/WeakTerm.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm.hs
@@ -45,7 +45,7 @@ data WeakTermF a
   | Var Ident
   | VarGlobal AttrVG.Attr DD.DefiniteDescription
   | Pi PiKind [(BinderF a, Maybe a)] [BinderF a] a
-  | PiIntro (AttrL.Attr a) [BinderF a] [BinderF a] a
+  | PiIntro (AttrL.Attr a) [(BinderF a, Maybe a)] [BinderF a] a
   | PiElim N.IsNoetic a (Maybe [a]) [a]
   | PiElimExact a
   | Data (AttrD.Attr DD.DefiniteDescription) DD.DefiniteDescription [a]

--- a/src/Language/WeakTerm/Rule/WeakTerm.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm.hs
@@ -44,7 +44,7 @@ data WeakTermF a
   = Tau
   | Var Ident
   | VarGlobal AttrVG.Attr DD.DefiniteDescription
-  | Pi PiKind [BinderF a] [BinderF a] a
+  | Pi PiKind [(BinderF a, Maybe a)] [BinderF a] a
   | PiIntro (AttrL.Attr a) [BinderF a] [BinderF a] a
   | PiElim N.IsNoetic a (Maybe [a]) [a]
   | PiElimExact a

--- a/src/Language/WeakTerm/Rule/WeakTerm.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm.hs
@@ -28,6 +28,7 @@ import Language.Common.Rule.DefiniteDescription qualified as DD
 import Language.Common.Rule.Foreign
 import Language.Common.Rule.HoleID
 import Language.Common.Rule.Ident
+import Language.Common.Rule.ImpArgs qualified as ImpArgs
 import Language.Common.Rule.Magic
 import Language.Common.Rule.Noema qualified as N
 import Language.Common.Rule.Opacity qualified as O
@@ -46,7 +47,7 @@ data WeakTermF a
   | VarGlobal AttrVG.Attr DD.DefiniteDescription
   | Pi PiKind [(BinderF a, Maybe a)] [BinderF a] a
   | PiIntro (AttrL.Attr a) [(BinderF a, Maybe a)] [BinderF a] a
-  | PiElim N.IsNoetic a (Maybe [a]) [a]
+  | PiElim N.IsNoetic a (ImpArgs.ImpArgs a) [a]
   | PiElimExact a
   | Data (AttrD.Attr DD.DefiniteDescription) DD.DefiniteDescription [a]
   | DataIntro (AttrDI.Attr DD.DefiniteDescription) DD.DefiniteDescription [a] [a] -- (consName, dataArgs, consArgs)

--- a/src/Language/WeakTerm/Rule/WeakTerm/Eq.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/Eq.hs
@@ -10,6 +10,7 @@ import Language.Common.Rule.Magic qualified as M
 import Language.WeakTerm.Rule.WeakPrim qualified as WP
 import Language.WeakTerm.Rule.WeakPrimValue qualified as WPV
 import Language.WeakTerm.Rule.WeakTerm qualified as WT
+import Language.Common.Rule.ImpArgs qualified as ImpArgs
 
 -- syntactic equality
 eq :: WT.WeakTerm -> WT.WeakTerm -> Bool
@@ -49,15 +50,15 @@ eq (_ :< term1) (_ :< term2)
           b1 && b2 && b3
         _ ->
           False
-  | WT.PiElim isNoetic1 f1 Nothing expArgs1 <- term1,
-    WT.PiElim isNoetic2 f2 Nothing expArgs2 <- term2,
+  | WT.PiElim isNoetic1 f1 ImpArgs.Unspecified expArgs1 <- term1,
+    WT.PiElim isNoetic2 f2 ImpArgs.Unspecified expArgs2 <- term2,
     length expArgs1 == length expArgs2,
     isNoetic1 == isNoetic2 = do
       let b1 = eq f1 f2
       let b2 = all (uncurry eq) $ zip expArgs1 expArgs2
       b1 && b2
-  | WT.PiElim isNoetic1 f1 (Just impArgs1) expArgs1 <- term1,
-    WT.PiElim isNoetic2 f2 (Just impArgs2) expArgs2 <- term2,
+  | WT.PiElim isNoetic1 f1 (ImpArgs.FullySpecified impArgs1) expArgs1 <- term1,
+    WT.PiElim isNoetic2 f2 (ImpArgs.FullySpecified impArgs2) expArgs2 <- term2,
     length impArgs1 == length impArgs2,
     length expArgs1 == length expArgs2,
     isNoetic1 == isNoetic2 = do

--- a/src/Language/WeakTerm/Rule/WeakTerm/Eq.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/Eq.hs
@@ -37,14 +37,16 @@ eq (_ :< term1) (_ :< term2)
     length expArgs1 == length expArgs2 =
       case (kind1, kind2) of
         (AttrL.Attr {lamKind = LK.Normal _ codType1}, AttrL.Attr {lamKind = LK.Normal _ codType2}) -> do
-          let b1 = eqBinder (map fst impArgs1 ++ expArgs1) (map fst impArgs2 ++ expArgs2)
-          let b2 = eq body1 body2
-          let b3 = eq codType1 codType2
-          b1 && b2 && b3
+          let b1 = eqImpArgs impArgs1 impArgs2
+          let b2 = eqBinder (map fst impArgs1 ++ expArgs1) (map fst impArgs2 ++ expArgs2)
+          let b3 = eq body1 body2
+          let b4 = eq codType1 codType2
+          b1 && b2 && b3 && b4
         (AttrL.Attr {lamKind = LK.Fix mxt1}, AttrL.Attr {lamKind = LK.Fix mxt2}) -> do
-          let b1 = eqBinder (map fst impArgs1 ++ expArgs1 ++ [mxt1]) (map fst impArgs2 ++ expArgs2 ++ [mxt2])
-          let b2 = eq body1 body2
-          b1 && b2
+          let b1 = eqImpArgs impArgs1 impArgs2
+          let b2 = eqBinder (map fst impArgs1 ++ expArgs1 ++ [mxt1]) (map fst impArgs2 ++ expArgs2 ++ [mxt2])
+          let b3 = eq body1 body2
+          b1 && b2 && b3
         _ ->
           False
   | WT.PiElim isNoetic1 f1 Nothing expArgs1 <- term1,

--- a/src/Language/WeakTerm/Rule/WeakTerm/Eq.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/Eq.hs
@@ -23,8 +23,8 @@ eq (_ :< term1) (_ :< term2)
   | WT.VarGlobal _ dd1 <- term1,
     WT.VarGlobal _ dd2 <- term2 =
       dd1 == dd2
-  | WT.Pi impArgs1 expArgs1 cod1 <- term1,
-    WT.Pi impArgs2 expArgs2 cod2 <- term2 = do
+  | WT.Pi _ impArgs1 expArgs1 cod1 <- term1,
+    WT.Pi _ impArgs2 expArgs2 cod2 <- term2 = do
       let b1 = eqBinder (impArgs1 ++ expArgs1) (impArgs2 ++ expArgs2)
       let b2 = eq cod1 cod2
       b1 && b2

--- a/src/Language/WeakTerm/Rule/WeakTerm/Eq.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/Eq.hs
@@ -37,12 +37,12 @@ eq (_ :< term1) (_ :< term2)
     length expArgs1 == length expArgs2 =
       case (kind1, kind2) of
         (AttrL.Attr {lamKind = LK.Normal _ codType1}, AttrL.Attr {lamKind = LK.Normal _ codType2}) -> do
-          let b1 = eqBinder (impArgs1 ++ expArgs1) (impArgs2 ++ expArgs2)
+          let b1 = eqBinder (map fst impArgs1 ++ expArgs1) (map fst impArgs2 ++ expArgs2)
           let b2 = eq body1 body2
           let b3 = eq codType1 codType2
           b1 && b2 && b3
         (AttrL.Attr {lamKind = LK.Fix mxt1}, AttrL.Attr {lamKind = LK.Fix mxt2}) -> do
-          let b1 = eqBinder (impArgs1 ++ expArgs1 ++ [mxt1]) (impArgs2 ++ expArgs2 ++ [mxt2])
+          let b1 = eqBinder (map fst impArgs1 ++ expArgs1 ++ [mxt1]) (map fst impArgs2 ++ expArgs2 ++ [mxt2])
           let b2 = eq body1 body2
           b1 && b2
         _ ->

--- a/src/Language/WeakTerm/Rule/WeakTerm/FreeVars.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/FreeVars.hs
@@ -23,7 +23,7 @@ freeVars term =
       let impBinders = map fst impArgs
       freeVars' (impBinders ++ expArgs) (freeVars t)
     _ :< WT.PiIntro k impArgs expArgs e ->
-      freeVars' (impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVars e)
+      freeVars' (map fst impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVars e)
     _ :< WT.PiElim _ e impArgs expArgs -> do
       let xs = freeVars e
       let ys = S.unions $ map freeVars (fromMaybe [] impArgs ++ expArgs)

--- a/src/Language/WeakTerm/Rule/WeakTerm/FreeVars.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/FreeVars.hs
@@ -19,8 +19,9 @@ freeVars term =
       S.singleton x
     _ :< WT.VarGlobal {} ->
       S.empty
-    _ :< WT.Pi _ impArgs expArgs t ->
-      freeVars' (impArgs ++ expArgs) (freeVars t)
+    _ :< WT.Pi _ impArgs expArgs t -> do
+      let impBinders = map fst impArgs
+      freeVars' (impBinders ++ expArgs) (freeVars t)
     _ :< WT.PiIntro k impArgs expArgs e ->
       freeVars' (impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVars e)
     _ :< WT.PiElim _ e impArgs expArgs -> do

--- a/src/Language/WeakTerm/Rule/WeakTerm/FreeVars.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/FreeVars.hs
@@ -19,7 +19,7 @@ freeVars term =
       S.singleton x
     _ :< WT.VarGlobal {} ->
       S.empty
-    _ :< WT.Pi impArgs expArgs t ->
+    _ :< WT.Pi _ impArgs expArgs t ->
       freeVars' (impArgs ++ expArgs) (freeVars t)
     _ :< WT.PiIntro k impArgs expArgs e ->
       freeVars' (impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVars e)

--- a/src/Language/WeakTerm/Rule/WeakTerm/FreeVars.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/FreeVars.hs
@@ -8,6 +8,7 @@ import Language.Common.Rule.Attr.Lam qualified as AttrL
 import Language.Common.Rule.Binder
 import Language.Common.Rule.DecisionTree qualified as DT
 import Language.Common.Rule.Ident
+import Language.Common.Rule.ImpArgs qualified as ImpArgs
 import Language.WeakTerm.Rule.WeakTerm qualified as WT
 
 freeVars :: WT.WeakTerm -> S.Set Ident
@@ -26,7 +27,7 @@ freeVars term =
       freeVars' (map fst impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (freeVars e)
     _ :< WT.PiElim _ e impArgs expArgs -> do
       let xs = freeVars e
-      let ys = S.unions $ map freeVars (fromMaybe [] impArgs ++ expArgs)
+      let ys = S.unions $ map freeVars (ImpArgs.extract impArgs ++ expArgs)
       S.union xs ys
     _ :< WT.PiElimExact e -> do
       freeVars e

--- a/src/Language/WeakTerm/Rule/WeakTerm/Holes.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/Holes.hs
@@ -23,7 +23,7 @@ holes term =
       let impBinders = map fst impArgs
       holes' (impBinders ++ expArgs) (holes t)
     _ :< WT.PiIntro k impArgs expArgs e ->
-      holes' (impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (holes e)
+      holes' (map fst impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (holes e)
     _ :< WT.PiElim _ e impArgs expArgs ->
       S.unions $ map holes $ e : (fromMaybe [] impArgs ++ expArgs)
     _ :< WT.PiElimExact e ->

--- a/src/Language/WeakTerm/Rule/WeakTerm/Holes.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/Holes.hs
@@ -8,6 +8,7 @@ import Language.Common.Rule.Attr.Lam qualified as AttrL
 import Language.Common.Rule.Binder
 import Language.Common.Rule.DecisionTree qualified as DT
 import Language.Common.Rule.HoleID
+import Language.Common.Rule.ImpArgs qualified as ImpArgs
 import Language.WeakTerm.Rule.WeakTerm qualified as WT
 
 holes :: WT.WeakTerm -> S.Set HoleID
@@ -25,7 +26,7 @@ holes term =
     _ :< WT.PiIntro k impArgs expArgs e ->
       holes' (map fst impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (holes e)
     _ :< WT.PiElim _ e impArgs expArgs ->
-      S.unions $ map holes $ e : (fromMaybe [] impArgs ++ expArgs)
+      S.unions $ map holes $ e : (ImpArgs.extract impArgs ++ expArgs)
     _ :< WT.PiElimExact e ->
       holes e
     _ :< WT.Data _ _ es ->

--- a/src/Language/WeakTerm/Rule/WeakTerm/Holes.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/Holes.hs
@@ -19,7 +19,7 @@ holes term =
       S.empty
     _ :< WT.VarGlobal {} ->
       S.empty
-    _ :< WT.Pi impArgs expArgs t ->
+    _ :< WT.Pi _ impArgs expArgs t ->
       holes' (impArgs ++ expArgs) (holes t)
     _ :< WT.PiIntro k impArgs expArgs e ->
       holes' (impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (holes e)

--- a/src/Language/WeakTerm/Rule/WeakTerm/Holes.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/Holes.hs
@@ -19,8 +19,9 @@ holes term =
       S.empty
     _ :< WT.VarGlobal {} ->
       S.empty
-    _ :< WT.Pi _ impArgs expArgs t ->
-      holes' (impArgs ++ expArgs) (holes t)
+    _ :< WT.Pi _ impArgs expArgs t -> do
+      let impBinders = map fst impArgs
+      holes' (impBinders ++ expArgs) (holes t)
     _ :< WT.PiIntro k impArgs expArgs e ->
       holes' (impArgs ++ expArgs ++ catMaybes [AttrL.fromAttr k]) (holes e)
     _ :< WT.PiElim _ e impArgs expArgs ->

--- a/src/Language/WeakTerm/Rule/WeakTerm/ToText.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/ToText.hs
@@ -47,7 +47,7 @@ toText term =
         AttrL.Attr {lamKind = LK.Fix (_, x, codType)} ->
           "define "
             <> showVariable x
-            <> showImpArgs impArgs
+            <> showImpArgsOld impArgs
             <> inParen (showDomArgList expArgs)
             <> ": "
             <> toText codType
@@ -57,7 +57,7 @@ toText term =
           let name = fromMaybe "" mName
           "function "
             <> name
-            <> showImpArgs impArgs
+            <> showImpArgsOld impArgs
             <> inParen (showDomArgList expArgs)
             <> ": "
             <> toText codType
@@ -130,21 +130,32 @@ toText term =
     _ :< WT.Void ->
       "void"
 
-showImpArgs :: [BinderF WT.WeakTerm] -> T.Text
+showImpArgs :: [(BinderF WT.WeakTerm, Maybe WT.WeakTerm)] -> T.Text
 showImpArgs impArgs =
   if null impArgs
     then ""
     else do
       inAngleBracket $ showImpDomArgList impArgs
 
-showDataImpArgs :: [BinderF WT.WeakTerm] -> T.Text
+showImpArgsOld :: [BinderF WT.WeakTerm] -> T.Text
+showImpArgsOld impArgs =
+  if null impArgs
+    then ""
+    else do
+      inAngleBracket $ showImpDomArgListOld impArgs
+
+showDataImpArgs :: [(BinderF WT.WeakTerm, Maybe WT.WeakTerm)] -> T.Text
 showDataImpArgs impArgs =
   if null impArgs
     then ""
-    else "∀ " <> T.intercalate " " (map showImpDomArg' impArgs) <> ". "
+    else "∀ " <> T.intercalate " " (map (showImpDomArg' . fst) impArgs) <> ". "
 
-showImpDomArgList :: [BinderF WT.WeakTerm] -> T.Text
+showImpDomArgList :: [(BinderF WT.WeakTerm, Maybe WT.WeakTerm)] -> T.Text
 showImpDomArgList mxts =
+  T.intercalate ", " $ map (showImpDomArg . fst) mxts
+
+showImpDomArgListOld :: [BinderF WT.WeakTerm] -> T.Text
+showImpDomArgListOld mxts =
   T.intercalate ", " $ map showImpDomArg mxts
 
 showImpDomArg :: BinderF WT.WeakTerm -> T.Text

--- a/src/Language/WeakTerm/Rule/WeakTerm/ToText.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/ToText.hs
@@ -47,7 +47,7 @@ toText term =
         AttrL.Attr {lamKind = LK.Fix (_, x, codType)} ->
           "define "
             <> showVariable x
-            <> showImpArgsOld impArgs
+            <> showImpArgsOld (map fst impArgs)
             <> inParen (showDomArgList expArgs)
             <> ": "
             <> toText codType
@@ -57,7 +57,7 @@ toText term =
           let name = fromMaybe "" mName
           "function "
             <> name
-            <> showImpArgsOld impArgs
+            <> showImpArgsOld (map fst impArgs)
             <> inParen (showDomArgList expArgs)
             <> ": "
             <> toText codType

--- a/src/Language/WeakTerm/Rule/WeakTerm/ToText.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/ToText.hs
@@ -22,6 +22,7 @@ import Language.Common.Rule.Rune qualified as RU
 import Language.WeakTerm.Rule.WeakPrim qualified as WP
 import Language.WeakTerm.Rule.WeakPrimValue qualified as WPV
 import Language.WeakTerm.Rule.WeakTerm qualified as WT
+import Language.Common.Rule.ImpArgs qualified as ImpArgs
 
 toText :: WT.WeakTerm -> T.Text
 toText term =
@@ -70,9 +71,9 @@ toText term =
               toText e
         _ -> do
           case impArgs of
-            Just impArgs' ->
+            ImpArgs.FullySpecified impArgs' ->
               showApp' (toText e) (map toText impArgs') (map toText expArgs)
-            Nothing ->
+            ImpArgs.Unspecified ->
               showApp (toText e) (map toText expArgs)
     _ :< WT.PiElimExact e -> do
       "exact " <> toText e

--- a/src/Language/WeakTerm/Rule/WeakTerm/ToText.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/ToText.hs
@@ -157,13 +157,14 @@ showImpDomArgWithDefault ((_, x, _), maybeDefault) = do
       baseArg <> " := " <> toText defaultValue
 
 showDataImpArgWithDefault :: (BinderF WT.WeakTerm, Maybe WT.WeakTerm) -> T.Text
-showDataImpArgWithDefault ((_, x, t), maybeDefault) =
-  let baseArg = case t of
-        _ :< WT.Tau -> showVariable x
-        _ -> "(" <> showVariable x <> ": " <> toText t <> ")"
-   in case maybeDefault of
-        Nothing -> baseArg
-        Just defaultValue -> "(" <> baseArg <> " := " <> toText defaultValue <> ")"
+showDataImpArgWithDefault ((_, x, t), maybeDefault) = do
+  let baseArg =
+        case t of
+          _ :< WT.Tau -> showVariable x
+          _ -> "(" <> showVariable x <> ": " <> toText t <> ")"
+  case maybeDefault of
+    Nothing -> baseArg
+    Just defaultValue -> "(" <> baseArg <> " := " <> toText defaultValue <> ")"
 
 inParen :: T.Text -> T.Text
 inParen s =

--- a/src/Language/WeakTerm/Rule/WeakTerm/ToText.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/ToText.hs
@@ -75,6 +75,8 @@ toText term =
               showApp' (toText e) (map toText impArgs') (map toText expArgs)
             ImpArgs.Unspecified ->
               showApp (toText e) (map toText expArgs)
+            ImpArgs.PartiallySpecified impArgs' ->
+              showApp' (toText e) (map toText (ImpArgs.extract (ImpArgs.PartiallySpecified impArgs'))) (map toText expArgs)
     _ :< WT.PiElimExact e -> do
       "exact " <> toText e
     _ :< WT.Data (AttrD.Attr {..}) name es -> do

--- a/src/SyntaxTree/Rule/Series.hs
+++ b/src/SyntaxTree/Rule/Series.hs
@@ -6,6 +6,7 @@ module SyntaxTree.Rule.Series
     emptySeries,
     emptySeries',
     emptySeriesPC,
+    emptySeriesAC,
     fromList,
     fromList',
     fromList'',
@@ -30,11 +31,11 @@ module SyntaxTree.Rule.Series
   )
 where
 
-import SyntaxTree.Rule.C (C)
 import Data.Bifunctor
 import Data.List (nubBy, sortBy)
 import Data.Maybe (mapMaybe)
 import Data.Text qualified as T
+import SyntaxTree.Rule.C (C)
 
 data Separator
   = Comma
@@ -144,6 +145,11 @@ cons x xs =
 emptySeriesPC :: Series a
 emptySeriesPC =
   emptySeries (Just Paren) Comma
+
+-- ac: angle comma
+emptySeriesAC :: Series a
+emptySeriesAC =
+  emptySeries (Just Angle) Comma
 
 fromList :: Container -> Separator -> [a] -> Series a
 fromList container separator xs =

--- a/test/misc/adder/module.ens
+++ b/test/misc/adder/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/args/module.ens
+++ b/test/misc/args/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/calc/module.ens
+++ b/test/misc/calc/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/check/module.ens
+++ b/test/misc/check/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/codata-basic/module.ens
+++ b/test/misc/codata-basic/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/complex-cancel/module.ens
+++ b/test/misc/complex-cancel/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/ex-falso/module.ens
+++ b/test/misc/ex-falso/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/fact/module.ens
+++ b/test/misc/fact/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/file/module.ens
+++ b/test/misc/file/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/fix-and-free-vars/module.ens
+++ b/test/misc/fix-and-free-vars/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/fold-tails/module.ens
+++ b/test/misc/fold-tails/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/foreign/module.ens
+++ b/test/misc/foreign/module.ens
@@ -20,9 +20,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/hello/module.ens
+++ b/test/misc/hello/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/lambda-list-noetic/module.ens
+++ b/test/misc/lambda-list-noetic/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/lambda-list/module.ens
+++ b/test/misc/lambda-list/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/loop-and-resource/module.ens
+++ b/test/misc/loop-and-resource/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/multi-targets/module.ens
+++ b/test/misc/multi-targets/module.ens
@@ -12,9 +12,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/mutable/module.ens
+++ b/test/misc/mutable/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/nat-fact/module.ens
+++ b/test/misc/nat-fact/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/nat-list/module.ens
+++ b/test/misc/nat-list/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/nested-enums/module.ens
+++ b/test/misc/nested-enums/module.ens
@@ -6,9 +6,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/num-literals/module.ens
+++ b/test/misc/num-literals/module.ens
@@ -6,9 +6,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/print-float/module.ens
+++ b/test/misc/print-float/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/static-file/module.ens
+++ b/test/misc/static-file/module.ens
@@ -12,9 +12,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/binary-search-tree/module.ens
+++ b/test/pfds/binary-search-tree/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/binomial-heap/module.ens
+++ b/test/pfds/binomial-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/custom-stack/module.ens
+++ b/test/pfds/custom-stack/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/finite-map/module.ens
+++ b/test/pfds/finite-map/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/leftist-heap/module.ens
+++ b/test/pfds/leftist-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/naive-queue/module.ens
+++ b/test/pfds/naive-queue/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/pairing-heap/module.ens
+++ b/test/pfds/pairing-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/random-access-list/module.ens
+++ b/test/pfds/random-access-list/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/red-black-tree/module.ens
+++ b/test/pfds/red-black-tree/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/splay-heap/module.ens
+++ b/test/pfds/splay-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/stack/module.ens
+++ b/test/pfds/stack/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
     },
   },

--- a/test/pfds/stream/module.ens
+++ b/test/pfds/stream/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
     },
   },

--- a/test/statement/define/module.ens
+++ b/test/statement/define/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/import-names/module.ens
+++ b/test/statement/import-names/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/resource-basic/module.ens
+++ b/test/statement/resource-basic/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/variant-struct/module.ens
+++ b/test/statement/variant-struct/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/box/module.ens
+++ b/test/term/box/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/flow/module.ens
+++ b/test/term/flow/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/noema/module.ens
+++ b/test/term/noema/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/pi/module.ens
+++ b/test/term/pi/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/prim/module.ens
+++ b/test/term/prim/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/rune/module.ens
+++ b/test/term/rune/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/tau/module.ens
+++ b/test/term/tau/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/unary/module.ens
+++ b/test/term/unary/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/var/module.ens
+++ b/test/term/var/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/variant/module.ens
+++ b/test/term/variant/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "8IOw3MKCGiyRg9wZYFcKGdqy13YoDI9qBA504o9NH64",
+      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-4.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
       ],
       enable-preset true,
     },


### PR DESCRIPTION
example:

```
define some-func<x := 10, z := 30>(y: int): int {
  add-int(add-int(x, y), z)
}

define use-some-func(): unit {
  let _ = some-func(20);
  let _ = some-func<1, 3>(20);
  let _ = some-func of {y := 20};
  let _ = some-func of {x := 1, y := 20};
  let _ = some-func of {x := 1, y := 20, z := 3};
  Unit
}
```