### PR TITLE
allow `format-source` and `format-ens` to read from stdin (`-`)

### DIFF
--- a/src/Command/FormatEns/Move/FormatEns.hs
+++ b/src/Command/FormatEns/Move/FormatEns.hs
@@ -3,21 +3,19 @@ module Command.FormatEns.Move.FormatEns
   )
 where
 
-import CommandParser.Rule.Config.FormatEns
-import Error.Rule.EIO (EIO)
-import Path.Move.EnsureFileExistence (ensureFileExistence')
-import Path.Move.Read (readText)
-import Path.Move.Write (printText, writeText)
 import Command.Common.Move.Format qualified as Format
+import CommandParser.Rule.Config.FormatEns
 import Control.Monad.IO.Class (MonadIO (liftIO))
+import Error.Rule.EIO (EIO)
 import Path.IO
+import Path.Move.Read (isStdin, readTextFromPathOrStdin)
+import Path.Move.Write (printText, writeText)
 
 format :: Config -> EIO ()
 format cfg = do
-  path <- resolveFile' $ filePathString cfg
-  ensureFileExistence' path
-  content <- liftIO $ readText path
+  path <- resolveFile' (filePathString cfg)
+  content <- readTextFromPathOrStdin path
   content' <- Format.formatEns path content
-  if mustUpdateInPlace cfg
+  if mustUpdateInPlace cfg && not (isStdin path)
     then liftIO $ writeText path content'
     else liftIO $ printText content'

--- a/src/Command/FormatSource/Move/FormatSource.hs
+++ b/src/Command/FormatSource/Move/FormatSource.hs
@@ -5,15 +5,14 @@ module Command.FormatSource.Move.FormatSource
   )
 where
 
-import CommandParser.Rule.Config.FormatSource
-import Error.Rule.EIO (EIO)
-import Path.Move.EnsureFileExistence (ensureFileExistence')
-import Path.Move.Read (readText)
-import Path.Move.Write (printText, writeText)
 import Command.Common.Move.Format qualified as Format
+import CommandParser.Rule.Config.FormatSource
 import Control.Monad.IO.Class (MonadIO (liftIO))
+import Error.Rule.EIO (EIO)
 import Kernel.Common.Move.CreateGlobalHandle qualified as Global
 import Path.IO
+import Path.Move.Read (isStdin, readTextFromPathOrStdin)
+import Path.Move.Write (printText, writeText)
 
 newtype Handle = Handle
   { globalHandle :: Global.Handle
@@ -25,11 +24,10 @@ new globalHandle = do
 
 format :: Handle -> Config -> EIO ()
 format h cfg = do
-  path <- resolveFile' $ filePathString cfg
-  ensureFileExistence' path
-  content <- liftIO $ readText path
+  path <- resolveFile' (filePathString cfg)
+  content <- readTextFromPathOrStdin path
   let formatHandle = Format.new (globalHandle h)
   content' <- Format.formatSource formatHandle (shouldMinimizeImports cfg) path content
-  if mustUpdateInPlace cfg
+  if mustUpdateInPlace cfg && not (isStdin path)
     then liftIO $ writeText path content'
     else liftIO $ printText content'

--- a/src/Ens/Move/Parse.hs
+++ b/src/Ens/Move/Parse.hs
@@ -7,25 +7,25 @@ where
 import CodeParser.Move.GetInfo
 import CodeParser.Move.Parse
 import CodeParser.Rule.Parser qualified as P
-import Ens.Rule.Ens qualified as E
-import Error.Move.Run (raiseError)
-import Error.Rule.EIO (EIO)
-import Logger.Rule.Hint
-import Path.Move.Read (readText)
-import SyntaxTree.Move.ParseSeries
-import SyntaxTree.Rule.C
-import SyntaxTree.Rule.Series qualified as SE
 import Control.Comonad.Cofree
 import Control.Monad.Trans
 import Data.Set qualified as S
 import Data.Text qualified as T
+import Ens.Rule.Ens qualified as E
+import Error.Move.Run (raiseError)
+import Error.Rule.EIO (EIO)
+import Logger.Rule.Hint
 import Path
+import Path.Move.Read (readTextFromPath)
+import SyntaxTree.Move.ParseSeries
+import SyntaxTree.Rule.C
+import SyntaxTree.Rule.Series qualified as SE
 import Text.Megaparsec hiding (runParser)
 import Text.Read (readMaybe)
 
 fromFilePath :: Path Abs File -> EIO (C, (E.Ens, C))
 fromFilePath path = do
-  fileContent <- liftIO $ readText path
+  fileContent <- readTextFromPath path
   fromFilePath' path fileContent
 
 fromFilePath' :: Path Abs File -> T.Text -> EIO (C, (E.Ens, C))

--- a/src/Kernel/Common/Move/Handle/Global/Path.hs
+++ b/src/Kernel/Common/Move/Handle/Global/Path.hs
@@ -17,12 +17,6 @@ module Kernel.Common.Move.Handle.Global.Path
   )
 where
 
-import Ens.Rule.Ens qualified as E
-import Ens.Rule.Ens.ToDoc qualified as E
-import Error.Move.Run (raiseError')
-import Error.Rule.EIO (EIO)
-import Logger.Rule.Handle qualified as Logger
-import Path.Move.Read (readText)
 import Control.Comonad.Cofree
 import Control.Monad.IO.Class
 import Data.ByteString.UTF8 qualified as B
@@ -30,6 +24,10 @@ import Data.HashMap.Strict qualified as Map
 import Data.IORef
 import Data.Text qualified as T
 import Data.Time
+import Ens.Rule.Ens qualified as E
+import Ens.Rule.Ens.ToDoc qualified as E
+import Error.Move.Run (raiseError')
+import Error.Rule.EIO (EIO)
 import Kernel.Common.Move.Handle.Global.Platform qualified as Platform
 import Kernel.Common.Rule.ClangOption qualified as CL
 import Kernel.Common.Rule.Const
@@ -42,9 +40,11 @@ import Kernel.Common.Rule.Source qualified as Src
 import Kernel.Common.Rule.Target qualified as Target
 import Language.Common.Rule.Digest
 import Language.Common.Rule.ModuleID qualified as MID
+import Logger.Rule.Handle qualified as Logger
 import Path (Abs, Dir, File, Path, (</>))
 import Path qualified as P
 import Path.IO qualified as P
+import Path.Move.Read (readTextFromPath)
 
 new :: MainModule -> Platform.Handle -> Logger.Handle -> IO Handle
 new _mainModule _platformHandle _loggerHandle = do
@@ -95,7 +95,7 @@ getBuildSignature h t = do
       let clangDigest = Platform.getClangDigest (_platformHandle h)
       let MainModule m = _mainModule h
       clangOption <- getClangOption t m
-      moduleEns' <- liftIO $ readText (moduleLocation m)
+      moduleEns' <- readTextFromPath (moduleLocation m)
       let ens =
             E.dictFromList
               _m

--- a/src/Kernel/Common/Move/Handle/Local/Locator.hs
+++ b/src/Kernel/Common/Move/Handle/Local/Locator.hs
@@ -8,10 +8,6 @@ module Kernel.Common.Move.Handle.Local.Locator
   )
 where
 
-import Error.Move.Run (raiseError, raiseError')
-import Error.Rule.EIO (EIO)
-import Logger.Rule.Hint
-import Path.Move.Read (readText)
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.Containers.ListUtils qualified as ListUtils
@@ -19,6 +15,8 @@ import Data.HashMap.Strict qualified as Map
 import Data.IORef
 import Data.Maybe (maybeToList)
 import Data.Text qualified as T
+import Error.Move.Run (raiseError, raiseError')
+import Error.Rule.EIO (EIO)
 import Kernel.Common.Move.Handle.Local.Tag qualified as Tag
 import Kernel.Common.Rule.AliasInfo (MustUpdateTag)
 import Kernel.Common.Rule.GlobalName qualified as GN
@@ -34,8 +32,10 @@ import Language.Common.Rule.DefiniteDescription qualified as DD
 import Language.Common.Rule.LocalLocator qualified as LL
 import Language.Common.Rule.SourceLocator qualified as SL
 import Language.Common.Rule.StrictGlobalLocator qualified as SGL
+import Logger.Rule.Hint
 import Path
 import Path.IO
+import Path.Move.Read (readTextFromPath)
 
 new :: Env.Handle -> Tag.Handle -> Source.Source -> EIO Handle
 new _envHandle _tagHandle source = do
@@ -85,7 +85,7 @@ activateStaticFile h m key path = do
   b <- doesFileExist path
   if b
     then do
-      content <- liftIO $ readText path
+      content <- readTextFromPath path
       liftIO $ modifyIORef' (_activeStaticFileListRef h) $ Map.insert key (path, content)
     else
       raiseError m $

--- a/src/Kernel/Load/Move/Load.hs
+++ b/src/Kernel/Load/Move/Load.hs
@@ -5,17 +5,17 @@ module Kernel.Load.Move.Load
   )
 where
 
+import Data.Text qualified as T
 import Error.Move.Run (forP)
 import Error.Rule.EIO (EIO)
-import Logger.Move.Debug qualified as Logger
-import Logger.Rule.Handle qualified as Logger
-import Path.Move.Read (readText)
-import Data.Text qualified as T
 import Kernel.Common.Move.CreateGlobalHandle qualified as Global
 import Kernel.Common.Move.ManageCache qualified as Cache
 import Kernel.Common.Rule.Cache qualified as Cache
 import Kernel.Common.Rule.Source qualified as Source
 import Kernel.Common.Rule.Target
+import Logger.Move.Debug qualified as Logger
+import Logger.Rule.Handle qualified as Logger
+import Path.Move.Read (readTextFromPath)
 import UnliftIO (MonadIO (liftIO))
 
 data Handle = Handle
@@ -42,4 +42,4 @@ _load h t source = do
     Just cache -> do
       return $ Left cache
     Nothing -> do
-      fmap Right $ liftIO . readText $ Source.sourceFilePath source
+      fmap Right $ readTextFromPath $ Source.sourceFilePath source

--- a/src/Kernel/Unravel/Move/Unravel.hs
+++ b/src/Kernel/Unravel/Move/Unravel.hs
@@ -10,12 +10,6 @@ module Kernel.Unravel.Move.Unravel
 where
 
 import CodeParser.Move.Parse (runParser)
-import Error.Move.Run (raiseError, raiseError')
-import Error.Rule.EIO (EIO)
-import Logger.Move.Debug qualified as Logger
-import Logger.Rule.Hint
-import Path.Move.EnsureFileExistence (ensureFileExistence, ensureFileExistence')
-import Path.Move.Read (readText)
 import Control.Monad
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Foldable
@@ -24,6 +18,8 @@ import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
 import Data.Sequence as Seq (Seq, empty, (><), (|>))
 import Data.Text qualified as T
 import Data.Time
+import Error.Move.Run (raiseError, raiseError')
+import Error.Rule.EIO (EIO)
 import Kernel.Common.Move.CreateGlobalHandle qualified as Global
 import Kernel.Common.Move.CreateLocalHandle qualified as Local
 import Kernel.Common.Move.Handle.Global.Antecedent qualified as Antecedent
@@ -44,8 +40,12 @@ import Kernel.Parse.Move.Internal.Import qualified as Import
 import Kernel.Parse.Move.Internal.Program (parseImport)
 import Kernel.Unravel.Rule.VisitInfo qualified as VI
 import Language.Common.Rule.ModuleID qualified as MID
+import Logger.Move.Debug qualified as Logger
+import Logger.Rule.Hint
 import Path
 import Path.IO
+import Path.Move.EnsureFileExistence (ensureFileExistence, ensureFileExistence')
+import Path.Move.Read (readTextFromPath)
 
 type CacheTime =
   Maybe UTCTime
@@ -348,7 +348,7 @@ parseSourceHeader :: Handle -> Local.Handle -> Source.Source -> EIO [ImportItem]
 parseSourceHeader h localHandle currentSource = do
   ensureSourceExistence currentSource
   let filePath = Source.sourceFilePath currentSource
-  fileContent <- liftIO $ readText filePath
+  fileContent <- readTextFromPath filePath
   (_, importList) <- runParser filePath fileContent False parseImport
   let m = newSourceHint filePath
   let importHandle = Import.new (globalHandle h) localHandle

--- a/src/Path/Move/Read.hs
+++ b/src/Path/Move/Read.hs
@@ -1,19 +1,28 @@
 module Path.Move.Read
-  ( readText,
-    readByteString,
+  ( readTextFromPath,
+    readTextFromPathOrStdin,
+    isStdin,
   )
 where
 
+import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.ByteString qualified as B
 import Data.Text qualified as T
 import Data.Text.Encoding
+import Error.Rule.EIO (EIO)
 import Path
+import Path.Move.EnsureFileExistence (ensureFileExistence')
 
-readText :: Path Abs File -> IO T.Text
-readText path = do
+readTextFromPath :: Path Abs File -> EIO T.Text
+readTextFromPath path = do
+  ensureFileExistence' path
+  decodeUtf8 <$> liftIO (readByteString path)
+
+readTextFromPathOrStdin :: Path Abs File -> EIO T.Text
+readTextFromPathOrStdin path = do
   if isStdin path
-    then decodeUtf8 <$> B.getContents
-    else decodeUtf8 <$> readByteString path
+    then decodeUtf8 <$> liftIO B.getContents
+    else readTextFromPath path
 
 readByteString :: Path Abs File -> IO B.ByteString
 readByteString path =


### PR DESCRIPTION
example:

```sh
cat ./source/adder.nt | neut format-source -
cat ./module.ens | neut format-ens -
```