### PR TITLE
add support for heap-free reification

### DIFF
--- a/bench/action/bubble/module.ens
+++ b/bench/action/bubble/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/bench/action/dictionary/module.ens
+++ b/bench/action/dictionary/module.ens
@@ -6,9 +6,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/bench/action/intmap/module.ens
+++ b/bench/action/intmap/module.ens
@@ -6,9 +6,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/book/src/manual-installation.md
+++ b/book/src/manual-installation.md
@@ -11,8 +11,8 @@ Add the below to your `.bashrc`, `.zshrc`, etc.
 
 ```sh
 # this sets the core module (or "prelude") that is used in `neut create`
-export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst"
-export NEUT_CORE_MODULE_DIGEST="ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ"
+export NEUT_CORE_MODULE_URL="https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst"
+export NEUT_CORE_MODULE_DIGEST="7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw"
 ```
 
 Then, get the compiler:

--- a/install.sh
+++ b/install.sh
@@ -142,8 +142,8 @@ printf $BLUE "note: "
 echo "please restart your shell after adding the following environment variables to your shell config:"
 
 echo ""
-echo "export NEUT_CORE_MODULE_URL=\"https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst\""
-echo "export NEUT_CORE_MODULE_DIGEST=\"ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ\""
+echo "export NEUT_CORE_MODULE_URL=\"https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst\""
+echo "export NEUT_CORE_MODULE_DIGEST=\"7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw\""
 
 if command -v apt-get >/dev/null 2>&1; then
   echo "export NEUT_CLANG=$CLANG"

--- a/src/Kernel/Clarify/Move/Clarify.hs
+++ b/src/Kernel/Clarify/Move/Clarify.hs
@@ -340,7 +340,7 @@ clarifyTerm h tenv term =
               clarifyTerm h tenv $ m :< TM.Prim (P.Value (PV.Int t PNS.intSize32 (RU.asInt r)))
     _ :< TM.Magic der -> do
       clarifyMagic h tenv der
-    m :< TM.Resource _ resourceID _ discarder copier -> do
+    m :< TM.Resource _ resourceID _ discarder copier _typeTag -> do
       let liftedName = Locator.attachCurrentLocator (locatorHandle h) $ BN.resourceName resourceID
       switchValue <- liftIO $ Gensym.newIdentFromText (gensymHandle h) "switchValue"
       value <- liftIO $ Gensym.newIdentFromText (gensymHandle h) "value"

--- a/src/Kernel/Clarify/Move/Clarify.hs
+++ b/src/Kernel/Clarify/Move/Clarify.hs
@@ -165,6 +165,7 @@ getBaseAuxEnv auxEnvHandle sigmaHandle = do
   Sigma.registerImmediateS4 sigmaHandle
   Sigma.registerImmediateTypeS4 sigmaHandle
   Sigma.registerImmediateEnumS4 sigmaHandle
+  Sigma.registerImmediateNoemaS4 sigmaHandle
   Sigma.registerClosureS4 sigmaHandle
   AuxEnv.get auxEnvHandle
 
@@ -308,7 +309,7 @@ clarifyTerm h tenv term =
     _ :< TM.Box t -> do
       clarifyTerm h tenv t
     _ :< TM.BoxNoema {} ->
-      return Sigma.returnImmediateS4
+      return Sigma.returnImmediateNoemaS4
     _ :< TM.BoxIntro letSeq e -> do
       embody h tenv letSeq e
     _ :< TM.BoxElim castSeq mxt e1 uncastSeq e2 -> do

--- a/src/Kernel/Clarify/Move/Clarify.hs
+++ b/src/Kernel/Clarify/Move/Clarify.hs
@@ -355,7 +355,7 @@ clarifyTerm h tenv term =
         tagMaker <-
           clarifyTerm h IntMap.empty typeTag
             >>= liftIO . Reduce.reduce (reduceHandle h)
-        let resourceSpec = Utility.ResourceSpec {switch, arg, discard, copy, tagMaker}
+        let resourceSpec = Utility.ResourceSpec {switch, arg, defaultClause = tagMaker, clauses = [discard, copy]}
         liftIO $ Utility.registerSwitcher (utilityHandle h) O.Clear liftedName resourceSpec
       return $ C.UpIntro $ C.VarGlobal liftedName AN.argNumS4
     _ :< TM.Void ->

--- a/src/Kernel/Clarify/Move/Clarify.hs
+++ b/src/Kernel/Clarify/Move/Clarify.hs
@@ -174,7 +174,9 @@ clarifyStmt h stmt =
           od <- liftIO $ OptimizableData.lookup (optDataHandle h) name
           case od of
             Just OD.Enum -> do
-              clarifyStmtDefineBody' h name xts'' Sigma.returnImmediateEnumS4
+              let discrimintList = map (\(_, _, _, _, d) -> d) consInfoList
+              liftIO (Sigma.returnSigmaEnumS4 (sigmaHandle h) name O.Clear discrimintList)
+                >>= clarifyStmtDefineBody' h name xts''
             Just OD.Unary
               | [(_, _, _, [(_, _, t)], _)] <- consInfoList -> do
                   (dataArgs', t') <- clarifyBinderBody h IntMap.empty dataArgs t

--- a/src/Kernel/Clarify/Move/Clarify.hs
+++ b/src/Kernel/Clarify/Move/Clarify.hs
@@ -569,6 +569,13 @@ clarifyMagic h tenv der = do
       return $ C.Primitive (C.Magic (M.Global name lt))
     M.OpaqueValue e ->
       clarifyTerm h tenv e
+    M.CallType func arg1 arg2 -> do
+      (funcVarName, func', funcVar) <- clarifyPlus h tenv func
+      (arg1VarName, arg1', arg1Var) <- clarifyPlus h tenv arg1
+      (arg2VarName, arg2', arg2Var) <- clarifyPlus h tenv arg2
+      return $
+        Utility.bindLet [(funcVarName, func'), (arg1VarName, arg1'), (arg2VarName, arg2')] $
+          C.Primitive (C.Magic (M.CallType funcVar arg1Var arg2Var))
 
 clarifyLambda ::
   Handle ->

--- a/src/Kernel/Clarify/Move/Clarify.hs
+++ b/src/Kernel/Clarify/Move/Clarify.hs
@@ -649,7 +649,7 @@ returnClosure ::
 returnClosure h tenv lamID mName opacity fvs xts e = do
   fvs'' <- dropFst <$> clarifyBinder h tenv fvs
   xts'' <- dropFst <$> clarifyBinder h tenv xts
-  fvEnvSigma <- liftIO $ Sigma.closureEnvS4 (sigmaHandle h) (locatorHandle h) $ map Right fvs''
+  fvEnvSigma <- liftIO $ Sigma.closureEnvS4 (sigmaHandle h) (locatorHandle h) fvs''
   let fvEnv = C.SigmaIntro (map (\(x, _) -> C.VarLocal x) fvs'')
   let argNum = AN.fromInt $ length xts'' + 2 -- argNum == count(xts) + env
   let name = Locator.attachCurrentLocator (locatorHandle h) $ BN.lambdaName mName lamID

--- a/src/Kernel/Clarify/Move/Clarify.hs
+++ b/src/Kernel/Clarify/Move/Clarify.hs
@@ -5,7 +5,6 @@ module Kernel.Clarify.Move.Clarify
     newMain,
     clarify,
     clarifyEntryPoint,
-    registerFoundationalTypes,
   )
 where
 
@@ -154,12 +153,6 @@ clarifyEntryPoint h = do
   forM (Map.toList baseAuxEnv) $ \(x, (opacity, args, e)) -> do
     e' <- Reduce.reduce (mainReduceHandle h) e
     return $ C.Def x opacity args e'
-
-registerFoundationalTypes :: Handle -> IO ()
-registerFoundationalTypes h = do
-  AuxEnv.clear (auxEnvHandle h)
-  auxEnv <- getBaseAuxEnv (auxEnvHandle h) (sigmaHandle h)
-  forM_ (Map.toList auxEnv) $ uncurry $ CompDef.insert (compDefHandle h)
 
 getBaseAuxEnv :: AuxEnv.Handle -> Sigma.Handle -> IO C.DefMap
 getBaseAuxEnv auxEnvHandle sigmaHandle = do

--- a/src/Kernel/Clarify/Move/Clarify.hs
+++ b/src/Kernel/Clarify/Move/Clarify.hs
@@ -163,6 +163,8 @@ registerFoundationalTypes h = do
 getBaseAuxEnv :: AuxEnv.Handle -> Sigma.Handle -> IO C.DefMap
 getBaseAuxEnv auxEnvHandle sigmaHandle = do
   Sigma.registerImmediateS4 sigmaHandle
+  Sigma.registerImmediateTypeS4 sigmaHandle
+  Sigma.registerImmediateEnumS4 sigmaHandle
   Sigma.registerClosureS4 sigmaHandle
   AuxEnv.get auxEnvHandle
 
@@ -180,7 +182,7 @@ clarifyStmt h stmt =
           od <- liftIO $ OptimizableData.lookup (optDataHandle h) name
           case od of
             Just OD.Enum -> do
-              clarifyStmtDefineBody' h name xts'' Sigma.returnImmediateS4
+              clarifyStmtDefineBody' h name xts'' Sigma.returnImmediateEnumS4
             Just OD.Unary
               | [(_, _, _, [(_, _, t)], _)] <- consInfoList -> do
                   (dataArgs', t') <- clarifyBinderBody h IntMap.empty dataArgs t
@@ -250,7 +252,7 @@ clarifyTerm :: Handle -> TM.TypeEnv -> TM.Term -> EIO C.Comp
 clarifyTerm h tenv term =
   case term of
     _ :< TM.Tau -> do
-      return Sigma.returnImmediateS4
+      return Sigma.returnImmediateTypeS4
     _ :< TM.Var x -> do
       return $ C.UpIntro $ C.VarLocal x
     _ :< TM.VarGlobal (AttrVG.Attr {..}) x -> do

--- a/src/Kernel/Clarify/Move/Clarify.hs
+++ b/src/Kernel/Clarify/Move/Clarify.hs
@@ -184,7 +184,7 @@ clarifyStmt h stmt =
               | otherwise ->
                   raiseCritical m "Found a broken unary data"
             _ -> do
-              let dataInfo = map (\(_, _, _, consArgs, discriminant) -> (discriminant, dataArgs, consArgs)) consInfoList
+              let dataInfo = map (\(_, consName, _, consArgs, discriminant) -> (consName, discriminant, dataArgs, consArgs)) consInfoList
               dataInfo' <- mapM (clarifyDataClause h) dataInfo
               liftIO (Sigma.returnSigmaDataS4 (sigmaHandle h) name O.Opaque dataInfo')
                 >>= clarifyStmtDefineBody' h name xts''
@@ -383,12 +383,12 @@ type DataArgsMap = IntMap.IntMap ([(Ident, TM.Term)], Size)
 
 clarifyDataClause ::
   Handle ->
-  (D.Discriminant, [BinderF TM.Term], [BinderF TM.Term]) ->
-  EIO (D.Discriminant, [(Ident, C.Comp)])
-clarifyDataClause h (discriminant, dataArgs, consArgs) = do
+  (DD.DefiniteDescription, D.Discriminant, [BinderF TM.Term], [BinderF TM.Term]) ->
+  EIO (DD.DefiniteDescription, D.Discriminant, [(Ident, C.Comp)])
+clarifyDataClause h (consName, discriminant, dataArgs, consArgs) = do
   let args = dataArgs ++ consArgs
   args' <- dropFst <$> clarifyBinder h IntMap.empty args
-  return (discriminant, args')
+  return (consName, discriminant, args')
 
 clarifyDecisionTree ::
   Handle ->

--- a/src/Kernel/Clarify/Move/Clarify.hs
+++ b/src/Kernel/Clarify/Move/Clarify.hs
@@ -342,20 +342,20 @@ clarifyTerm h tenv term =
       clarifyMagic h tenv der
     m :< TM.Resource _ resourceID _ discarder copier typeTag -> do
       let liftedName = Locator.attachCurrentLocator (locatorHandle h) $ BN.resourceName resourceID
-      switch <- liftIO $ Gensym.createVar (gensymHandle h) "switch"
-      arg@(argVarName, _) <- liftIO $ Gensym.createVar (gensymHandle h) "arg"
-      discard <-
-        clarifyTerm h IntMap.empty (m :< TM.PiElim False discarder [] [m :< TM.Var argVarName])
-          >>= liftIO . Reduce.reduce (reduceHandle h)
-      copy <-
-        clarifyTerm h IntMap.empty (m :< TM.PiElim False copier [] [m :< TM.Var argVarName])
-          >>= liftIO . Reduce.reduce (reduceHandle h)
-      tagMaker <-
-        clarifyTerm h IntMap.empty typeTag
-          >>= liftIO . Reduce.reduce (reduceHandle h)
-      let resourceSpec = Utility.ResourceSpec {switch, arg, discard, copy, tagMaker}
       isAlreadyRegistered <- liftIO $ AuxEnv.checkIfAlreadyRegistered (auxEnvHandle h) liftedName
       unless isAlreadyRegistered $ do
+        switch <- liftIO $ Gensym.createVar (gensymHandle h) "switch"
+        arg@(argVarName, _) <- liftIO $ Gensym.createVar (gensymHandle h) "arg"
+        discard <-
+          clarifyTerm h IntMap.empty (m :< TM.PiElim False discarder [] [m :< TM.Var argVarName])
+            >>= liftIO . Reduce.reduce (reduceHandle h)
+        copy <-
+          clarifyTerm h IntMap.empty (m :< TM.PiElim False copier [] [m :< TM.Var argVarName])
+            >>= liftIO . Reduce.reduce (reduceHandle h)
+        tagMaker <-
+          clarifyTerm h IntMap.empty typeTag
+            >>= liftIO . Reduce.reduce (reduceHandle h)
+        let resourceSpec = Utility.ResourceSpec {switch, arg, discard, copy, tagMaker}
         liftIO $ Utility.registerSwitcher (utilityHandle h) O.Clear liftedName resourceSpec
       return $ C.UpIntro $ C.VarGlobal liftedName AN.argNumS4
     _ :< TM.Void ->

--- a/src/Kernel/Clarify/Move/Clarify.hs
+++ b/src/Kernel/Clarify/Move/Clarify.hs
@@ -174,8 +174,8 @@ clarifyStmt h stmt =
           od <- liftIO $ OptimizableData.lookup (optDataHandle h) name
           case od of
             Just OD.Enum -> do
-              let discrimintList = map (\(_, _, _, _, d) -> d) consInfoList
-              liftIO (Sigma.returnSigmaEnumS4 (sigmaHandle h) name O.Clear discrimintList)
+              let enumInfo = map (\(_, consName, _, _, d) -> (consName, d)) consInfoList
+              liftIO (Sigma.returnSigmaEnumS4 (sigmaHandle h) name O.Clear enumInfo)
                 >>= clarifyStmtDefineBody' h name xts''
             Just OD.Unary
               | [(_, _, _, [(_, _, t)], _)] <- consInfoList -> do

--- a/src/Kernel/Clarify/Move/Internal/Linearize.hs
+++ b/src/Kernel/Clarify/Move/Internal/Linearize.hs
@@ -167,3 +167,8 @@ distinguishPrimitive h z term =
         M.OpaqueValue e -> do
           (vs, e') <- distinguishValue h z e
           return (vs, C.Magic (M.OpaqueValue e'))
+        M.CallType func arg1 arg2 -> do
+          (vs1, func') <- distinguishValue h z func
+          (vs2, arg1') <- distinguishValue h z arg1
+          (vs3, arg2') <- distinguishValue h z arg2
+          return (vs1 <> vs2 <> vs3, C.Magic (M.CallType func' arg1' arg2'))

--- a/src/Kernel/Clarify/Move/Internal/Linearize.hs
+++ b/src/Kernel/Clarify/Move/Internal/Linearize.hs
@@ -2,6 +2,7 @@ module Kernel.Clarify.Move.Internal.Linearize
   ( Handle (..),
     new,
     linearize,
+    linearizeDuplicatedVariables,
   )
 where
 
@@ -43,6 +44,28 @@ linearize h binder e =
           hole <- liftIO $ Gensym.newIdentFromText (gensymHandle h) "unit"
           discardUnusedVar <- Utility.toAffineApp (utilityHandle h) (C.VarLocal x) t
           return $ C.UpElim True hole discardUnusedVar e''
+        [z] ->
+          return $ C.UpElim True z (C.UpIntro (C.VarLocal x)) e''
+        z : zs -> do
+          localName <- liftIO $ Gensym.newIdentFromText (gensymHandle h) $ toText x <> "-local"
+          e''' <- insertHeader h localName z zs t e''
+          return $ C.UpElim False localName (C.UpIntro (C.VarLocal x)) e'''
+
+linearizeDuplicatedVariables ::
+  Handle ->
+  [(Ident, C.Comp)] ->
+  C.Comp ->
+  IO C.Comp
+linearizeDuplicatedVariables h binder e =
+  case binder of
+    [] ->
+      return e
+    (x, t) : xts -> do
+      e' <- linearizeDuplicatedVariables h xts e
+      (newNameList, e'') <- distinguishComp h x e'
+      case newNameList of
+        [] -> do
+          return e''
         [z] ->
           return $ C.UpElim True z (C.UpIntro (C.VarLocal x)) e''
         z : zs -> do
@@ -140,6 +163,9 @@ distinguishPrimitive h z term =
     C.PrimOp op ds -> do
       (vss, ds') <- mapAndUnzipM (distinguishValue h z) ds
       return (concat vss, C.PrimOp op ds')
+    C.ShiftPointer v size index -> do
+      (vs, v') <- distinguishValue h z v
+      return (vs, C.ShiftPointer v' size index)
     C.Magic magic -> do
       case magic of
         M.Cast from to value -> do

--- a/src/Kernel/Clarify/Move/Internal/Sigma.hs
+++ b/src/Kernel/Clarify/Move/Internal/Sigma.hs
@@ -33,6 +33,7 @@ import Language.Common.Rule.Discriminant qualified as D
 import Language.Common.Rule.Ident
 import Language.Common.Rule.Magic qualified as M
 import Language.Common.Rule.Opacity qualified as O
+import Language.Common.Rule.PrimNumSize (IntSize (IntSize))
 import Language.Comp.Move.CreateVar qualified as Gensym
 import Language.Comp.Rule.Comp qualified as C
 import Language.Comp.Rule.EnumCase qualified as EC
@@ -47,26 +48,29 @@ new :: Gensym.Handle -> Linearize.Handle -> Utility.Handle -> Handle
 new gensymHandle linearizeHandle utilityHandle = do
   Handle {..}
 
+defaultTag :: C.Value
+defaultTag = C.Int (IntSize 64) 42
+
 registerImmediateS4 :: Handle -> IO ()
 registerImmediateS4 h = do
   let immediateT _ = return $ C.UpIntro $ C.SigmaIntro []
   let immediate4 arg = return $ C.UpIntro arg
   Utility.registerSwitcher (utilityHandle h) O.Clear DD.imm $
-    ResourceSpec {discard = immediateT, copy = immediate4}
+    ResourceSpec {discard = immediateT, copy = immediate4, tag = defaultTag}
 
 registerImmediateTypeS4 :: Handle -> IO ()
 registerImmediateTypeS4 h = do
   let immediateT _ = return $ C.UpIntro $ C.SigmaIntro []
   let immediate4 arg = return $ C.UpIntro arg
   Utility.registerSwitcher (utilityHandle h) O.Clear DD.immType $
-    ResourceSpec {discard = immediateT, copy = immediate4}
+    ResourceSpec {discard = immediateT, copy = immediate4, tag = defaultTag}
 
 registerImmediateEnumS4 :: Handle -> IO ()
 registerImmediateEnumS4 h = do
   let immediateT _ = return $ C.UpIntro $ C.SigmaIntro []
   let immediate4 arg = return $ C.UpIntro arg
   Utility.registerSwitcher (utilityHandle h) O.Clear DD.immEnum $
-    ResourceSpec {discard = immediateT, copy = immediate4}
+    ResourceSpec {discard = immediateT, copy = immediate4, tag = defaultTag}
 
 registerClosureS4 :: Handle -> IO ()
 registerClosureS4 h = do
@@ -116,7 +120,7 @@ registerSigmaS4 h name opacity mxts = do
 
 makeSigmaResourceSpec :: Handle -> [Either C.Comp (Ident, C.Comp)] -> ResourceSpec
 makeSigmaResourceSpec h mxts =
-  ResourceSpec {discard = sigmaT h mxts, copy = sigma4 h mxts}
+  ResourceSpec {discard = sigmaT h mxts, copy = sigma4 h mxts, tag = defaultTag}
 
 -- (Assuming `ti` = `return di` for some `di` such that `xi : di`)
 -- sigmaT NAME LOC [(x1, t1), ..., (xn, tn)]   ~>
@@ -209,7 +213,7 @@ returnSigmaDataS4 h dataName opacity dataInfo = do
   let discard = sigmaDataT h dataInfo
   let copy = sigmaData4 h dataInfo
   let dataName' = DD.getFormDD dataName
-  Utility.registerSwitcher (utilityHandle h) opacity dataName' $ ResourceSpec {discard, copy}
+  Utility.registerSwitcher (utilityHandle h) opacity dataName' $ ResourceSpec {discard, copy, tag = defaultTag}
   return $ C.UpIntro $ C.VarGlobal dataName' AN.argNumS4
 
 sigmaData4 :: Handle -> [(D.Discriminant, [(Ident, C.Comp)])] -> C.Value -> IO C.Comp

--- a/src/Kernel/Clarify/Move/Internal/Sigma.hs
+++ b/src/Kernel/Clarify/Move/Internal/Sigma.hs
@@ -2,9 +2,13 @@ module Kernel.Clarify.Move.Internal.Sigma
   ( Handle (..),
     new,
     registerImmediateS4,
+    registerImmediateTypeS4,
+    registerImmediateEnumS4,
     registerClosureS4,
     immediateS4,
     returnImmediateS4,
+    returnImmediateTypeS4,
+    returnImmediateEnumS4,
     returnClosureS4,
     closureEnvS4,
     returnSigmaDataS4,
@@ -48,6 +52,18 @@ registerImmediateS4 h = do
   let immediate4 arg = return $ C.UpIntro arg
   Utility.registerSwitcher (utilityHandle h) O.Clear DD.imm immediateT immediate4
 
+registerImmediateTypeS4 :: Handle -> IO ()
+registerImmediateTypeS4 h = do
+  let immediateT _ = return $ C.UpIntro $ C.SigmaIntro []
+  let immediate4 arg = return $ C.UpIntro arg
+  Utility.registerSwitcher (utilityHandle h) O.Clear DD.immType immediateT immediate4
+
+registerImmediateEnumS4 :: Handle -> IO ()
+registerImmediateEnumS4 h = do
+  let immediateT _ = return $ C.UpIntro $ C.SigmaIntro []
+  let immediate4 arg = return $ C.UpIntro arg
+  Utility.registerSwitcher (utilityHandle h) O.Clear DD.immEnum immediateT immediate4
+
 registerClosureS4 :: Handle -> IO ()
 registerClosureS4 h = do
   (env, envVar) <- Gensym.createVar (gensymHandle h) "env"
@@ -61,6 +77,14 @@ returnImmediateS4 :: C.Comp
 returnImmediateS4 = do
   C.UpIntro immediateS4
 
+returnImmediateTypeS4 :: C.Comp
+returnImmediateTypeS4 = do
+  C.UpIntro immediateTypeS4
+
+returnImmediateEnumS4 :: C.Comp
+returnImmediateEnumS4 = do
+  C.UpIntro immediateEnumS4
+
 returnClosureS4 :: C.Comp
 returnClosureS4 = do
   C.UpIntro $ C.VarGlobal DD.cls AN.argNumS4
@@ -68,6 +92,14 @@ returnClosureS4 = do
 immediateS4 :: C.Value
 immediateS4 = do
   C.VarGlobal DD.imm AN.argNumS4
+
+immediateTypeS4 :: C.Value
+immediateTypeS4 = do
+  C.VarGlobal DD.immType AN.argNumS4
+
+immediateEnumS4 :: C.Value
+immediateEnumS4 = do
+  C.VarGlobal DD.immEnum AN.argNumS4
 
 registerSigmaS4 ::
   Handle ->

--- a/src/Kernel/Clarify/Move/Internal/Sigma.hs
+++ b/src/Kernel/Clarify/Move/Internal/Sigma.hs
@@ -60,7 +60,7 @@ registerImmediateS4 h = do
     let discard = C.UpIntro $ C.SigmaIntro []
     let copy = C.UpIntro argVar
     Utility.registerSwitcher (utilityHandle h) O.Clear name $ do
-      ResourceSpec {switch, arg, discard, copy, tagMaker = newTagMaker typeTag}
+      ResourceSpec {switch, arg, defaultClause = newTagMaker typeTag, clauses = [discard, copy]}
 
 registerClosureS4 :: Handle -> IO ()
 registerClosureS4 h = do
@@ -149,7 +149,7 @@ makeSigmaResourceSpec h mxts tagMaker = do
   arg@(_, argVar) <- Gensym.createVar (gensymHandle h) "arg"
   discard <- sigmaT h mxts argVar
   copy <- sigma4 h mxts argVar
-  return $ ResourceSpec {switch, arg, discard, copy, tagMaker}
+  return $ ResourceSpec {switch, arg, defaultClause = tagMaker, clauses = [discard, copy]}
 
 -- (Assuming `ti` = `return di` for some `di` such that `xi : di`)
 -- sigmaT NAME LOC [(x1, t1), ..., (xn, tn)]   ~>
@@ -245,7 +245,7 @@ returnSigmaDataS4 h dataName opacity dataInfo = do
   discard <- sigmaDataT h dataInfo argVar
   copy <- sigmaData4 h dataInfo argVar
   let dataName' = DD.getFormDD dataName
-  Utility.registerSwitcher (utilityHandle h) opacity dataName' $ ResourceSpec {switch, arg, discard, copy, tagMaker = newTagMaker Algebraic}
+  Utility.registerSwitcher (utilityHandle h) opacity dataName' $ ResourceSpec {switch, arg, defaultClause = newTagMaker Algebraic, clauses = [discard, copy]}
   return $ C.UpIntro $ C.VarGlobal dataName' AN.argNumS4
 
 sigmaData4 :: Handle -> [(D.Discriminant, [(Ident, C.Comp)])] -> C.Value -> IO C.Comp

--- a/src/Kernel/Clarify/Move/Internal/Sigma.hs
+++ b/src/Kernel/Clarify/Move/Internal/Sigma.hs
@@ -35,7 +35,7 @@ import Language.Common.Rule.Discriminant qualified as D
 import Language.Common.Rule.Ident
 import Language.Common.Rule.Magic qualified as M
 import Language.Common.Rule.Opacity qualified as O
-import Language.Common.Rule.PrimNumSize (IntSize (IntSize))
+import Language.Common.Rule.PrimNumSize (IntSize (..))
 import Language.Comp.Move.CreateVar qualified as Gensym
 import Language.Comp.Rule.Comp qualified as C
 import Language.Comp.Rule.EnumCase qualified as EC
@@ -292,7 +292,7 @@ data TypeTag
 newTagMaker :: TypeTag -> C.Comp
 newTagMaker tag = do
   C.UpIntro $
-    C.Int (IntSize 64) $
+    C.Int IntSize64 $
       case tag of
         Opaque ->
           0

--- a/src/Kernel/Clarify/Move/Internal/Utility.hs
+++ b/src/Kernel/Clarify/Move/Internal/Utility.hs
@@ -76,19 +76,19 @@ makeSwitcher ::
   ResourceSpec ->
   IO ([Ident], C.Comp)
 makeSwitcher h resourceSpec = do
-  let ResourceSpec {discard, copy, tagMaker} = resourceSpec
+  let ResourceSpec {defaultClause, clauses} = resourceSpec
   let (argVarName, _) = arg resourceSpec
   let (switchVarName, switchVar) = switch resourceSpec
-  enumElim <- getEnumElim h [argVarName] switchVar tagMaker [(EC.Int 0, discard), (EC.Int 1, copy)]
+  let clauseList = zip (map EC.Int [0 ..]) clauses
+  enumElim <- getEnumElim h [argVarName] switchVar defaultClause clauseList
   return ([switchVarName, argVarName], enumElim)
 
 data ResourceSpec
   = ResourceSpec
   { switch :: (Ident, C.Value),
     arg :: (Ident, C.Value),
-    discard :: C.Comp,
-    copy :: C.Comp,
-    tagMaker :: C.Comp
+    defaultClause :: C.Comp,
+    clauses :: [C.Comp]
   }
 
 registerSwitcher ::

--- a/src/Kernel/Clarify/Move/Internal/Utility.hs
+++ b/src/Kernel/Clarify/Move/Internal/Utility.hs
@@ -16,6 +16,7 @@ import Data.IntMap qualified as IntMap
 import Gensym.Rule.Handle qualified as Gensym
 import Kernel.Clarify.Move.Internal.Handle.AuxEnv qualified as AuxEnv
 import Language.Common.Move.CreateSymbol qualified as Gensym
+import Language.Common.Rule.DataSize qualified as DS
 import Language.Common.Rule.DefiniteDescription qualified as DD
 import Language.Common.Rule.Ident
 import Language.Common.Rule.Ident.Reify
@@ -31,10 +32,10 @@ data Handle = Handle
   { gensymHandle :: Gensym.Handle,
     substHandle :: Subst.Handle,
     auxEnvHandle :: AuxEnv.Handle,
-    baseSize :: Int
+    baseSize :: DS.DataSize
   }
 
-new :: Gensym.Handle -> Subst.Handle -> AuxEnv.Handle -> Int -> Handle
+new :: Gensym.Handle -> Subst.Handle -> AuxEnv.Handle -> DS.DataSize -> Handle
 new gensymHandle substHandle auxEnvHandle baseSize = do
   Handle {..}
 
@@ -44,7 +45,7 @@ new gensymHandle substHandle auxEnvHandle baseSize = do
 toAffineApp :: Handle -> C.Value -> C.Comp -> IO C.Comp
 toAffineApp h v t = do
   (expVarName, expVar) <- Gensym.createVar (gensymHandle h) "exp"
-  return $ C.UpElim True expVarName t (C.PiElimDownElim expVar [C.Int (IntSize (baseSize h)) 0, v])
+  return $ C.UpElim True expVarName t (C.PiElimDownElim expVar [C.Int (dataSizeToIntSize (baseSize h)) 0, v])
 
 -- toRelevantApp meta x t ~>
 --   bind exp := t in
@@ -52,7 +53,7 @@ toAffineApp h v t = do
 toRelevantApp :: Handle -> C.Value -> C.Comp -> IO C.Comp
 toRelevantApp h v t = do
   (expVarName, expVar) <- Gensym.createVar (gensymHandle h) "exp"
-  return $ C.UpElim True expVarName t (C.PiElimDownElim expVar [C.Int (IntSize (baseSize h)) 1, v])
+  return $ C.UpElim True expVarName t (C.PiElimDownElim expVar [C.Int (dataSizeToIntSize (baseSize h)) 1, v])
 
 bindLet :: [(Ident, C.Comp)] -> C.Comp -> C.Comp
 bindLet =

--- a/src/Kernel/Common/Rule/TypeTag.hs
+++ b/src/Kernel/Common/Rule/TypeTag.hs
@@ -1,0 +1,102 @@
+module Kernel.Common.Rule.TypeTag
+  ( TypeTag (..),
+    typeTagToInteger,
+    immTypeTagMap,
+    baseTypeTagMap,
+  )
+where
+
+import Language.Common.Rule.DefiniteDescription qualified as DD
+
+data TypeTag
+  = Opaque
+  | Type
+  | Function
+  | Algebraic
+  | Noema
+  | Enum
+  | Int1
+  | Int2
+  | Int4
+  | Int8
+  | Int16
+  | Int32
+  | Int64
+  | Float16
+  | Float32
+  | Float64
+  | Pointer
+  | Null
+  | Rune
+  | Binary
+  | Vector
+
+immTypeTagMap :: [(DD.DefiniteDescription, TypeTag)]
+immTypeTagMap =
+  [ (DD.immType, Type),
+    (DD.immNoema, Noema),
+    (DD.immEnum, Enum),
+    (DD.immInt1, Int1),
+    (DD.immInt2, Int2),
+    (DD.immInt4, Int4),
+    (DD.immInt8, Int8),
+    (DD.immInt16, Int16),
+    (DD.immInt32, Int32),
+    (DD.immInt64, Int64),
+    (DD.immFloat16, Float16),
+    (DD.immFloat32, Float32),
+    (DD.immFloat64, Float64),
+    (DD.immPointer, Pointer),
+    (DD.immNull, Null),
+    (DD.immRune, Rune)
+  ]
+
+baseTypeTagMap :: [(DD.DefiniteDescription, TypeTag)]
+baseTypeTagMap =
+  immTypeTagMap ++ [(DD.cls, Function)]
+
+typeTagToInteger :: TypeTag -> Integer
+typeTagToInteger tag =
+  case tag of
+    Opaque ->
+      0
+    Type ->
+      1
+    Function ->
+      2
+    Algebraic ->
+      3
+    Noema ->
+      4
+    Enum ->
+      5
+    Int1 ->
+      6
+    Int2 ->
+      7
+    Int4 ->
+      8
+    Int8 ->
+      9
+    Int16 ->
+      10
+    Int32 ->
+      11
+    Int64 ->
+      12
+    Float16 ->
+      13
+    Float32 ->
+      14
+    Float64 ->
+      15
+    Pointer ->
+      16
+    Null ->
+      17
+    Rune ->
+      18
+    Binary ->
+      19
+    Vector ->
+      20

--- a/src/Kernel/Common/Rule/TypeTag.hs
+++ b/src/Kernel/Common/Rule/TypeTag.hs
@@ -35,7 +35,6 @@ immTypeTagMap :: [(DD.DefiniteDescription, TypeTag)]
 immTypeTagMap =
   [ (DD.immType, Type),
     (DD.immNoema, Noema),
-    (DD.immEnum, Enum),
     (DD.immInt1, Int1),
     (DD.immInt2, Int2),
     (DD.immInt4, Int4),

--- a/src/Kernel/Elaborate/Move/Elaborate.hs
+++ b/src/Kernel/Elaborate/Move/Elaborate.hs
@@ -368,11 +368,12 @@ elaborate' h term =
           let typeRemark = L.newLog m remarkLevel message
           liftIO $ LocalLogs.insert (localLogsHandle h) typeRemark
           return e'
-    m :< WT.Resource dd resourceID unitType discarder copier -> do
+    m :< WT.Resource dd resourceID unitType discarder copier typeTag -> do
       unitType' <- elaborate' h unitType
       discarder' <- elaborate' h discarder
       copier' <- elaborate' h copier
-      return $ m :< TM.Resource dd resourceID unitType' discarder' copier'
+      typeTag' <- elaborate' h typeTag
+      return $ m :< TM.Resource dd resourceID unitType' discarder' copier' typeTag'
     m :< WT.Void ->
       return $ m :< TM.Void
 

--- a/src/Kernel/Elaborate/Move/Elaborate.hs
+++ b/src/Kernel/Elaborate/Move/Elaborate.hs
@@ -354,6 +354,11 @@ elaborate' h term =
         M.OpaqueValue e -> do
           e' <- elaborate' h e
           return $ m :< TM.Magic (M.OpaqueValue e')
+        M.CallType func arg1 arg2 -> do
+          func' <- elaborate' h func
+          arg1' <- elaborate' h arg1
+          arg2' <- elaborate' h arg2
+          return $ m :< TM.Magic (M.CallType func' arg1' arg2')
     m :< WT.Annotation remarkLevel annot e -> do
       e' <- elaborate' h e
       case annot of

--- a/src/Kernel/Elaborate/Move/Internal/EnsureAffinity.hs
+++ b/src/Kernel/Elaborate/Move/Internal/EnsureAffinity.hs
@@ -225,11 +225,12 @@ analyze h term = do
           cs2 <- analyze h arg1
           cs3 <- analyze h arg2
           return $ cs1 ++ cs2 ++ cs3
-    _ :< TM.Resource _ _ unitType discarder copier -> do
+    _ :< TM.Resource _ _ unitType discarder copier typeTag -> do
       cs1 <- analyze h unitType
       cs2 <- analyze h discarder
       cs3 <- analyze h copier
-      return $ cs1 ++ cs2 ++ cs3
+      cs4 <- analyze h typeTag
+      return $ cs1 ++ cs2 ++ cs3 ++ cs4
     _ :< TM.Void ->
       return []
 

--- a/src/Kernel/Elaborate/Move/Internal/EnsureAffinity.hs
+++ b/src/Kernel/Elaborate/Move/Internal/EnsureAffinity.hs
@@ -220,6 +220,11 @@ analyze h term = do
           return []
         M.OpaqueValue e ->
           analyze h e
+        M.CallType func arg1 arg2 -> do
+          cs1 <- analyze h func
+          cs2 <- analyze h arg1
+          cs3 <- analyze h arg2
+          return $ cs1 ++ cs2 ++ cs3
     _ :< TM.Resource _ _ unitType discarder copier -> do
       cs1 <- analyze h unitType
       cs2 <- analyze h discarder

--- a/src/Kernel/Elaborate/Move/Internal/Infer.hs
+++ b/src/Kernel/Elaborate/Move/Internal/Infer.hs
@@ -345,6 +345,14 @@ infer h term =
         M.OpaqueValue e -> do
           (e', t) <- infer h e
           return (m :< WT.Magic (M.WeakMagic $ M.OpaqueValue e'), t)
+        M.CallType func arg1 arg2 -> do
+          func' <- inferType h func
+          (arg1', t1) <- infer h arg1
+          (arg2', _) <- infer h arg2
+          intType <- getIntType (platformHandle h) m
+          liftIO $ Constraint.insert (constraintHandle h) intType t1
+          resultType <- liftIO $ newHole h m (varEnv h)
+          return (m :< WT.Magic (M.WeakMagic $ M.CallType func' arg1' arg2'), resultType)
     m :< WT.Annotation logLevel annot e -> do
       (e', t) <- infer h e
       case annot of

--- a/src/Kernel/Elaborate/Move/Internal/Infer.hs
+++ b/src/Kernel/Elaborate/Move/Internal/Infer.hs
@@ -136,7 +136,7 @@ inferStmtKind h stmtKind =
 
 getIntType :: Platform.Handle -> Hint -> EIO WT.WeakTerm
 getIntType h m = do
-  let baseSize = Platform.getDataSizeValue h
+  let baseSize = Platform.getDataSize h
   return $ WT.intTypeBySize m baseSize
 
 getMainUnitType :: StmtKind WT.WeakTerm -> Maybe WT.WeakTerm

--- a/src/Kernel/Elaborate/Move/Internal/WeakTerm/Fill.hs
+++ b/src/Kernel/Elaborate/Move/Internal/WeakTerm/Fill.hs
@@ -134,11 +134,12 @@ fill h holeSubst term =
         AN.Type t -> do
           t' <- fill h holeSubst t
           return $ m :< WT.Annotation logLevel (AN.Type t') e'
-    m :< WT.Resource dd resourceID unitType discarder copier -> do
+    m :< WT.Resource dd resourceID unitType discarder copier typeTag -> do
       unitType' <- fill h holeSubst unitType
       discarder' <- fill h holeSubst discarder
       copier' <- fill h holeSubst copier
-      return $ m :< WT.Resource dd resourceID unitType' discarder' copier'
+      typeTag' <- fill h holeSubst typeTag
+      return $ m :< WT.Resource dd resourceID unitType' discarder' copier' typeTag'
     _ :< WT.Void ->
       return term
 

--- a/src/Kernel/Emit/Move/Internal/LowComp.hs
+++ b/src/Kernel/Emit/Move/Internal/LowComp.hs
@@ -42,7 +42,7 @@ new globalHandle retType = do
   let currentLabel = Nothing
   let goalLabel = Nothing
   labelMapRef <- liftIO $ newIORef IntMap.empty
-  let baseSize = Platform.getDataSizeValue (Global.platformHandle globalHandle)
+  let baseSize = Platform.getDataSize (Global.platformHandle globalHandle)
   let emitOpHandle = EmitOp.new baseSize
   let gensymHandle = Global.gensymHandle globalHandle
   return $ Handle {..}

--- a/src/Kernel/Emit/Rule/LowOp.hs
+++ b/src/Kernel/Emit/Rule/LowOp.hs
@@ -11,20 +11,20 @@ import Data.Text.Encoding qualified as TE
 import Kernel.Emit.Rule.LowType
 import Kernel.Emit.Rule.LowValue
 import Kernel.Emit.Rule.PrimType
+import Language.Common.Rule.DataSize (DataSize)
 import Language.Common.Rule.LowType qualified as LT
 import Language.Common.Rule.PrimNumSize
 import Language.Common.Rule.PrimOp
 import Language.Common.Rule.PrimType qualified as PT
 import Language.LowComp.Rule.LowComp qualified as LC
 
-data Handle = Handle
-  { baseSize :: Int,
-    intType :: LT.LowType
+newtype Handle = Handle
+  { intType :: LT.LowType
   }
 
-new :: Int -> Handle
+new :: DataSize -> Handle
 new baseSize = do
-  let intType = LT.PrimNum $ PT.Int $ IntSize baseSize
+  let intType = LT.PrimNum $ PT.Int $ dataSizeToIntSize baseSize
   Handle {..}
 
 emitLowOp :: Handle -> LC.Op -> Builder

--- a/src/Kernel/Emit/Rule/PrimType.hs
+++ b/src/Kernel/Emit/Rule/PrimType.hs
@@ -17,6 +17,6 @@ emitPrimType lowType =
     PT.Float FloatSize64 ->
       "double"
     PT.Rune ->
-      emitPrimType $ PT.Int intSize32
+      emitPrimType $ PT.Int IntSize32
     PT.Pointer ->
       "ptr"

--- a/src/Kernel/Lower/Move/Lower.hs
+++ b/src/Kernel/Lower/Move/Lower.hs
@@ -34,6 +34,7 @@ import Kernel.Common.Rule.Arch qualified as A
 import Kernel.Common.Rule.Const
 import Kernel.Common.Rule.Handle.Global.Env qualified as Env
 import Kernel.Common.Rule.Target
+import Kernel.Common.Rule.TypeTag (baseTypeTagMap)
 import Kernel.Lower.Rule.Cancel
 import Language.Common.Move.CreateSymbol qualified as Gensym
 import Language.Common.Rule.ArgNum qualified as AN
@@ -92,8 +93,8 @@ makeBaseDeclEnv arch = do
 lower :: Handle -> [C.CompStmt] -> EIO LC.LowCode
 lower h stmtList = do
   liftIO $ registerInternalNames h stmtList
-  liftIO $ insDeclEnv h (DN.In DD.imm) AN.argNumS4
-  liftIO $ insDeclEnv h (DN.In DD.cls) AN.argNumS4
+  liftIO $ forM baseTypeTagMap $ \(dd, _) ->
+    insDeclEnv h (DN.In dd) AN.argNumS4
   stmtList' <- catMaybes <$> mapM (lowerStmt h) stmtList
   LC.LowCodeNormal <$> liftIO (summarize h stmtList')
 

--- a/src/Kernel/Lower/Move/Lower.hs
+++ b/src/Kernel/Lower/Move/Lower.hs
@@ -260,6 +260,18 @@ lowerCompPrimitive h resultVar codeOp cont =
           uncast h resultVar (LC.VarExternal name) t' cont
         M.OpaqueValue e ->
           lowerValue h resultVar e cont
+        M.CallType func arg1 arg2 -> do
+          (funcVar, funcValue) <- liftIO $ newValueLocal h "func"
+          (arg1Var, arg1Value) <- liftIO $ newValueLocal h "arg1"
+          (arg2Var, arg2Value) <- liftIO $ newValueLocal h "arg2"
+          let arg1Type = LT.Pointer
+          let arg2Type = LT.Pointer
+          let resultType = LT.Pointer
+          lowerValue h funcVar func
+            =<< lowerValue h arg1Var arg1
+            =<< lowerValue h arg2Var arg2
+            =<< return . LC.Let resultVar (LC.Call resultType funcValue [(arg1Type, arg1Value), (arg2Type, arg2Value)])
+            =<< return cont
 
 lowerCompPrimOp :: Handle -> Ident -> PrimOp -> [C.Value] -> LC.Comp -> EIO LC.Comp
 lowerCompPrimOp h resultVar op vs cont = do

--- a/src/Kernel/Lower/Move/Lower.hs
+++ b/src/Kernel/Lower/Move/Lower.hs
@@ -208,8 +208,8 @@ lowerCompPrimitive h resultVar codeOp cont =
       lowerCompPrimOp h resultVar op vs cont
     C.ShiftPointer v size index -> do
       (ptrVar, ptr) <- liftIO $ newValueLocal h "func"
-      let aggType = AggTypeStruct $ map (const LT.Pointer) [1 .. size]
-      let indexList' = [(LC.Int index, LT.PrimNum $ PT.Int IntSize32)]
+      let aggType = AggTypeArray (fromInteger size) LT.Pointer
+      let indexList' = [(LC.Int 0, LT.PrimNum $ PT.Int IntSize32), (LC.Int index, LT.PrimNum $ PT.Int IntSize32)]
       lowerValue h ptrVar v
         =<< return (LC.Let resultVar (LC.GetElementPtr (ptr, toLowType aggType) indexList') cont)
     C.Magic der -> do

--- a/src/Kernel/Lower/Move/Lower.hs
+++ b/src/Kernel/Lower/Move/Lower.hs
@@ -206,6 +206,12 @@ lowerCompPrimitive h resultVar codeOp cont =
   case codeOp of
     C.PrimOp op vs ->
       lowerCompPrimOp h resultVar op vs cont
+    C.ShiftPointer v size index -> do
+      (ptrVar, ptr) <- liftIO $ newValueLocal h "func"
+      let aggType = AggTypeStruct $ map (const LT.Pointer) [1 .. size]
+      let indexList' = [(LC.Int index, LT.PrimNum $ PT.Int IntSize32)]
+      lowerValue h ptrVar v
+        =<< return (LC.Let resultVar (LC.GetElementPtr (ptr, toLowType aggType) indexList') cont)
     C.Magic der -> do
       case der of
         M.Cast _ _ value -> do

--- a/src/Kernel/Parse/Move/Internal/Discern.hs
+++ b/src/Kernel/Parse/Move/Internal/Discern.hs
@@ -568,6 +568,11 @@ discernMagic h m magic =
     RT.OpaqueValue _ (_, (e, _)) -> do
       e' <- discern h e
       return $ M.WeakMagic $ M.OpaqueValue e'
+    RT.CallType _ (_, (func, _)) (_, (arg1, _)) (_, (arg2, _)) -> do
+      func' <- discern h func
+      arg1' <- discern h arg1
+      arg2' <- discern h arg2
+      return $ M.WeakMagic $ M.CallType func' arg1' arg2'
 
 modifyLetContinuation ::
   H.Handle ->

--- a/src/Kernel/Parse/Move/Internal/Discern/Name.hs
+++ b/src/Kernel/Parse/Move/Internal/Discern/Name.hs
@@ -164,7 +164,7 @@ interpretTopLevelFunc m dd argNum isConstLike = do
 
 castFromIntToBool :: H.Handle -> WT.WeakTerm -> EIO WT.WeakTerm
 castFromIntToBool h e@(m :< _) = do
-  let i1 = m :< WT.Prim (WP.Type (PT.Int (PNS.IntSize 1)))
+  let i1 = m :< WT.Prim (WP.Type (PT.Int PNS.IntSize1))
   l <- liftEither $ DD.getLocatorPair m C.coreBool
   (dd, (_, gn)) <- resolveLocator h m l False
   bool <- interpretGlobalName h m dd gn

--- a/src/Kernel/Parse/Move/Internal/Handle/NameMap.hs
+++ b/src/Kernel/Parse/Move/Internal/Handle/NameMap.hs
@@ -188,7 +188,7 @@ _getGlobalNames stmt = do
           []
     PostRawStmtNominal {} -> do
       []
-    PostRawStmtDefineResource _ m (name, _) _ _ _ -> do
+    PostRawStmtDefineResource _ m (name, _) _ _ _ _ -> do
       [(name, (m, GN.TopLevelFunc AN.zero True))]
     PostRawStmtForeign {} ->
       []

--- a/src/Kernel/Parse/Move/Internal/Program.hs
+++ b/src/Kernel/Parse/Move/Internal/Program.hs
@@ -195,7 +195,7 @@ parseResource h = do
   (name, c2) <- baseName
   (handlers, c) <- seriesBrace $ rawExpr h
   case SE.elems handlers of
-    [discarder, copier] -> do
-      return (RawStmtDefineResource c1 m (name, c2) discarder copier (SE.trailingComment handlers), c)
+    [discarder, copier, typeTag] -> do
+      return (RawStmtDefineResource c1 m (name, c2) discarder copier typeTag (SE.trailingComment handlers), c)
     _ ->
-      failure Nothing (S.fromList [asLabel "discarder and copier"])
+      failure Nothing (S.fromList [asLabel "discarder, copier, and type-tag"])

--- a/src/Kernel/Parse/Move/Internal/Program.hs
+++ b/src/Kernel/Parse/Move/Internal/Program.hs
@@ -9,7 +9,6 @@ import CodeParser.Move.Parse
 import CodeParser.Rule.Parser
 import Control.Monad
 import Control.Monad.Trans
-import Data.Set qualified as S
 import Data.Text qualified as T
 import Error.Move.Run (raiseError)
 import Kernel.Parse.Move.Internal.RawTerm
@@ -198,4 +197,4 @@ parseResource h = do
     [discarder, copier, typeTag] -> do
       return (RawStmtDefineResource c1 m (name, c2) discarder copier typeTag (SE.trailingComment handlers), c)
     _ ->
-      failure Nothing (S.fromList [asLabel "discarder, copier, and type-tag"])
+      lift $ raiseError m $ "`resource` must have 3 elements, but found: " <> T.pack (show $ length $ SE.elems handlers)

--- a/src/Kernel/Parse/Move/Internal/RawTerm.hs
+++ b/src/Kernel/Parse/Move/Internal/RawTerm.hs
@@ -439,7 +439,8 @@ rawTermMagic h m c = do
       rawTermMagicAlloca h m c,
       rawTermMagicExternal h m c,
       rawTermMagicOpaqueValue h m c,
-      rawTermMagicGlobal h m c
+      rawTermMagicGlobal h m c,
+      rawTermMagicCallType h m c
     ]
 
 rawTermMagicBase :: T.Text -> Parser (C -> C -> a) -> Parser (a, C)
@@ -524,6 +525,16 @@ rawTermMagicOpaqueValue h m c0 = do
   c1 <- keyword "opaque-value"
   (c2, (e, c)) <- betweenBrace $ rawExpr h
   return (m :< RT.Magic c0 (RT.OpaqueValue c1 (c2, e)), c)
+
+rawTermMagicCallType :: Handle -> Hint -> C -> Parser (RT.RawTerm, C)
+rawTermMagicCallType h m c = do
+  rawTermMagicBase "call-type" $ do
+    func <- rawTerm h
+    c3 <- delimiter ","
+    arg1 <- rawTerm h
+    c4 <- delimiter ","
+    arg2 <- rawTerm h
+    return $ \c1 c2 -> m :< RT.Magic c (RT.CallType c1 (c2, func) (c3, arg1) (c4, arg2))
 
 rawTermMatch :: Handle -> Hint -> C -> Bool -> Parser (RT.RawTerm, C)
 rawTermMatch h m c1 isNoetic = do

--- a/src/Kernel/Parse/Move/Parse.hs
+++ b/src/Kernel/Parse/Move/Parse.hs
@@ -112,9 +112,9 @@ postprocess' h stmt = do
       let name' = Locator.attachCurrentLocator h name
       let consInfo' = fmap (liftRawCons h) consInfo
       defineData m name' args (SE.extract consInfo') loc
-    RawStmtDefineResource c m (name, c1) (c2, discarder) (c3, copier) c4 -> do
+    RawStmtDefineResource c m (name, c1) (c2, discarder) (c3, copier) (c4, typeTag) c5 -> do
       let name' = Locator.attachCurrentLocator h name
-      [PostRawStmtDefineResource c m (name', c1) (c2, discarder) (c3, copier) c4]
+      [PostRawStmtDefineResource c m (name', c1) (c2, discarder) (c3, copier) (c4, typeTag) c5]
     RawStmtNominal c m geistList -> do
       let geistList' = fmap (first (liftGeist h)) geistList
       [PostRawStmtNominal c m geistList']

--- a/src/Language/Common/Rule/BaseName.hs
+++ b/src/Language/Common/Rule/BaseName.hs
@@ -25,6 +25,7 @@ module Language.Common.Rule.BaseName
     imm,
     immType,
     immEnum,
+    immNoema,
     cls,
     cell,
     arrayType,
@@ -135,6 +136,10 @@ immType =
 immEnum :: BaseName
 immEnum =
   MakeBaseName "imm-enum"
+
+immNoema :: BaseName
+immNoema =
+  MakeBaseName "imm-noema"
 
 cls :: BaseName
 cls =

--- a/src/Language/Common/Rule/BaseName.hs
+++ b/src/Language/Common/Rule/BaseName.hs
@@ -23,6 +23,8 @@ module Language.Common.Rule.BaseName
     internalBaseName,
     cons,
     imm,
+    immType,
+    immEnum,
     cls,
     cell,
     arrayType,
@@ -125,6 +127,14 @@ new =
 imm :: BaseName
 imm =
   MakeBaseName "imm"
+
+immType :: BaseName
+immType =
+  MakeBaseName "imm-type"
+
+immEnum :: BaseName
+immEnum =
+  MakeBaseName "imm-enum"
 
 cls :: BaseName
 cls =

--- a/src/Language/Common/Rule/BaseName.hs
+++ b/src/Language/Common/Rule/BaseName.hs
@@ -23,7 +23,6 @@ module Language.Common.Rule.BaseName
     internalBaseName,
     cons,
     immType,
-    immEnum,
     immNoema,
     immInt1,
     immInt2,
@@ -140,10 +139,6 @@ new =
 immType :: BaseName
 immType =
   MakeBaseName "imm-type"
-
-immEnum :: BaseName
-immEnum =
-  MakeBaseName "imm-enum"
 
 immNoema :: BaseName
 immNoema =

--- a/src/Language/Common/Rule/BaseName.hs
+++ b/src/Language/Common/Rule/BaseName.hs
@@ -22,10 +22,22 @@ module Language.Common.Rule.BaseName
     core,
     internalBaseName,
     cons,
-    imm,
     immType,
     immEnum,
     immNoema,
+    immInt1,
+    immInt2,
+    immInt4,
+    immInt8,
+    immInt16,
+    immInt32,
+    immInt64,
+    immFloat16,
+    immFloat32,
+    immFloat64,
+    immRune,
+    immPointer,
+    immNull,
     cls,
     cell,
     arrayType,
@@ -125,10 +137,6 @@ new :: BaseName
 new =
   MakeBaseName "New"
 
-imm :: BaseName
-imm =
-  MakeBaseName "imm"
-
 immType :: BaseName
 immType =
   MakeBaseName "imm-type"
@@ -140,6 +148,58 @@ immEnum =
 immNoema :: BaseName
 immNoema =
   MakeBaseName "imm-noema"
+
+immInt1 :: BaseName
+immInt1 =
+  MakeBaseName "imm-int1"
+
+immInt2 :: BaseName
+immInt2 =
+  MakeBaseName "imm-int2"
+
+immInt4 :: BaseName
+immInt4 =
+  MakeBaseName "imm-int4"
+
+immInt8 :: BaseName
+immInt8 =
+  MakeBaseName "imm-int8"
+
+immInt16 :: BaseName
+immInt16 =
+  MakeBaseName "imm-int16"
+
+immInt32 :: BaseName
+immInt32 =
+  MakeBaseName "imm-int32"
+
+immInt64 :: BaseName
+immInt64 =
+  MakeBaseName "imm-int64"
+
+immFloat16 :: BaseName
+immFloat16 =
+  MakeBaseName "imm-float16"
+
+immFloat32 :: BaseName
+immFloat32 =
+  MakeBaseName "imm-float32"
+
+immFloat64 :: BaseName
+immFloat64 =
+  MakeBaseName "imm-float64"
+
+immRune :: BaseName
+immRune =
+  MakeBaseName "imm-rune"
+
+immPointer :: BaseName
+immPointer =
+  MakeBaseName "imm-pointer"
+
+immNull :: BaseName
+immNull =
+  MakeBaseName "imm-null"
 
 cls :: BaseName
 cls =

--- a/src/Language/Common/Rule/BasePrimType/FromText.hs
+++ b/src/Language/Common/Rule/BasePrimType/FromText.hs
@@ -28,7 +28,7 @@ asLowInt dataSize s = do
     then return $ BPT.Implicit $ dataSizeToIntSize dataSize
     else do
       size <- readMaybe $ T.unpack rest
-      BPT.Explicit <$> asIntSize dataSize size
+      BPT.Explicit <$> intToIntSize dataSize size
 
 asLowFloat :: DS.DataSize -> T.Text -> Maybe (BPT.BasePrimTypeSize FloatSize)
 asLowFloat dataSize s = do
@@ -37,34 +37,4 @@ asLowFloat dataSize s = do
     then return $ BPT.Implicit $ dataSizeToFloatSize dataSize
     else do
       size <- readMaybe $ T.unpack rest
-      BPT.Explicit <$> asFloatSize dataSize size
-
-dataSizeToIntSize :: DS.DataSize -> IntSize
-dataSizeToIntSize dataSize =
-  IntSize $ DS.reify dataSize
-
-dataSizeToFloatSize :: DS.DataSize -> FloatSize
-dataSizeToFloatSize dataSize =
-  case dataSize of
-    DS.DataSize64 ->
-      FloatSize64
-
-asIntSize :: DS.DataSize -> Int -> Maybe IntSize
-asIntSize dataSize size =
-  if 1 <= size && size <= DS.reify dataSize
-    then return $ IntSize size
-    else Nothing
-
-asFloatSize :: DS.DataSize -> Int -> Maybe FloatSize
-asFloatSize dataSize size =
-  if size > DS.reify dataSize
-    then Nothing
-    else case size of
-      16 ->
-        return FloatSize16
-      32 ->
-        return FloatSize32
-      64 ->
-        return FloatSize64
-      _ ->
-        Nothing
+      BPT.Explicit <$> intToFloatSize dataSize size

--- a/src/Language/Common/Rule/DefiniteDescription.hs
+++ b/src/Language/Common/Rule/DefiniteDescription.hs
@@ -7,10 +7,22 @@ module Language.Common.Rule.DefiniteDescription
     getLocatorPair,
     newByGlobalLocator,
     getFormDD,
-    imm,
     immType,
     immEnum,
     immNoema,
+    immInt1,
+    immInt2,
+    immInt4,
+    immInt8,
+    immInt16,
+    immInt32,
+    immInt64,
+    immFloat16,
+    immFloat32,
+    immFloat64,
+    immRune,
+    immPointer,
+    immNull,
     cls,
     toBuilder,
     llvmGlobalLocator,
@@ -120,10 +132,6 @@ localLocator dd = do
     _ ->
       error "Rule.DefiniteDescription.localLocator"
 
-imm :: DefiniteDescription
-imm =
-  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.imm
-
 immType :: DefiniteDescription
 immType =
   newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immType
@@ -135,6 +143,58 @@ immEnum =
 immNoema :: DefiniteDescription
 immNoema =
   newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immNoema
+
+immInt1 :: DefiniteDescription
+immInt1 =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immInt1
+
+immInt2 :: DefiniteDescription
+immInt2 =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immInt2
+
+immInt4 :: DefiniteDescription
+immInt4 =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immInt4
+
+immInt8 :: DefiniteDescription
+immInt8 =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immInt8
+
+immInt16 :: DefiniteDescription
+immInt16 =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immInt16
+
+immInt32 :: DefiniteDescription
+immInt32 =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immInt32
+
+immInt64 :: DefiniteDescription
+immInt64 =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immInt64
+
+immFloat16 :: DefiniteDescription
+immFloat16 =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immFloat16
+
+immFloat32 :: DefiniteDescription
+immFloat32 =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immFloat32
+
+immFloat64 :: DefiniteDescription
+immFloat64 =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immFloat64
+
+immRune :: DefiniteDescription
+immRune =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immRune
+
+immPointer :: DefiniteDescription
+immPointer =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immPointer
+
+immNull :: DefiniteDescription
+immNull =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immNull
 
 cls :: DefiniteDescription
 cls =

--- a/src/Language/Common/Rule/DefiniteDescription.hs
+++ b/src/Language/Common/Rule/DefiniteDescription.hs
@@ -8,7 +8,6 @@ module Language.Common.Rule.DefiniteDescription
     newByGlobalLocator,
     getFormDD,
     immType,
-    immEnum,
     immNoema,
     immInt1,
     immInt2,
@@ -135,10 +134,6 @@ localLocator dd = do
 immType :: DefiniteDescription
 immType =
   newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immType
-
-immEnum :: DefiniteDescription
-immEnum =
-  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immEnum
 
 immNoema :: DefiniteDescription
 immNoema =

--- a/src/Language/Common/Rule/DefiniteDescription.hs
+++ b/src/Language/Common/Rule/DefiniteDescription.hs
@@ -10,6 +10,7 @@ module Language.Common.Rule.DefiniteDescription
     imm,
     immType,
     immEnum,
+    immNoema,
     cls,
     toBuilder,
     llvmGlobalLocator,
@@ -130,6 +131,10 @@ immType =
 immEnum :: DefiniteDescription
 immEnum =
   newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immEnum
+
+immNoema :: DefiniteDescription
+immNoema =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immNoema
 
 cls :: DefiniteDescription
 cls =

--- a/src/Language/Common/Rule/DefiniteDescription.hs
+++ b/src/Language/Common/Rule/DefiniteDescription.hs
@@ -8,6 +8,8 @@ module Language.Common.Rule.DefiniteDescription
     newByGlobalLocator,
     getFormDD,
     imm,
+    immType,
+    immEnum,
     cls,
     toBuilder,
     llvmGlobalLocator,
@@ -15,13 +17,12 @@ module Language.Common.Rule.DefiniteDescription
   )
 where
 
-import Error.Rule.Error
-import Logger.Rule.Hint qualified as H
 import Data.Binary
 import Data.ByteString.Builder
 import Data.Hashable
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
+import Error.Rule.Error
 import GHC.Generics
 import Language.Common.Rule.BaseName qualified as BN
 import Language.Common.Rule.Const
@@ -32,6 +33,7 @@ import Language.Common.Rule.ModuleDigest qualified as MD
 import Language.Common.Rule.ModuleID qualified as MID
 import Language.Common.Rule.SourceLocator qualified as SL
 import Language.Common.Rule.StrictGlobalLocator qualified as SGL
+import Logger.Rule.Hint qualified as H
 
 newtype DefiniteDescription = MakeDefiniteDescription {reify :: T.Text}
   deriving (Generic, Show)
@@ -120,6 +122,14 @@ localLocator dd = do
 imm :: DefiniteDescription
 imm =
   newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.imm
+
+immType :: DefiniteDescription
+immType =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immType
+
+immEnum :: DefiniteDescription
+immEnum =
+  newByGlobalLocator (SGL.baseGlobalLocatorOf SL.internalLocator) BN.immEnum
 
 cls :: DefiniteDescription
 cls =

--- a/src/Language/Common/Rule/LowType.hs
+++ b/src/Language/Common/Rule/LowType.hs
@@ -2,6 +2,7 @@ module Language.Common.Rule.LowType (LowType (..), textType, textTypeInner) wher
 
 import Data.Binary
 import GHC.Generics qualified as G
+import Language.Common.Rule.DataSize (DataSize)
 import Language.Common.Rule.PrimNumSize
 import Language.Common.Rule.PrimType qualified as PT
 
@@ -20,14 +21,14 @@ instance Show LowType where
 
 instance Binary LowType
 
-textType :: Int -> Int -> LowType
+textType :: DataSize -> Int -> LowType
 textType baseSize len =
   Struct
-    [ PrimNum $ PT.Int $ IntSize baseSize,
-      PrimNum $ PT.Int $ IntSize baseSize,
+    [ PrimNum $ PT.Int $ dataSizeToIntSize baseSize,
+      PrimNum $ PT.Int $ dataSizeToIntSize baseSize,
       textTypeInner len
     ]
 
 textTypeInner :: Int -> LowType
 textTypeInner len =
-  Array len (PrimNum $ PT.Int $ IntSize 8)
+  Array len (PrimNum $ PT.Int IntSize8)

--- a/src/Language/Common/Rule/PrimNumSize.hs
+++ b/src/Language/Common/Rule/PrimNumSize.hs
@@ -1,15 +1,25 @@
 module Language.Common.Rule.PrimNumSize
   ( IntSize (..),
     FloatSize (..),
-    intSize32,
+    dataSizeToIntSize,
+    dataSizeToFloatSize,
+    intToIntSize,
+    intToFloatSize,
   )
 where
 
 import Data.Binary
 import GHC.Generics qualified as G
+import Language.Common.Rule.DataSize qualified as DS
 
-newtype IntSize
-  = IntSize Int
+data IntSize
+  = IntSize1
+  | IntSize2
+  | IntSize4
+  | IntSize8
+  | IntSize16
+  | IntSize32
+  | IntSize64
   deriving (Eq, Ord, Show, G.Generic)
 
 instance Binary IntSize
@@ -22,6 +32,52 @@ data FloatSize
 
 instance Binary FloatSize
 
-intSize32 :: IntSize
-intSize32 =
-  IntSize 32
+dataSizeToIntSize :: DS.DataSize -> IntSize
+dataSizeToIntSize dataSize =
+  case dataSize of
+    DS.DataSize64 ->
+      IntSize64
+
+dataSizeToFloatSize :: DS.DataSize -> FloatSize
+dataSizeToFloatSize dataSize =
+  case dataSize of
+    DS.DataSize64 ->
+      FloatSize64
+
+intToIntSize :: DS.DataSize -> Int -> Maybe IntSize
+intToIntSize dataSize size =
+  if size > DS.reify dataSize
+    then Nothing
+    else do
+      case size of
+        1 ->
+          return IntSize1
+        2 ->
+          return IntSize2
+        4 ->
+          return IntSize4
+        8 ->
+          return IntSize8
+        16 ->
+          return IntSize16
+        32 ->
+          return IntSize32
+        64 ->
+          return IntSize64
+        _ ->
+          Nothing
+
+intToFloatSize :: DS.DataSize -> Int -> Maybe FloatSize
+intToFloatSize dataSize size =
+  if size > DS.reify dataSize
+    then Nothing
+    else do
+      case size of
+        16 ->
+          return FloatSize16
+        32 ->
+          return FloatSize32
+        64 ->
+          return FloatSize64
+        _ ->
+          Nothing

--- a/src/Language/Common/Rule/PrimNumSize/ToInt.hs
+++ b/src/Language/Common/Rule/PrimNumSize/ToInt.hs
@@ -9,8 +9,20 @@ import Language.Common.Rule.PrimNumSize
 intSizeToInt :: IntSize -> Int
 intSizeToInt intSize =
   case intSize of
-    IntSize size ->
-      size
+    IntSize1 ->
+      1
+    IntSize2 ->
+      2
+    IntSize4 ->
+      4
+    IntSize8 ->
+      8
+    IntSize16 ->
+      16
+    IntSize32 ->
+      32
+    IntSize64 ->
+      64
 
 floatSizeToInt :: FloatSize -> Int
 floatSizeToInt floatSize =

--- a/src/Language/Common/Rule/PrimOp/FromText.hs
+++ b/src/Language/Common/Rule/PrimOp/FromText.hs
@@ -35,14 +35,14 @@ fromText dataSize name
           | Just op <- asIntBinaryOp opStr ->
               return $ PrimBinaryOp op primType primType
           | Just op <- asIntCmpOp opStr ->
-              return $ PrimCmpOp op primType (PT.Int $ IntSize 1)
+              return $ PrimCmpOp op primType (PT.Int IntSize1)
         PT.Float {}
           | Just op <- asFloatUnaryOp opStr ->
               return $ PrimUnaryOp op primType primType
           | Just op <- asFloatBinaryOp opStr ->
               return $ PrimBinaryOp op primType primType
           | Just op <- asFloatCmpOp opStr ->
-              return $ PrimCmpOp op primType (PT.Int $ IntSize 1)
+              return $ PrimCmpOp op primType (PT.Int IntSize1)
         _ ->
           Nothing
   | otherwise =

--- a/src/Language/Common/Rule/PrimType/FromText.hs
+++ b/src/Language/Common/Rule/PrimType/FromText.hs
@@ -38,7 +38,7 @@ asLowInt dataSize s =
         (c, rest)
           | c == intTypeName,
             Just n <- readMaybe $ T.unpack rest,
-            Just size <- asIntSize dataSize n ->
+            Just size <- intToIntSize dataSize n ->
               Just size
           | otherwise ->
               Nothing
@@ -57,37 +57,7 @@ asLowFloat dataSize s =
         (c, rest)
           | c == floatTypeName,
             Just n <- readMaybe $ T.unpack rest,
-            Just size <- asFloatSize dataSize n ->
+            Just size <- intToFloatSize dataSize n ->
               Just size
           | otherwise ->
               Nothing
-
-asIntSize :: DS.DataSize -> Int -> Maybe IntSize
-asIntSize dataSize size =
-  if 1 <= size && size <= DS.reify dataSize
-    then Just $ IntSize size
-    else Nothing
-
-asFloatSize :: DS.DataSize -> Int -> Maybe FloatSize
-asFloatSize dataSize size =
-  if size > DS.reify dataSize
-    then Nothing
-    else case size of
-      16 ->
-        Just FloatSize16
-      32 ->
-        Just FloatSize32
-      64 ->
-        Just FloatSize64
-      _ ->
-        Nothing
-
-dataSizeToFloatSize :: DS.DataSize -> FloatSize
-dataSizeToFloatSize dataSize =
-  case dataSize of
-    DS.DataSize64 ->
-      FloatSize64
-
-dataSizeToIntSize :: DS.DataSize -> IntSize
-dataSizeToIntSize dataSize =
-  IntSize $ DS.reify dataSize

--- a/src/Language/Comp/Move/Subst.hs
+++ b/src/Language/Comp/Move/Subst.hs
@@ -91,6 +91,8 @@ substPrimitive sub c =
     C.PrimOp op vs -> do
       let vs' = map (substValue sub) vs
       C.PrimOp op vs'
+    C.ShiftPointer v size index ->
+      C.ShiftPointer (substValue sub v) size index
     C.Magic der -> do
       let der' = fmap (substValue sub) der
       C.Magic der'

--- a/src/Language/Comp/Rule/Comp.hs
+++ b/src/Language/Comp/Rule/Comp.hs
@@ -104,6 +104,7 @@ type ShouldDeallocate = Bool
 
 data Primitive
   = PrimOp PrimOp [Value]
+  | ShiftPointer Value Integer Integer -- (ptr, num-of-elems, index)
   | Magic (Magic BaseLowType Value)
   deriving (Show)
 

--- a/src/Language/Comp/Rule/Comp.hs
+++ b/src/Language/Comp/Rule/Comp.hs
@@ -123,11 +123,11 @@ type DefMap =
 
 intValue0 :: Value
 intValue0 =
-  Int (IntSize 1) 0
+  Int IntSize1 0
 
 intValue1 :: Value
 intValue1 =
-  Int (IntSize 1) 1
+  Int IntSize1 1
 
 getPhiList :: Comp -> Maybe [Value]
 getPhiList e =

--- a/src/Language/RawTerm/Rule/RawStmt.hs
+++ b/src/Language/RawTerm/Rule/RawStmt.hs
@@ -66,6 +66,7 @@ data BaseRawStmt name
       (name, C)
       (C, RT.RawTerm)
       (C, RT.RawTerm)
+      (C, RT.RawTerm)
       C
   | RawStmtNominal C Hint (SE.Series (RT.RawGeist name, Loc))
   | RawStmtForeign C (SE.Series RawForeignItem)
@@ -90,6 +91,7 @@ data PostRawStmt
       (DD.DefiniteDescription, C)
       (C, RT.RawTerm)
       (C, RT.RawTerm)
+      (C, RT.RawTerm)
       C
   | PostRawStmtNominal C Hint (SE.Series (RT.RawGeist DD.DefiniteDescription, Loc))
   | PostRawStmtForeign C (SE.Series RawForeignItem)
@@ -101,7 +103,7 @@ getPostRawStmtName stmt =
       let m = RT.loc $ RT.geist def
       let name = fst $ RT.name $ RT.geist def
       [(m, name)]
-    PostRawStmtDefineResource _ m (name, _) _ _ _ ->
+    PostRawStmtDefineResource _ m (name, _) _ _ _ _ ->
       [(m, name)]
     PostRawStmtNominal {} ->
       []

--- a/src/Language/RawTerm/Rule/RawStmt/ToDoc.hs
+++ b/src/Language/RawTerm/Rule/RawStmt/ToDoc.hs
@@ -198,10 +198,10 @@ decStmt stmt =
             D.text " ",
             SE.decode $ fmap decConsInfo consInfo
           ]
-    RawStmtDefineResource c1 _ (name, c2) discarder copier trailingComment -> do
+    RawStmtDefineResource c1 _ (name, c2) discarder copier typeTag trailingComment -> do
       let series =
             SE.Series
-              { elems = [discarder, copier],
+              { elems = [discarder, copier, typeTag],
                 trailingComment,
                 prefix = Nothing,
                 container = Just SE.Brace,

--- a/src/Language/RawTerm/Rule/RawTerm.hs
+++ b/src/Language/RawTerm/Rule/RawTerm.hs
@@ -83,7 +83,7 @@ data RawTermF a
   | Magic C RawMagic -- (magic kind arg-1 ... arg-n)
   | Hole HoleID
   | Annotation LogLevel (Annot.Annotation ()) a
-  | Resource DD.DefiniteDescription C (a, C) (a, C) -- DD is only for printing
+  | Resource DD.DefiniteDescription C (a, C) (a, C) (a, C) -- DD is only for printing
   | If (KeywordClause a) [KeywordClause a] (EL a)
   | When (KeywordClause a)
   | Seq (a, C) C a

--- a/src/Language/RawTerm/Rule/RawTerm.hs
+++ b/src/Language/RawTerm/Rule/RawTerm.hs
@@ -247,6 +247,7 @@ data RawMagic
   | External C Hint EN.ExternalName C (SE.Series RawTerm) (Maybe (C, SE.Series VarArg))
   | Global C (EL EN.ExternalName) (EL RawTerm) (Maybe C)
   | OpaqueValue C (EL RawTerm)
+  | CallType C (EL RawTerm) (EL RawTerm) (EL RawTerm)
 
 -- elem
 type EL a =

--- a/src/Language/RawTerm/Rule/RawTerm/ToDoc.hs
+++ b/src/Language/RawTerm/Rule/RawTerm/ToDoc.hs
@@ -264,7 +264,7 @@ toDoc term =
       D.text "_"
     _ :< Annotation {} -> do
       D.text "<annot>"
-    _ :< Resource dd _ _ _ -> do
+    _ :< Resource dd _ _ _ _ -> do
       D.text $ DD.localLocator dd
     _ :< If ifClause elseIfClauseList elseBody -> do
       let ifClause' = decodeKeywordClause "if" $ mapKeywordClause toDoc ifClause

--- a/src/Language/RawTerm/Rule/RawTerm/ToDoc.hs
+++ b/src/Language/RawTerm/Rule/RawTerm/ToDoc.hs
@@ -248,6 +248,18 @@ toDoc term =
             [ attachComment (c ++ c1) $ D.text "magic opaque-value ",
               decodeBrace True c2 e c3
             ]
+        CallType c1 func arg1 arg2 -> do
+          D.join
+            [ attachComment (c ++ c1) $ D.text "magic call-type",
+              SE.decode $
+                SE.fromListWithComment
+                  (Just SE.Paren)
+                  SE.Comma
+                  [ RT.mapEL toDoc func,
+                    RT.mapEL toDoc arg1,
+                    RT.mapEL toDoc arg2
+                  ]
+            ]
     _ :< Hole {} ->
       D.text "_"
     _ :< Annotation {} -> do

--- a/src/Language/Term/Move/Inline.hs
+++ b/src/Language/Term/Move/Inline.hs
@@ -228,11 +228,12 @@ inline' h term = do
           return (m :< TM.Magic magic')
     _ :< TM.Void ->
       return term
-    m :< TM.Resource dd resourceID unitType discarder copier -> do
+    m :< TM.Resource dd resourceID unitType discarder copier typeTag -> do
       unitType' <- inline' h unitType
       discarder' <- inline' h discarder
       copier' <- inline' h copier
-      return $ m :< TM.Resource dd resourceID unitType' discarder' copier'
+      typeTag' <- inline' h typeTag
+      return $ m :< TM.Resource dd resourceID unitType' discarder' copier' typeTag'
 
 inlineBinder :: Handle -> BinderF TM.Term -> EIO (BinderF TM.Term)
 inlineBinder h (m, x, t) = do

--- a/src/Language/Term/Move/Refresh.hs
+++ b/src/Language/Term/Move/Refresh.hs
@@ -98,11 +98,12 @@ refresh h term =
     m :< TM.Magic der -> do
       der' <- traverse (refresh h) der
       return (m :< TM.Magic der')
-    m :< TM.Resource dd resourceID unitType discarder copier -> do
+    m :< TM.Resource dd resourceID unitType discarder copier typeTag -> do
       unitType' <- refresh h unitType
       discarder' <- refresh h discarder
       copier' <- refresh h copier
-      return $ m :< TM.Resource dd resourceID unitType' discarder' copier'
+      typeTag' <- refresh h typeTag
+      return $ m :< TM.Resource dd resourceID unitType' discarder' copier' typeTag'
     _ :< TM.Void ->
       return term
 

--- a/src/Language/Term/Move/Subst.hs
+++ b/src/Language/Term/Move/Subst.hs
@@ -123,11 +123,12 @@ subst h sub term =
     m :< TM.Magic der -> do
       der' <- traverse (subst h sub) der
       return (m :< TM.Magic der')
-    m :< TM.Resource dd resourceID unitType discarder copier -> do
+    m :< TM.Resource dd resourceID unitType discarder copier typeTag -> do
       unitType' <- subst h sub unitType
       discarder' <- subst h sub discarder
       copier' <- subst h sub copier
-      return $ m :< TM.Resource dd resourceID unitType' discarder' copier'
+      typeTag' <- subst h sub typeTag
+      return $ m :< TM.Resource dd resourceID unitType' discarder' copier' typeTag'
     _ :< TM.Void ->
       return term
 

--- a/src/Language/Term/Rule/Term.hs
+++ b/src/Language/Term/Rule/Term.hs
@@ -51,7 +51,7 @@ data TermF a
   | Let O.Opacity (BinderF a) a a
   | Prim (P.Prim a)
   | Magic (Magic BaseLowType a)
-  | Resource DD.DefiniteDescription ID a a a
+  | Resource DD.DefiniteDescription ID a a a a
   | Void
   deriving (Show, Generic)
 

--- a/src/Language/Term/Rule/Term/Chain.hs
+++ b/src/Language/Term/Rule/Term/Chain.hs
@@ -70,11 +70,12 @@ chainOf' tenv term =
       []
     _ :< TM.Magic der ->
       foldMap (chainOf' tenv) der
-    _ :< TM.Resource _ _ unitType discarder copier -> do
+    _ :< TM.Resource _ _ unitType discarder copier typeTag -> do
       let xs1 = chainOf' tenv unitType
       let xs2 = chainOf' tenv discarder
       let xs3 = chainOf' tenv copier
-      xs1 ++ xs2 ++ xs3
+      let xs4 = chainOf' tenv typeTag
+      xs1 ++ xs2 ++ xs3 ++ xs4
     _ :< TM.Void ->
       []
 

--- a/src/Language/Term/Rule/Term/Compress.hs
+++ b/src/Language/Term/Rule/Term/Compress.hs
@@ -67,8 +67,8 @@ compress term =
       () :< TM.Prim (compressPrim prim)
     _ :< TM.Magic der -> do
       () :< TM.Magic (fmap compress der)
-    _ :< TM.Resource dd resourceID unitType discarder copier -> do
-      () :< TM.Resource dd resourceID (compress unitType) (compress discarder) (compress copier)
+    _ :< TM.Resource dd resourceID unitType discarder copier typeTag -> do
+      () :< TM.Resource dd resourceID (compress unitType) (compress discarder) (compress copier) (compress typeTag)
     _ :< TM.Void ->
       () :< TM.Void
 

--- a/src/Language/Term/Rule/Term/Extend.hs
+++ b/src/Language/Term/Rule/Term/Extend.hs
@@ -74,8 +74,8 @@ extend term =
       _m :< TM.Prim (extendPrim prim)
     _ :< TM.Magic der -> do
       _m :< TM.Magic (fmap extend der)
-    _ :< TM.Resource dd resourceID unitType discarder copier -> do
-      _m :< TM.Resource dd resourceID (extend unitType) (extend discarder) (extend copier)
+    _ :< TM.Resource dd resourceID unitType discarder copier typeTag -> do
+      _m :< TM.Resource dd resourceID (extend unitType) (extend discarder) (extend copier) (extend typeTag)
     _ :< TM.Void ->
       _m :< TM.Void
 

--- a/src/Language/Term/Rule/Term/FreeVars.hs
+++ b/src/Language/Term/Rule/Term/FreeVars.hs
@@ -62,11 +62,12 @@ freeVars term =
           S.empty
     _ :< TM.Magic der ->
       foldMap freeVars der
-    _ :< TM.Resource _ _ unitType discarder copier -> do
+    _ :< TM.Resource _ _ unitType discarder copier typeTag -> do
       let xs1 = freeVars unitType
       let xs2 = freeVars discarder
       let xs3 = freeVars copier
-      S.unions [xs1, xs2, xs3]
+      let xs4 = freeVars typeTag
+      S.unions [xs1, xs2, xs3, xs4]
     _ :< TM.Void ->
       S.empty
 

--- a/src/Language/Term/Rule/Term/FreeVarsWithHints.hs
+++ b/src/Language/Term/Rule/Term/FreeVarsWithHints.hs
@@ -63,11 +63,12 @@ freeVarsWithHints term =
           S.empty
     _ :< TM.Magic der ->
       foldMap freeVarsWithHints der
-    _ :< TM.Resource _ _ unitType discarder copier -> do
+    _ :< TM.Resource _ _ unitType discarder copier typeTag -> do
       let xs1 = freeVarsWithHints unitType
       let xs2 = freeVarsWithHints discarder
       let xs3 = freeVarsWithHints copier
-      S.unions [xs1, xs2, xs3]
+      let xs4 = freeVarsWithHints typeTag
+      S.unions [xs1, xs2, xs3, xs4]
     _ :< TM.Void ->
       S.empty
 

--- a/src/Language/Term/Rule/Term/Weaken.hs
+++ b/src/Language/Term/Rule/Term/Weaken.hs
@@ -96,8 +96,8 @@ weaken term =
       m :< WT.Prim (weakenPrim prim)
     m :< TM.Magic magic -> do
       m :< WT.Magic (weakenMagic m magic)
-    m :< TM.Resource dd resourceID unitType discarder copier -> do
-      m :< WT.Resource dd resourceID (weaken unitType) (weaken discarder) (weaken copier)
+    m :< TM.Resource dd resourceID unitType discarder copier typeTag -> do
+      m :< WT.Resource dd resourceID (weaken unitType) (weaken discarder) (weaken copier) (weaken typeTag)
     m :< TM.Void ->
       m :< WT.Void
 

--- a/src/Language/Term/Rule/Term/Weaken.hs
+++ b/src/Language/Term/Rule/Term/Weaken.hs
@@ -121,6 +121,8 @@ weakenMagic m magic = do
       M.WeakMagic $ M.Global name (WT.fromBaseLowType m t)
     M.OpaqueValue e ->
       M.WeakMagic $ M.OpaqueValue (weaken e)
+    M.CallType func arg1 arg2 ->
+      M.WeakMagic $ M.CallType (weaken func) (weaken arg1) (weaken arg2)
 
 weakenBinder :: (Hint, Ident, TM.Term) -> (Hint, Ident, WT.WeakTerm)
 weakenBinder (m, x, t) =

--- a/src/Language/WeakTerm/Move/Subst.hs
+++ b/src/Language/WeakTerm/Move/Subst.hs
@@ -141,11 +141,12 @@ subst h sub term =
         AN.Type t -> do
           t' <- subst h sub t
           return $ m :< WT.Annotation logLevel (AN.Type t') e'
-    m :< WT.Resource dd resourceID unitType discarder copier -> do
+    m :< WT.Resource dd resourceID unitType discarder copier typeTag -> do
       unitType' <- subst h sub unitType
       discarder' <- subst h sub discarder
       copier' <- subst h sub copier
-      return $ m :< WT.Resource dd resourceID unitType' discarder' copier'
+      typeTag' <- subst h sub typeTag
+      return $ m :< WT.Resource dd resourceID unitType' discarder' copier' typeTag'
     _ :< WT.Void ->
       return term
 

--- a/src/Language/WeakTerm/Rule/WeakTerm.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm.hs
@@ -63,7 +63,7 @@ data WeakTermF a
   | Magic (WeakMagic a) -- (magic kind arg-1 ... arg-n)
   | Hole HoleID [WeakTerm] -- ?M @ (e1, ..., en)
   | Annotation LogLevel (AN.Annotation a) a
-  | Resource DD.DefiniteDescription Int a a a
+  | Resource DD.DefiniteDescription Int a a a a
   | Void
 
 type SubstWeakTerm =

--- a/src/Language/WeakTerm/Rule/WeakTerm.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm.hs
@@ -23,6 +23,7 @@ import Language.Common.Rule.Attr.VarGlobal qualified as AttrVG
 import Language.Common.Rule.BaseLowType qualified as BLT
 import Language.Common.Rule.BasePrimType qualified as BPT
 import Language.Common.Rule.Binder
+import Language.Common.Rule.DataSize (DataSize)
 import Language.Common.Rule.DecisionTree qualified as DT
 import Language.Common.Rule.DefiniteDescription qualified as DD
 import Language.Common.Rule.Foreign
@@ -93,9 +94,9 @@ reflectOpacity opacity =
     O.Clear ->
       Clear
 
-intTypeBySize :: Hint -> Int -> WeakTerm
+intTypeBySize :: Hint -> DataSize -> WeakTerm
 intTypeBySize m size =
-  m :< Prim (WP.Type $ PT.Int $ IntSize size)
+  m :< Prim (WP.Type $ PT.Int $ dataSizeToIntSize size)
 
 metaOf :: WeakTerm -> Hint
 metaOf (m :< _) =

--- a/src/Language/WeakTerm/Rule/WeakTerm/Eq.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/Eq.hs
@@ -131,8 +131,8 @@ eq (_ :< term1) (_ :< term2)
   | WT.Annotation _ _ e1 <- term1,
     WT.Annotation _ _ e2 <- term2 =
       eq e1 e2
-  | WT.Resource _ id1 _ _ _ <- term1,
-    WT.Resource _ id2 _ _ _ <- term2 =
+  | WT.Resource _ id1 _ _ _ _ <- term1,
+    WT.Resource _ id2 _ _ _ _ <- term2 =
       id1 == id2
   | WT.Void <- term1,
     WT.Void <- term2 =

--- a/src/Language/WeakTerm/Rule/WeakTerm/Eq.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/Eq.hs
@@ -5,12 +5,12 @@ import Language.Common.Rule.Attr.Lam qualified as AttrL
 import Language.Common.Rule.Binder (BinderF)
 import Language.Common.Rule.DecisionTree qualified as DT
 import Language.Common.Rule.ForeignCodType qualified as FCT
+import Language.Common.Rule.ImpArgs qualified as ImpArgs
 import Language.Common.Rule.LamKind qualified as LK
 import Language.Common.Rule.Magic qualified as M
 import Language.WeakTerm.Rule.WeakPrim qualified as WP
 import Language.WeakTerm.Rule.WeakPrimValue qualified as WPV
 import Language.WeakTerm.Rule.WeakTerm qualified as WT
-import Language.Common.Rule.ImpArgs qualified as ImpArgs
 
 -- syntactic equality
 eq :: WT.WeakTerm -> WT.WeakTerm -> Bool
@@ -299,6 +299,12 @@ eqM (M.WeakMagic m1) (M.WeakMagic m2)
   | M.OpaqueValue e1 <- m1,
     M.OpaqueValue e2 <- m2 = do
       eq e1 e2
+  | M.CallType func1 switch1 arg1 <- m1,
+    M.CallType func2 switch2 arg2 <- m2 = do
+      let b1 = eq func1 func2
+      let b2 = eq switch1 switch2
+      let b3 = eq arg1 arg2
+      b1 && b2 && b3
   | otherwise =
       False
 

--- a/src/Language/WeakTerm/Rule/WeakTerm/FreeVars.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/FreeVars.hs
@@ -71,11 +71,12 @@ freeVars term =
         AN.Type t -> do
           let xs2 = freeVars t
           S.union xs1 xs2
-    _ :< WT.Resource _ _ unitType discarder copier -> do
+    _ :< WT.Resource _ _ unitType discarder copier typeTag -> do
       let xs1 = freeVars unitType
       let xs2 = freeVars discarder
       let xs3 = freeVars copier
-      S.unions [xs1, xs2, xs3]
+      let xs4 = freeVars typeTag
+      S.unions [xs1, xs2, xs3, xs4]
     _ :< WT.Void ->
       S.empty
 

--- a/src/Language/WeakTerm/Rule/WeakTerm/Holes.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/Holes.hs
@@ -69,8 +69,8 @@ holes term =
         AN.Type t -> do
           let xs2 = holes t
           S.union xs1 xs2
-    _ :< WT.Resource _ _ unitType discarder copier -> do
-      S.unions $ map holes [unitType, discarder, copier]
+    _ :< WT.Resource _ _ unitType discarder copier typeTag -> do
+      S.unions $ map holes [unitType, discarder, copier, typeTag]
     _ :< WT.Void ->
       S.empty
 

--- a/src/Language/WeakTerm/Rule/WeakTerm/ToText.hs
+++ b/src/Language/WeakTerm/Rule/WeakTerm/ToText.hs
@@ -126,7 +126,7 @@ toText term =
       "<magic>"
     _ :< WT.Annotation _ _ e ->
       toText e
-    _ :< WT.Resource dd _ _ _ _ -> do
+    _ :< WT.Resource dd _ _ _ _ _ -> do
       showGlobalVariable dd
     _ :< WT.Void ->
       "void"

--- a/test/misc/adder/module.ens
+++ b/test/misc/adder/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/args/module.ens
+++ b/test/misc/args/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/calc/module.ens
+++ b/test/misc/calc/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/check/module.ens
+++ b/test/misc/check/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/codata-basic/module.ens
+++ b/test/misc/codata-basic/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/complex-cancel/module.ens
+++ b/test/misc/complex-cancel/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/ex-falso/module.ens
+++ b/test/misc/ex-falso/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/fact/module.ens
+++ b/test/misc/fact/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/file/module.ens
+++ b/test/misc/file/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/fix-and-free-vars/module.ens
+++ b/test/misc/fix-and-free-vars/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/fold-tails/module.ens
+++ b/test/misc/fold-tails/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/foreign/module.ens
+++ b/test/misc/foreign/module.ens
@@ -20,9 +20,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/hello/module.ens
+++ b/test/misc/hello/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/lambda-list-noetic/module.ens
+++ b/test/misc/lambda-list-noetic/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/lambda-list/module.ens
+++ b/test/misc/lambda-list/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/loop-and-resource/module.ens
+++ b/test/misc/loop-and-resource/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/multi-targets/module.ens
+++ b/test/misc/multi-targets/module.ens
@@ -12,9 +12,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/mutable/module.ens
+++ b/test/misc/mutable/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/nat-fact/module.ens
+++ b/test/misc/nat-fact/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/nat-list/module.ens
+++ b/test/misc/nat-list/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/nested-enums/module.ens
+++ b/test/misc/nested-enums/module.ens
@@ -6,9 +6,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/num-literals/module.ens
+++ b/test/misc/num-literals/module.ens
@@ -6,9 +6,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/print-float/module.ens
+++ b/test/misc/print-float/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/static-file/module.ens
+++ b/test/misc/static-file/module.ens
@@ -12,9 +12,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/binary-search-tree/module.ens
+++ b/test/pfds/binary-search-tree/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/binomial-heap/module.ens
+++ b/test/pfds/binomial-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/custom-stack/module.ens
+++ b/test/pfds/custom-stack/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/finite-map/module.ens
+++ b/test/pfds/finite-map/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/leftist-heap/module.ens
+++ b/test/pfds/leftist-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/naive-queue/module.ens
+++ b/test/pfds/naive-queue/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/pairing-heap/module.ens
+++ b/test/pfds/pairing-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/random-access-list/module.ens
+++ b/test/pfds/random-access-list/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/red-black-tree/module.ens
+++ b/test/pfds/red-black-tree/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/splay-heap/module.ens
+++ b/test/pfds/splay-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/stack/module.ens
+++ b/test/pfds/stack/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
     },
   },

--- a/test/pfds/stream/module.ens
+++ b/test/pfds/stream/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
     },
   },

--- a/test/statement/define/module.ens
+++ b/test/statement/define/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/import-names/module.ens
+++ b/test/statement/import-names/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/resource-basic/module.ens
+++ b/test/statement/resource-basic/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/resource-basic/source/resource-basic.nt
+++ b/test/statement/resource-basic/source/resource-basic.nt
@@ -2,6 +2,7 @@ import {
   core.c-size {C-Size},
   core.external {free, malloc},
   core.memory {load-int, store-int},
+  core.type-tag {Opaque, type-tag-to-int},
 }
 
 resource noisy-boxed-int {
@@ -16,6 +17,7 @@ resource noisy-boxed-int {
     magic store(int, orig-value, new-ptr);
     new-ptr
   },
+  type-tag-to-int(Opaque),
 }
 
 // provide a way to introduce new boxed integer

--- a/test/statement/variant-struct/module.ens
+++ b/test/statement/variant-struct/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/box/module.ens
+++ b/test/term/box/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/flow/module.ens
+++ b/test/term/flow/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/noema/module.ens
+++ b/test/term/noema/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/pi/module.ens
+++ b/test/term/pi/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/prim/module.ens
+++ b/test/term/prim/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/rune/module.ens
+++ b/test/term/rune/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/tau/module.ens
+++ b/test/term/tau/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/unary/module.ens
+++ b/test/term/unary/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/var/module.ens
+++ b/test/term/var/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/variant/module.ens
+++ b/test/term/variant/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "ZSsmC2Kn4zj5-jUVTrVzwa9QYmhfiQarmH9nmPu1tYQ",
+      digest "7uVdkITAvSU7J23fDdapVkJdMoBywG3jn25ojt9c9nw",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-5.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-51-6.tar.zst",
       ],
       enable-preset true,
     },


### PR DESCRIPTION
This PR allows:

- Getting the tag (integer value) associated with a type
- Getting the number of arguments each constructor takes in an ADT
- Getting the type information of each field in an ADT
- Calling types via `magic call-type(some-type, switch, value)`

With these in place you can write functions such as:

```neut
define vet<a>(x: &a): unit {
  // Recursively traverse the structure of `x` and print it
}
```

A usage example can be found [here](https://github.com/vekatze/neut-core/blob/bb9f8ab68398884c901e3c2139d5bb574fcf4408/source/debug.nt#L108), but proper documentation is still pending.


## How it works

Previously a type such as `list` compiled into a function of the form

```neut
define list-type(switch, value) {
  match switch {
  | 0 =>
    // discard `value`
  | _ =>
    // copy `value`
  }
}
```

It has now been extended to:

```neut
define list-type(tag, value) {
  match tag {
  | 0 =>
    // discard `value`
  | 1 =>
    // copy `value`
  | 2 =>
    // return an integer that represents the kind of this type
  | 3 =>
    // treat `value` as a discriminant and
    // return the size of the constructor indicated by that discriminant
  | _ =>
    // overwrite each field of `value` with its type information
    // overwrite the 0-th component (the discriminant) with the constructor name (&text)
  }
}
```
