### PR TITLE
improve dead code detection

### DIFF
--- a/src/Command/Common/Build.hs
+++ b/src/Command/Common/Build.hs
@@ -48,6 +48,7 @@ import Kernel.Emit.Emit qualified as Emit
 import Kernel.Load.Load qualified as Load
 import Kernel.Lower.Lower qualified as Lower
 import Kernel.Parse.Interpret qualified as Interpret
+import Kernel.Parse.Internal.Handle.UnusedTopLevelName qualified as UnusedTopLevelName
 import Kernel.Parse.Parse qualified as Parse
 import Kernel.Unravel.Unravel qualified as Unravel
 import Language.Common.ModuleID qualified as MID
@@ -152,6 +153,7 @@ compile h target outputKindList contentSeq = do
           virtualCode <- Lower.lower lowerHandle stmtList' auxStmtList
           emit h hp currentTime target outputKindList (Right source) virtualCode
       else return Nothing
+  registerUnusedTopLevelNameRemarks h
   entryPointVirtualCode <- compileEntryPoint h target outputKindList
   entryPointAsync <- forM entryPointVirtualCode $ \(src, code) -> liftIO $ do
     async $ runApp $ emit h hp currentTime target outputKindList src code
@@ -160,6 +162,11 @@ compile h target outputKindList contentSeq = do
   if null errors
     then return ()
     else throwError $ E.join errors
+
+registerUnusedTopLevelNameRemarks :: Handle -> App ()
+registerUnusedTopLevelNameRemarks h = do
+  logs <- liftIO $ UnusedTopLevelName.flushRemarks $ Global.unusedTopLevelNameHandle $ globalHandle h
+  liftIO $ GlobalRemark.insert (Global.globalRemarkHandle $ globalHandle h) logs
 
 getCompletedTitle :: Int -> T.Text
 getCompletedTitle numOfItems = do

--- a/src/Command/Common/Check.hs
+++ b/src/Command/Common/Check.hs
@@ -31,6 +31,7 @@ import Kernel.Elaborate.Elaborate qualified as Elaborate
 import Kernel.Elaborate.Internal.Handle.Elaborate qualified as Elaborate
 import Kernel.Load.Load qualified as Load
 import Kernel.Parse.Interpret qualified as Interpret
+import Kernel.Parse.Internal.Handle.UnusedTopLevelName qualified as UnusedTopLevelName
 import Kernel.Parse.Parse qualified as Parse
 import Kernel.Unravel.Unravel qualified as Unravel
 import Language.WeakTerm.WeakStmt (WeakStmt)
@@ -103,6 +104,7 @@ _check h target baseModule = do
       return (localHandle, (source, item))
     forM_ cacheOrStmtList $ \(localHandle, (source, cacheOrContent)) -> do
       checkSource h localHandle target source cacheOrContent
+    registerUnusedTopLevelNameRemarks h
 
 _check' :: Handle -> Target -> M.Module -> App (Maybe Elaborate.Handle)
 _check' h target baseModule = do
@@ -116,12 +118,15 @@ _check' h target baseModule = do
     item <- Interpret.interpret interpretHandle target source cacheOrProg
     return (localHandle, (source, item))
   case unsnoc cacheOrStmtList of
-    Nothing ->
+    Nothing -> do
+      registerUnusedTopLevelNameRemarks h
       return Nothing
     Just (deps, (rootLocalHandle, (rootSource, rootCacheOrContent))) -> do
       forM_ deps $ \(localHandle, (source, cacheOrContent)) -> do
         checkSource h localHandle target source cacheOrContent
-      Just <$> checkSource h rootLocalHandle target rootSource rootCacheOrContent
+      result <- Just <$> checkSource h rootLocalHandle target rootSource rootCacheOrContent
+      registerUnusedTopLevelNameRemarks h
+      return result
 
 checkSource :: Handle -> Local.Handle -> Target -> Source -> (Either Cache [WeakStmt], [Log]) -> App Elaborate.Handle
 checkSource h localHandle target source (cacheOrStmtList, logs) = do
@@ -131,6 +136,11 @@ checkSource h localHandle target source (cacheOrStmtList, logs) = do
       "Checking: " <> T.pack (toFilePath $ sourceFilePath source)
   void $ Elaborate.elaborate elaborateHandle target logs cacheOrStmtList
   return elaborateHandle
+
+registerUnusedTopLevelNameRemarks :: Handle -> App ()
+registerUnusedTopLevelNameRemarks h = do
+  logs <- liftIO $ UnusedTopLevelName.flushRemarks $ Global.unusedTopLevelNameHandle $ globalHandle h
+  liftIO $ GlobalRemark.insert (Global.globalRemarkHandle $ globalHandle h) logs
 
 unsnoc :: [a] -> Maybe ([a], a)
 unsnoc =

--- a/src/Kernel/Common/Cache.hs
+++ b/src/Kernel/Common/Cache.hs
@@ -15,6 +15,7 @@ import Kernel.Common.LocalVarTree qualified as LVT
 import Kernel.Common.LocationTree qualified as LT
 import Kernel.Common.RawImportSummary
 import Kernel.Common.TopCandidate (TopCandidate)
+import Language.Common.DefiniteDescription qualified as DD
 import Language.Term.Compress qualified as TM
 import Language.Term.Extend qualified as TM
 import Language.Term.Stmt qualified as Stmt
@@ -23,6 +24,7 @@ import Logger.Log
 data Cache = Cache
   { stmtList :: [Stmt.Stmt],
     remarkList :: [Log],
+    globalReferenceList :: [DD.DefiniteDescription],
     countSnapshot :: Int
   }
   deriving (Generic)
@@ -30,6 +32,7 @@ data Cache = Cache
 data LowCache = LowCache
   { stmtList' :: [Stmt.StrippedStmt],
     remarkList' :: [Log],
+    globalReferenceList' :: [DD.DefiniteDescription],
     countSnapshot' :: Int
   }
   deriving (Generic)
@@ -57,6 +60,7 @@ compress cache =
   LowCache
     { stmtList' = map compressStmt (stmtList cache),
       remarkList' = remarkList cache,
+      globalReferenceList' = globalReferenceList cache,
       countSnapshot' = countSnapshot cache
     }
 
@@ -65,6 +69,7 @@ extend cache =
   Cache
     { stmtList = map extendStmt (stmtList' cache),
       remarkList = remarkList' cache,
+      globalReferenceList = globalReferenceList' cache,
       countSnapshot = countSnapshot' cache
     }
 

--- a/src/Kernel/Common/CreateGlobalHandle.hs
+++ b/src/Kernel/Common/CreateGlobalHandle.hs
@@ -32,6 +32,7 @@ import Kernel.Elaborate.Internal.Handle.TypeDef qualified as TypeDef
 import Kernel.Elaborate.Internal.Handle.WeakDef qualified as WeakDef
 import Kernel.Elaborate.Internal.Handle.WeakTypeDef qualified as WeakTypeDef
 import Kernel.Parse.Internal.Handle.GlobalNameMap qualified as GlobalNameMap
+import Kernel.Parse.Internal.Handle.UnusedTopLevelName qualified as UnusedTopLevelName
 import Language.Common.ModuleID qualified as MID
 import Logger.CreateHandle qualified as Logger
 import Logger.Handle qualified as Logger
@@ -57,6 +58,7 @@ data Handle = Handle
     weakTypeDefHandle :: WeakTypeDef.Handle,
     typeDefHandle :: TypeDef.Handle,
     globalNameMapHandle :: GlobalNameMap.Handle,
+    unusedTopLevelNameHandle :: UnusedTopLevelName.Handle,
     presetCacheRef :: IORef (Map.HashMap MID.ModuleID [ImportItem])
   }
 
@@ -96,5 +98,6 @@ newOrError cfg moduleFilePathOrNone = do
       typeDefHandle <- TypeDef.new
       antecedentHandle <- Antecedent.new
       globalNameMapHandle <- GlobalNameMap.new
+      unusedTopLevelNameHandle <- UnusedTopLevelName.new
       presetCacheRef <- newIORef Map.empty
       return $ Right $ Handle {..}

--- a/src/Kernel/Common/CreateLocalHandle.hs
+++ b/src/Kernel/Common/CreateLocalHandle.hs
@@ -17,9 +17,11 @@ import Kernel.Elaborate.Internal.Handle.WeakDecl qualified as WeakDecl
 import Kernel.Parse.Internal.Handle.Alias qualified as Alias
 import Kernel.Parse.Internal.Handle.PreDecl qualified as PreDecl
 import Kernel.Parse.Internal.Handle.Unused qualified as Unused
+import Kernel.Parse.Internal.Handle.UsedTopLevelName qualified as UsedTopLevelName
 
 data Handle = Handle
   { unusedHandle :: Unused.Handle,
+    usedTopLevelNameHandle :: UsedTopLevelName.Handle,
     aliasHandle :: Alias.Handle,
     locatorHandle :: Locator.Handle,
     tagHandle :: Tag.Handle,
@@ -35,6 +37,7 @@ new h source = do
   let envHandle = Global.envHandle h
   let antecedentHandle = Global.antecedentHandle h
   unusedHandle <- liftIO Unused.new
+  usedTopLevelNameHandle <- liftIO UsedTopLevelName.new
   tagHandle <- liftIO Tag.new
   locatorHandle <- Locator.new envHandle tagHandle source
   aliasHandle <- liftIO $ Alias.new antecedentHandle locatorHandle envHandle source

--- a/src/Kernel/Elaborate/Elaborate.hs
+++ b/src/Kernel/Elaborate/Elaborate.hs
@@ -22,6 +22,7 @@ import Data.Text qualified as T
 import Gensym.Trick qualified as Gensym
 import Kernel.Common.Cache qualified as Cache
 import Kernel.Common.Const (holeLiteral)
+import Kernel.Common.CreateGlobalHandle qualified as Global
 import Kernel.Common.Handle.Global.Data qualified as Data
 import Kernel.Common.Handle.Global.GlobalRemark qualified as GlobalRemark
 import Kernel.Common.Handle.Global.KeyArg qualified as KeyArg
@@ -42,6 +43,8 @@ import Kernel.Elaborate.Internal.Handle.WeakTypeDef qualified as WeakTypeDef
 import Kernel.Elaborate.Internal.Infer qualified as Infer
 import Kernel.Elaborate.Internal.Unify qualified as Unify
 import Kernel.Elaborate.TypeHoleSubst qualified as THS
+import Kernel.Parse.Internal.Handle.UnusedTopLevelName qualified as UnusedTopLevelName
+import Kernel.Parse.Internal.Handle.UsedTopLevelName qualified as UsedTopLevelName
 import Language.Common.Annotation qualified as AN
 import Language.Common.Attr.Lam qualified as AttrL
 import Language.Common.BaseLowType qualified as BLT
@@ -92,12 +95,16 @@ elaborate h t logs cacheOrStmt = do
   case cacheOrStmt of
     Left cache -> do
       let stmtList = Cache.stmtList cache
+      liftIO $
+        UnusedTopLevelName.deleteMany (Global.unusedTopLevelNameHandle $ globalHandle h) $
+          Cache.globalReferenceList cache
       forM_ stmtList $ insertStmt h
       liftIO $ GlobalRemark.insert (globalRemarkHandle h) logs
       liftIO $ Gensym.setCount (gensymHandle h) $ Cache.countSnapshot cache
       return stmtList
     Right stmtList -> do
-      analyzeStmtList h stmtList >>= synthesizeStmtList h t logs
+      globalReferenceList <- liftIO $ UsedTopLevelName.get (usedTopLevelNameHandle h)
+      analyzeStmtList h stmtList >>= synthesizeStmtList h t logs globalReferenceList
 
 analyzeStmtList :: Handle -> [WeakStmt] -> App [WeakStmt]
 analyzeStmtList h stmtList = do
@@ -106,8 +113,8 @@ analyzeStmtList h stmtList = do
     insertWeakStmt h stmt'
     return stmt'
 
-synthesizeStmtList :: Handle -> Target -> [L.Log] -> [WeakStmt] -> App [Stmt]
-synthesizeStmtList h t logs stmtList = do
+synthesizeStmtList :: Handle -> Target -> [L.Log] -> [DD.DefiniteDescription] -> [WeakStmt] -> App [Stmt]
+synthesizeStmtList h t logs globalReferenceList stmtList = do
   -- mapM_ (liftIO . viewStmt) stmtList
   liftIO (Constraint.get (constraintHandle h)) >>= Unify.unify h >>= liftIO . Hole.setTypeSubst (holeHandle h)
   (stmtList', affineErrorList) <- bimap concat concat . unzip <$> mapM (elaborateStmt h) stmtList
@@ -123,6 +130,7 @@ synthesizeStmtList h t logs stmtList = do
     Cache.Cache
       { Cache.stmtList = stmtList'',
         Cache.remarkList = logs',
+        Cache.globalReferenceList = globalReferenceList,
         Cache.countSnapshot = countSnapshot
       }
   liftIO $ GlobalRemark.insert (globalRemarkHandle h) logs'

--- a/src/Kernel/Elaborate/Internal/Handle/Elaborate.hs
+++ b/src/Kernel/Elaborate/Internal/Handle/Elaborate.hs
@@ -37,6 +37,7 @@ import Kernel.Elaborate.Internal.Handle.WeakType qualified as WeakType
 import Kernel.Elaborate.Internal.Handle.WeakTypeDef qualified as WeakTypeDef
 import Kernel.Elaborate.Internal.WeakTerm.Fill qualified as Fill
 import Kernel.Elaborate.TypeHoleSubst qualified as THS
+import Kernel.Parse.Internal.Handle.UsedTopLevelName qualified as UsedTopLevelName
 import Language.Common.Binder
 import Language.Term.Inline qualified as Inline
 import Language.Term.Inline.Handle qualified as InlineHandle
@@ -63,6 +64,7 @@ data Handle = Handle
     typeDefHandle :: TypeDef.Handle,
     gensymHandle :: Gensym.Handle,
     keyArgHandle :: KeyArg.Handle,
+    usedTopLevelNameHandle :: UsedTopLevelName.Handle,
     localLogsHandle :: LocalLogs.Handle,
     pathHandle :: Path.Handle,
     globalRemarkHandle :: GlobalRemark.Handle,

--- a/src/Kernel/Parse/Internal/Discern.hs
+++ b/src/Kernel/Parse/Internal/Discern.hs
@@ -871,6 +871,7 @@ discernMagic h m magic =
       ensureRuntimeStage m h "runtime magic (`external`)"
       mDef <- PreDecl.lookup (H.preDeclHandle h) m funcName
       liftIO $ Tag.insertExternalName (H.tagHandle h) mUse funcName mDef
+      liftIO $ Unused.deleteForeign (H.unusedHandle h) funcName
       let domList = []
       let cod = FCT.Void
       args' <- mapM (discern h) $ SE.extract args
@@ -1548,6 +1549,7 @@ interpretForeignItem h (RawForeignItemF m name _ lts _ _ cod) = do
   let lts' = SE.extract lts
   Tag.insertExternalName (H.tagHandle h) m name m
   PreDecl.insert (H.preDeclHandle h) name m
+  Unused.insertForeign (H.unusedHandle h) name m
   return $ F.Foreign m name lts' cod
 
 selectDefaultKeyArgs :: [DefaultKey] -> Map.HashMap Key a -> DefaultArgs.DefaultArgs a

--- a/src/Kernel/Parse/Internal/Handle/NameMap.hs
+++ b/src/Kernel/Parse/Internal/Handle/NameMap.hs
@@ -28,6 +28,8 @@ import Kernel.Common.Handle.Local.Tag qualified as Tag
 import Kernel.Common.ReadableDD
 import Kernel.Common.TopNameMap
 import Kernel.Parse.Internal.Handle.Unused qualified as Unused
+import Kernel.Parse.Internal.Handle.UnusedTopLevelName qualified as UnusedTopLevelName
+import Kernel.Parse.Internal.Handle.UsedTopLevelName qualified as UsedTopLevelName
 import Language.Common.ArgNum qualified as AN
 import Language.Common.DataInfo qualified as DI
 import Language.Common.DefiniteDescription qualified as DD
@@ -52,6 +54,8 @@ data Handle = Handle
     platformHandle :: Platform.Handle,
     tagHandle :: Tag.Handle,
     unusedHandle :: Unused.Handle,
+    usedTopLevelNameHandle :: UsedTopLevelName.Handle,
+    unusedTopLevelNameHandle :: UnusedTopLevelName.Handle,
     nameMapRef :: IORef TopNameMap,
     geistMapRef :: IORef (Map.HashMap DD.DefiniteDescription (Hint, IsConstLike))
   }
@@ -59,8 +63,8 @@ data Handle = Handle
 type NameEntry =
   (DD.DefiniteDescription, TopNameInfo)
 
-new :: Global.Handle -> Unused.Handle -> Tag.Handle -> IO Handle
-new (Global.Handle {..}) unusedHandle tagHandle = do
+new :: Global.Handle -> Unused.Handle -> UsedTopLevelName.Handle -> Tag.Handle -> IO Handle
+new (Global.Handle {..}) unusedHandle usedTopLevelNameHandle tagHandle = do
   nameMapRef <- newIORef Map.empty
   geistMapRef <- newIORef Map.empty
   return $ Handle {..}
@@ -93,6 +97,8 @@ lookup h m currentLocator name = do
   case lookupAvailable currentLocator name nameMap of
     Just (mFound, _tag, gn) -> do
       liftIO $ Unused.deleteGlobalLocator (unusedHandle h) $ DD.globalLocator name
+      liftIO $ UsedTopLevelName.insert (usedTopLevelNameHandle h) name
+      liftIO $ UnusedTopLevelName.delete (unusedTopLevelNameHandle h) name
       return $ Just (mFound, gn)
     Nothing
       | Just primType <- PT.fromDefiniteDescription dataSize name ->

--- a/src/Kernel/Parse/Internal/Handle/Unused.hs
+++ b/src/Kernel/Parse/Internal/Handle/Unused.hs
@@ -5,14 +5,17 @@ module Kernel.Parse.Internal.Handle.Unused
     insertLocalLocator,
     insertStaticFile,
     insertVariable,
+    insertForeign,
     deleteGlobalLocator,
     deleteLocalLocator,
     deleteStaticFile,
     deleteVariable,
+    deleteForeign,
     getGlobalLocator,
     getLocalLocator,
     getStaticFile,
     getVariable,
+    getForeign,
     getUnusedLocators,
   )
 where
@@ -23,6 +26,7 @@ import Data.IORef
 import Data.IntMap qualified as IntMap
 import Data.Text qualified as T
 import Kernel.Parse.VarDefKind
+import Language.Common.ExternalName qualified as EN
 import Language.Common.Ident
 import Language.Common.Ident.Reify
 import Language.Common.LocalLocator qualified as LL
@@ -36,7 +40,8 @@ data Handle = Handle
     unusedLocalLocatorMapRef :: IORef (Map.HashMap LL.LocalLocator Hint),
     unusedPresetMapRef :: IORef (Map.HashMap T.Text Hint),
     unusedStaticFileMapRef :: IORef (Map.HashMap T.Text Hint),
-    unusedVariableMapRef :: IORef (IntMap.IntMap (Hint, Ident, VarDefKind))
+    unusedVariableMapRef :: IORef (IntMap.IntMap (Hint, Ident, VarDefKind)),
+    unusedForeignMapRef :: IORef (Map.HashMap EN.ExternalName Hint)
   }
 
 new :: IO Handle
@@ -46,6 +51,7 @@ new = do
   unusedPresetMapRef <- newIORef Map.empty
   unusedStaticFileMapRef <- newIORef Map.empty
   unusedVariableMapRef <- newIORef IntMap.empty
+  unusedForeignMapRef <- newIORef Map.empty
   return $ Handle {..}
 
 insertGlobalLocator :: Handle -> T.Text -> Hint -> T.Text -> IO ()
@@ -64,6 +70,10 @@ insertVariable :: Handle -> Hint -> Ident -> VarDefKind -> IO ()
 insertVariable h m x k =
   modifyIORef' (unusedVariableMapRef h) $ IntMap.insert (toInt x) (m, x, k)
 
+insertForeign :: Handle -> EN.ExternalName -> Hint -> IO ()
+insertForeign h name m =
+  modifyIORef' (unusedForeignMapRef h) $ Map.insert name m
+
 deleteGlobalLocator :: Handle -> T.Text -> IO ()
 deleteGlobalLocator h sglText =
   modifyIORef' (unusedGlobalLocatorMapRef h) $ Map.delete sglText
@@ -79,6 +89,10 @@ deleteStaticFile h ll =
 deleteVariable :: Handle -> Ident -> IO ()
 deleteVariable h x = do
   modifyIORef' (unusedVariableMapRef h) $ IntMap.delete (toInt x)
+
+deleteForeign :: Handle -> EN.ExternalName -> IO ()
+deleteForeign h name =
+  modifyIORef' (unusedForeignMapRef h) $ Map.delete name
 
 getGlobalLocator :: Handle -> IO UnusedGlobalLocators
 getGlobalLocator h = do
@@ -99,6 +113,11 @@ getVariable :: Handle -> IO [(Hint, Ident, VarDefKind)]
 getVariable h = do
   vars <- readIORef (unusedVariableMapRef h)
   return $ filter (\(_, var, _) -> not (isHole var)) $ IntMap.elems vars
+
+getForeign :: Handle -> IO [(EN.ExternalName, Hint)]
+getForeign h = do
+  uenv <- readIORef (unusedForeignMapRef h)
+  return $ Map.toList uenv
 
 getUnusedLocators :: Handle -> IO (UnusedGlobalLocators, UnusedLocalLocators)
 getUnusedLocators h = do

--- a/src/Kernel/Parse/Internal/Handle/UnusedTopLevelName.hs
+++ b/src/Kernel/Parse/Internal/Handle/UnusedTopLevelName.hs
@@ -1,0 +1,85 @@
+module Kernel.Parse.Internal.Handle.UnusedTopLevelName
+  ( Handle,
+    new,
+    clear,
+    insert,
+    delete,
+    deleteMany,
+    flushRemarks,
+  )
+where
+
+import Control.Monad
+import Data.HashMap.Strict qualified as Map
+import Data.IORef
+import Data.List qualified as List
+import Data.Text qualified as T
+import Kernel.Common.GlobalName qualified as GN
+import Language.Common.Availability qualified as AV
+import Language.Common.DefiniteDescription qualified as DD
+import Language.Common.ModuleID qualified as MID
+import Logger.Hint
+import Logger.Log qualified as L
+import Logger.LogLevel qualified as L
+
+data Handle = Handle
+  { unusedTopLevelNameMapRef :: IORef (Map.HashMap DD.DefiniteDescription Hint),
+    constructorOwnerMapRef :: IORef (Map.HashMap DD.DefiniteDescription DD.DefiniteDescription)
+  }
+
+new :: IO Handle
+new = do
+  unusedTopLevelNameMapRef <- newIORef Map.empty
+  constructorOwnerMapRef <- newIORef Map.empty
+  return $ Handle {..}
+
+clear :: Handle -> IO ()
+clear h = do
+  writeIORef (unusedTopLevelNameMapRef h) Map.empty
+  writeIORef (constructorOwnerMapRef h) Map.empty
+
+insert :: Handle -> DD.DefiniteDescription -> Hint -> GN.GlobalName -> IO ()
+insert h dd m gn = do
+  when (shouldTrack dd) $
+    atomicModifyIORef' (unusedTopLevelNameMapRef h) $ \mp ->
+      (Map.insert dd m mp, ())
+  case gn of
+    GN.Data _ consInfoList _ ->
+      forM_ consInfoList $ \(consDD, _) ->
+        atomicModifyIORef' (constructorOwnerMapRef h) $ \mp ->
+          (Map.insert consDD dd mp, ())
+    _ ->
+      return ()
+
+shouldTrack :: DD.DefiniteDescription -> Bool
+shouldTrack dd = do
+  let (moduleID, _) = DD.unconsDD dd
+  moduleID == MID.Main
+    && AV.isRestricted dd
+    && DD.localLocator dd /= "main"
+    && DD.localLocator dd /= "zen"
+    && not (";" `T.isInfixOf` DD.reify dd)
+    && not ("#" `T.isInfixOf` DD.reify dd)
+
+delete :: Handle -> DD.DefiniteDescription -> IO ()
+delete h dd = do
+  constructorOwnerMap <- readIORef (constructorOwnerMapRef h)
+  atomicModifyIORef' (unusedTopLevelNameMapRef h) $ \mp -> do
+    let mp' =
+          Map.delete dd $
+            maybe id Map.delete (Map.lookup dd constructorOwnerMap) mp
+    (mp', ())
+
+deleteMany :: Handle -> [DD.DefiniteDescription] -> IO ()
+deleteMany h =
+  mapM_ (delete h)
+
+flushRemarks :: Handle -> IO [L.Log]
+flushRemarks h = do
+  unusedTopLevelNameMap <- atomicModifyIORef' (unusedTopLevelNameMapRef h) $ \m ->
+    (Map.empty, m)
+  writeIORef (constructorOwnerMapRef h) Map.empty
+  let unusedTopLevelNames = List.sortOn fst $ Map.toList unusedTopLevelNameMap
+  return $ flip map unusedTopLevelNames $ \(dd, m) ->
+    L.newLog m L.Warning $
+      "Defined but not used: `" <> DD.reify dd <> "`"

--- a/src/Kernel/Parse/Internal/Handle/UsedTopLevelName.hs
+++ b/src/Kernel/Parse/Internal/Handle/UsedTopLevelName.hs
@@ -1,0 +1,29 @@
+module Kernel.Parse.Internal.Handle.UsedTopLevelName
+  ( Handle,
+    new,
+    insert,
+    get,
+  )
+where
+
+import Data.IORef
+import Data.Set qualified as S
+import Language.Common.DefiniteDescription qualified as DD
+
+newtype Handle = Handle
+  { usedTopLevelNameSetRef :: IORef (S.Set DD.DefiniteDescription)
+  }
+
+new :: IO Handle
+new = do
+  usedTopLevelNameSetRef <- newIORef S.empty
+  return $ Handle {..}
+
+insert :: Handle -> DD.DefiniteDescription -> IO ()
+insert h dd =
+  atomicModifyIORef' (usedTopLevelNameSetRef h) $ \s ->
+    (S.insert dd s, ())
+
+get :: Handle -> IO [DD.DefiniteDescription]
+get h =
+  S.toList <$> readIORef (usedTopLevelNameSetRef h)

--- a/src/Kernel/Parse/Interpret.hs
+++ b/src/Kernel/Parse/Interpret.hs
@@ -30,6 +30,7 @@ import Kernel.Parse.Internal.Handle.NameMap qualified as NameMap
 import Kernel.Parse.Internal.Handle.Unused qualified as Unused
 import Kernel.Parse.Internal.Import qualified as Import
 import Kernel.Parse.VarDefKind
+import Language.Common.ExternalName qualified as EN
 import Language.Common.Ident.Reify
 import Language.Common.LocalLocator qualified as LL
 import Language.RawTerm.RawStmt
@@ -107,7 +108,8 @@ interpret' h currentSource (PostRawProgram m importList stmtList) = do
   logs2 <- liftIO $ registerUnusedGlobalLocatorRemarks h
   logs3 <- liftIO $ registerUnusedLocalLocatorRemarks h
   logs4 <- liftIO $ registerUnusedStaticFileRemarks h
-  return (stmtList'', logs1 ++ logs2 ++ logs3 ++ logs4)
+  logs5 <- liftIO $ registerUnusedForeignRemarks h
+  return (stmtList'', logs1 ++ logs2 ++ logs3 ++ logs4 ++ logs5)
 
 activateImport :: Handle -> Hint -> Source.Source -> [ImportItem] -> App ()
 activateImport h m currentSource sourceInfoList = do
@@ -159,3 +161,10 @@ registerUnusedStaticFileRemarks h = do
   return $ flip map unusedStaticFiles $ \(k, m) ->
     L.newLog m L.Warning $
       "Imported but not used: `" <> k <> "`"
+
+registerUnusedForeignRemarks :: Handle -> IO [L.Log]
+registerUnusedForeignRemarks h = do
+  unusedForeigns <- Unused.getForeign (unusedHandle h)
+  return $ flip map unusedForeigns $ \(name, m) ->
+    L.newLog m L.Warning $
+      "Declared but not used: `" <> EN.reify name <> "`"

--- a/src/Kernel/Parse/Interpret.hs
+++ b/src/Kernel/Parse/Interpret.hs
@@ -59,13 +59,14 @@ new ::
   IO Handle
 new globalHandle localHandle currentModule = do
   let unusedHandle = Local.unusedHandle localHandle
+  let usedTopLevelNameHandle = Local.usedTopLevelNameHandle localHandle
   let pathHandle = Global.pathHandle globalHandle
   let importHandle = Import.new globalHandle localHandle
   let globalNameMapHandle = Global.globalNameMapHandle globalHandle
   let aliasHandle = Local.aliasHandle localHandle
   let locatorHandle = Local.locatorHandle localHandle
   let tagHandle = Local.tagHandle localHandle
-  nameMapHandle <- NameMap.new globalHandle unusedHandle tagHandle
+  nameMapHandle <- NameMap.new globalHandle unusedHandle usedTopLevelNameHandle tagHandle
   let symLocHandle = Local.symLocHandle localHandle
   let topCandidateHandle = Local.topCandidateHandle localHandle
   let rawImportSummaryHandle = Local.rawImportSummaryHandle localHandle

--- a/src/Kernel/Parse/Parse.hs
+++ b/src/Kernel/Parse/Parse.hs
@@ -26,6 +26,7 @@ import Kernel.Parse.Internal.Discern.Data (defineData)
 import Kernel.Parse.Internal.Discern.Variadic (defineVariadic)
 import Kernel.Parse.Internal.Handle.GlobalNameMap qualified as GlobalNameMap
 import Kernel.Parse.Internal.Handle.NameMap qualified as NameMap
+import Kernel.Parse.Internal.Handle.UnusedTopLevelName qualified as UnusedTopLevelName
 import Kernel.Parse.Internal.Program qualified as Parse
 import Kernel.Parse.Internal.RawTerm qualified as ParseRT
 import Language.Common.ArgNum qualified as AN
@@ -43,6 +44,7 @@ import SyntaxTree.Series qualified as SE
 data Handle = Handle
   { parseHandle :: ParseRT.Handle,
     globalNameMapHandle :: GlobalNameMap.Handle,
+    unusedTopLevelNameHandle :: UnusedTopLevelName.Handle,
     keyArgHandle :: KeyArg.Handle,
     optDataHandle :: OptimizableData.Handle
   }
@@ -53,6 +55,7 @@ new ::
 new globalHandle = do
   let parseHandle = ParseRT.new (Global.gensymHandle globalHandle)
   let globalNameMapHandle = Global.globalNameMapHandle globalHandle
+  let unusedTopLevelNameHandle = Global.unusedTopLevelNameHandle globalHandle
   let keyArgHandle = Global.keyArgHandle globalHandle
   let optDataHandle = Global.optDataHandle globalHandle
   Handle {..}
@@ -63,6 +66,7 @@ parse ::
   App [(Local.Handle, (Source, Either Cache PostRawProgram))]
 parse h contentSeq = do
   let parseHandle = new h
+  liftIO $ UnusedTopLevelName.clear (unusedTopLevelNameHandle parseHandle)
   cacheOrProgList <- forP contentSeq $ \(source, cacheOrContent) -> do
     prog <- parse' parseHandle source cacheOrContent
     localHandle <- Local.new h source
@@ -181,6 +185,8 @@ saveTopLevelNames :: Handle -> Source.Source -> [(DD.DefiniteDescription, (Hint,
 saveTopLevelNames h source nameArrowList = do
   let nameMap = Map.fromList nameArrowList
   GlobalNameMap.insert (globalNameMapHandle h) (Source.sourceFilePath source) nameMap
+  forM_ nameArrowList $ \(dd, (m, _, gn)) ->
+    UnusedTopLevelName.insert (unusedTopLevelNameHandle h) dd m gn
   registerOptDataInfo h nameArrowList
 
 registerKeyArg :: Handle -> PostRawStmt -> App ()

--- a/src/Language/Common/Availability.hs
+++ b/src/Language/Common/Availability.hs
@@ -1,5 +1,6 @@
 module Language.Common.Availability
   ( allows,
+    isRestricted,
   )
 where
 
@@ -21,3 +22,12 @@ allows currentLocator dd = do
       True
     Just owner ->
       defModuleID == SGL.moduleID currentLocator && owner `SP.contains` SGL.sourceLocator currentLocator
+
+isRestricted :: DD.DefiniteDescription -> Bool
+isRestricted dd = do
+  let (_, rest) = DD.unconsDD dd
+  case SP.internalOwnerOf $ map BN.fromText $ T.splitOn nsSep rest of
+    Nothing ->
+      False
+    Just _ ->
+      True

--- a/src/Logger/Log.hs
+++ b/src/Logger/Log.hs
@@ -2,12 +2,14 @@ module Logger.Log
   ( Log (..),
     isFailure,
     newLog,
+    sortByPosition,
     _logLevelToText,
     _logLevelToSGR,
   )
 where
 
 import Data.Binary (Binary)
+import Data.List qualified as List
 import Data.Text qualified as T
 import GHC.Generics (Generic)
 import Logger.Hint
@@ -64,3 +66,15 @@ newLog m level text = do
       logLevel = level,
       content = text
     }
+
+sortByPosition :: [Log] -> [Log]
+sortByPosition =
+  List.sortOn logPositionKey
+
+logPositionKey :: Log -> (Int, FilePath, Line, Column)
+logPositionKey logItem = do
+  case position logItem of
+    Just (SavedHint Hint {metaFileName, metaLocation = (line, column)}) ->
+      (1, metaFileName, line, column)
+    Nothing ->
+      (0, "", 0, 0)

--- a/src/Logger/Print.hs
+++ b/src/Logger/Print.hs
@@ -24,11 +24,11 @@ printLog =
 
 printLogList :: Handle -> [L.Log] -> IO ()
 printLogList h logList = do
-  foldr ((>>) . printLog h) (return ()) logList
+  foldr ((>>) . printLog h) (return ()) $ L.sortByPosition logList
 
 printErrorList :: Handle -> [L.Log] -> IO ()
 printErrorList h logList = do
-  foldr ((>>) . printErrorIO h) (return ()) logList
+  foldr ((>>) . printErrorIO h) (return ()) $ L.sortByPosition logList
 
 printNote' :: Handle -> T.Text -> IO ()
 printNote' h =


### PR DESCRIPTION
Input:

```neut
foreign {
  foo(int) -> int,
}

define _bar() -> unit {
  Unit
}
```

Before:

```
(empty)
```

After:

```
source/sample.nt:2:3
Warning: Declared but not used: `foo`
source/sample.nt:5:8
Warning: Defined but not used: `this.sample._bar`
```