### PR TITLE
update docs with an example for meta

### DIFF
--- a/book/src/modality-and-memory.md
+++ b/book/src/modality-and-memory.md
@@ -349,8 +349,8 @@ define id-bin(arg: &binary): &binary {
 ```
 It's type signature is `&binary -> &binary`, but we would need it to be `&binary -> meta &binary`, so let's rewrite it:
 ```neut
-define id-bin(arg: &binary): &binary {
+define id-bin(arg: &binary): meta &binary {
   quote {arg}
 }
 ```
-But this won't compile either because we have a layer mismatch! In short, the use of the `meta` specifier forbids us from using functions that would cause misuse of memory.
+But this won't compile either because we have a layer mismatch! We can try different things in an attempt to create `bin-id: &binary -> meta &binary` but we won't find an implementation that satisfies our requirements. In short, the use of the `meta` specifier forbids us from using functions that would cause misuse of memory.

--- a/book/src/modality-and-memory.md
+++ b/book/src/modality-and-memory.md
@@ -284,7 +284,7 @@ To help understand how to use `meta` types and how they enforce memory safety su
 
 We have the following function in our codebase which is used to parse input and store backups of it, which is crucial for the bussiness.
 ```neut
-define backup-parse<a>(transformer: binary -> a): a {
+define backup-parse<a>(transformer: (binary) -> a): a {
   let !input: binary = get-next-input();
   write-to-file(input-backup, bin-to-hex(!input)); // !input is copied
   transformer(!input) // !input is copied... again
@@ -295,7 +295,7 @@ Lately our system has been recieving huge chunks of input which has skyrocketed 
 #### Using noetic values
 The following snippet is our previous code rewritten to use noetic values in order to avoid copies.
 ```neut
-define backup-parse<a>(transformer: &binary -> a): a {
+define backup-parse<a>(transformer: (&binary) -> a): a {
   let input: binary = get-next-input();
   let result on binary = {
     write-to-file(input-backup, bin-to-hex(input)); // We have rewritten bin-to-hex so it takes a noetic value instead
@@ -310,7 +310,7 @@ define id-bin(arg: &binary): &binary {
   arg
 }
 
-define backup-parse<a>(transformer: &binary -> a): a {
+define backup-parse<a>(transformer: (&binary) -> a): a {
   let input: binary = get-next-input();
   let result on binary = {
     write-to-file(input-backup, bin-to-hex(input)); // We have rewritten bin-to-hex so it takes a noetic value instead
@@ -331,7 +331,7 @@ Inside `backup-parse` the value of `result` is a reference to `input` which is f
 #### Using `meta` to circumvent the issue
 In order to compile we must restrict the value a call `transformer` evaluates to. We need that whatever `transformer` returns is valid in the outer layer, that is, outside of `backup-parse`. To achieve this we rewrite it to the following:
 ```neut
-define backup-parse<a>(transformer: &binary -> meta a): a {
+define backup-parse<a>(transformer: (&binary) -> meta a): a {
   let input: binary = get-next-input();
   letbox-T result on binary = {
     write-to-file(input-backup, bin-to-hex(input)); // We have rewritten bin-to-hex so it takes a noetic value instead

--- a/book/src/modality-and-memory.md
+++ b/book/src/modality-and-memory.md
@@ -287,7 +287,7 @@ We have the following function in our codebase which is used to parse input and 
 define backup-parse<a>(transformer: (binary) -> a): a {
   let !input: binary = get-next-input();
   write-to-file(input-backup, bin-to-hex(!input)); // !input is copied
-  transformer(!input) // !input is copied... again
+  transformer(!input)
 }
 ```
 Lately our system has been recieving huge chunks of input which has skyrocketed our operating costs due to the input being needlessly copied.

--- a/book/src/modality-and-memory.md
+++ b/book/src/modality-and-memory.md
@@ -266,8 +266,14 @@ define joker(): () -> unit {
         Unit
       }
     };
-  f
+  f // function with xs: &list(int) as a free variable
+  // FREE(xs)
+}
+
+define main(): unit {
+  let f = joker();
+  f(); // xs used after freed here
 }
 ```
 
-This example would wrongly allow a function at layer 0 (`★`) to keep a reference to data (`xs`) that, after the outer `letbox` completes, could be deallocated, leading to a use-after-free scenario. Hence, Neut’s layer rules prohibit capturing a higher-layer variable in a lower-layer function.
+This example would wrongly allow a function at layer 0 (`★`) to keep a reference to data (`xs`) that, after the outer `letbox` completes, could be deallocated, leading to a use-after-free scenario in the body of the main function. Hence, Neut’s layer rules prohibit capturing a higher-layer variable in a lower-layer function.


### PR DESCRIPTION
Attempt at making the example on that use-after-free in the docs more clear and provide an example on the usage of `meta`.

The provided example is made from the perspective of someone who didn't know how this worked some time ago so it may be helpful for those who aren't yet familiarized with the concept.

I believe it to be more informal than the rest of the docs, I am willing to try rewrite this piece of thing.

The only (I hope at least) promises I can't make are time related ones!