### PR TITLE
add support for formatting inline comments

### DIFF
--- a/src/Ens/Rule/Ens/ToDoc.hs
+++ b/src/Ens/Rule/Ens/ToDoc.hs
@@ -40,4 +40,4 @@ dictItemToDoc (k, v) =
 
 commentToDoc :: C -> [D.Doc]
 commentToDoc c = do
-  foldr (\com acc -> [D.line, D.text "//", D.text com] ++ acc) [] c
+  foldr (\com acc -> [D.line, D.text "//", D.text (commentText com)] ++ acc) [] c

--- a/src/Language/RawTerm/Rule/RawTerm/ToDoc.hs
+++ b/src/Language/RawTerm/Rule/RawTerm/ToDoc.hs
@@ -540,6 +540,8 @@ isMultiLine docList =
           isMultiLine $ next : rest
         D.Line {} ->
           True
+        D.InlineComment {} ->
+          True
 
 decPiElimKey :: SE.Series (Hint, Key, C, C, RawTerm) -> D.Doc
 decPiElimKey kvs = do

--- a/src/PrettyPrinter/Rule/Doc.hs
+++ b/src/PrettyPrinter/Rule/Doc.hs
@@ -3,6 +3,7 @@ module PrettyPrinter.Rule.Doc
     indent,
     line,
     text,
+    inlineComment,
     join,
     nest,
     layout,
@@ -17,6 +18,7 @@ data Doc
   = Nil
   | Text T.Text Doc
   | Line Int Doc
+  | InlineComment T.Text Doc
   deriving (Show)
 
 indent :: Int
@@ -28,6 +30,9 @@ line = Line 0 Nil
 
 text :: T.Text -> Doc
 text t = Text t Nil
+
+inlineComment :: T.Text -> Doc
+inlineComment t = InlineComment t Nil
 
 join :: [Doc] -> Doc
 join =
@@ -42,6 +47,8 @@ _join doc1 doc2 =
       Text t (_join x doc2)
     Line i x ->
       Line i (_join x doc2)
+    InlineComment t x ->
+      InlineComment t (_join x doc2)
 
 nest :: Int -> Doc -> Doc
 nest i doc =
@@ -52,16 +59,42 @@ nest i doc =
       Text t (nest i x)
     Line j x ->
       Line (i + j) (nest i x)
+    InlineComment t x ->
+      InlineComment t (nest i x)
 
 layout :: Doc -> T.Text
 layout doc =
+  layoutDirect (slideInlineComments doc)
+
+slideInlineComments :: Doc -> Doc
+slideInlineComments doc =
+  case doc of
+    Nil ->
+      Nil
+    Text t x ->
+      Text t (slideInlineComments x)
+    Line i x ->
+      case x of
+        -- InlineComment t cont ->
+        --   Text (" " <> t) (Line i (slideInlineComments cont))
+        InlineComment t cont ->
+          Text (" " <> t) (slideInlineComments cont)
+        _ ->
+          Line i (slideInlineComments x)
+    InlineComment t x ->
+      InlineComment t (slideInlineComments x)
+
+layoutDirect :: Doc -> T.Text
+layoutDirect doc =
   case doc of
     Nil ->
       ""
     Text t x ->
-      t <> layout x
+      t <> layoutDirect x
     Line i x ->
-      "\n" <> T.replicate i " " <> layout x
+      "\n" <> T.replicate i " " <> layoutDirect x
+    InlineComment t x ->
+      t <> layoutDirect x
 
 isMulti :: [Doc] -> Bool
 isMulti docList =
@@ -76,6 +109,8 @@ isMulti docList =
           isMulti $ next : rest
         Line {} ->
           True
+        InlineComment _ next ->
+          isMulti $ next : rest
 
 intercalate :: Doc -> [Doc] -> Doc
 intercalate sep docList =

--- a/src/SyntaxTree/Rule/C.hs
+++ b/src/SyntaxTree/Rule/C.hs
@@ -1,6 +1,17 @@
-module SyntaxTree.Rule.C (C) where
+module SyntaxTree.Rule.C (C, Comment (..), CommentType (..)) where
 
 import Data.Text qualified as T
 
+data CommentType
+  = InlineComment
+  | LineComment
+  deriving (Eq, Show, Ord)
+
+data Comment = Comment
+  { commentType :: CommentType,
+    commentText :: T.Text
+  }
+  deriving (Eq, Show, Ord)
+
 -- list of comments
-type C = [T.Text]
+type C = [Comment]

--- a/src/SyntaxTree/Rule/C/ToDoc.hs
+++ b/src/SyntaxTree/Rule/C/ToDoc.hs
@@ -4,22 +4,56 @@ module SyntaxTree.Rule.C.ToDoc
     asPrefix',
     asSuffix,
     asClauseHeader,
+    asStmtPrefix,
   )
 where
 
+import Data.List (uncons)
+import Data.Text qualified as T
 import PrettyPrinter.Rule.Doc qualified as D
 import SyntaxTree.Rule.C
-import Data.Text qualified as T
 
 decode :: C -> D.Doc
-decode =
-  D.intercalate D.line . map (\com -> D.join [D.text "//", D.text com])
+decode commentList =
+  case uncons commentList of
+    Nothing ->
+      D.Nil
+    Just (headComment, rest) -> do
+      case commentType headComment of
+        LineComment -> do
+          D.intercalate D.line $ map decode' (headComment : rest)
+        InlineComment -> do
+          let rest' = D.intercalate D.line $ map decode' rest
+          D.join [decode' headComment, rest']
+
+decode' :: Comment -> D.Doc
+decode' com = do
+  case commentType com of
+    LineComment ->
+      D.text $ "//" <> commentText com
+    InlineComment ->
+      D.inlineComment $ "//" <> commentText com
 
 asPrefix :: C -> D.Doc
-asPrefix c =
-  if null c
-    then D.Nil
-    else D.join [decode c, D.line]
+asPrefix commentList = do
+  case uncons commentList of
+    Nothing ->
+      D.Nil
+    Just _ -> do
+      let commentList' = map decode' commentList
+      D.join [D.intercalate D.line commentList', D.line]
+
+asStmtPrefix :: C -> D.Doc
+asStmtPrefix commentList = do
+  asPrefix $ map (\com -> com {commentType = LineComment}) commentList
+
+hasLeadingInlineComment :: C -> Bool
+hasLeadingInlineComment commentList =
+  case uncons commentList of
+    Nothing ->
+      False
+    Just (com, _) ->
+      commentType com == InlineComment
 
 asPrefix' :: C -> D.Doc
 asPrefix' c =
@@ -28,10 +62,13 @@ asPrefix' c =
     else D.join [D.text (T.replicate D.indent " "), D.nest D.indent $ decode c, D.line]
 
 asSuffix :: C -> D.Doc
-asSuffix c =
-  if null c
+asSuffix commentList =
+  if null commentList
     then D.Nil
-    else D.join [D.line, decode c]
+    else do
+      let prefix = if hasLeadingInlineComment commentList then D.text " " else D.line
+      let commentList' = map decode' commentList
+      D.join [prefix, D.intercalate D.line commentList']
 
 asClauseHeader :: C -> D.Doc
 asClauseHeader c =


### PR DESCRIPTION
before:

```
define yo(): unit {
  print("Yo") // Yo
}

↓ (format)

define yo(): unit {
  print("Yo")
  // Yo
}
```

after:


```
define yo(): unit {
  print("Yo") // Yo
}

↓ (format)

define yo(): unit {
  print("Yo") // Yo
}
```