### PR TITLE
generalize string literal types

### DIFF
--- a/book/src/modules.md
+++ b/book/src/modules.md
@@ -14,7 +14,7 @@ Below is a list of the configurations in `module.ens`.
 - [source](#source)
 - [foreign](#foreign)
 - [extra-content](#extra-content)
-- [text-file](#text-file)
+- [static-file](#static-file)
 - [preset](#preset)
 - [inline-limit](#inline-limit)
 - [antecedent](#antecedent)
@@ -358,14 +358,14 @@ If an entry ends with `/`, it is treated as a directory. Otherwise, it is treate
 
 The field `extra-content` is optional. The default value of `extra-content` is `[]`.
 
-## `text-file`
+## `static-file`
 
-The field `text-file` defines the list of text files that can be embedded into source files at compile time. It should look like the following:
+The field `static-file` defines the list of static files that can be embedded into source files at compile time. It should look like the following:
 
 ```ens
 {
   // ..
-  text-file {
+  static-file {
     some-file "relative/path/from/the/module/root/to/some-file.txt",
     other-file "relative/path/from/the/module/root/to/other-file.txt",
   },
@@ -381,7 +381,7 @@ You can use the keys defined here in source files using `import` and `static`:
 import {
   // ..
   core.string {from-text},
-  text-file {some-file, other-file},
+  static-file {some-file, other-file},
   // ..
 }
 
@@ -391,11 +391,11 @@ define use-some-file() -> unit {
 }
 ```
 
-After specifying a key for a text file in `import`, you can use `static` to embed the file's content into the source file at compile time. Here, `static` assumes that the encoding of the file is UTF-8. For the term-level details of `static` and `text`, see [Terms](./terms.md#static) and [Primitives](./primitives.md#primitive-types).
+After specifying a key for a static file in `import`, you can use `static` to embed the file's content into the source file at compile time. `static` is resolved as `text`, `blob`, `&string`, or `&binary` according to the surrounding type context; UTF-8 is required only when it resolves as `text` or `&string`. For the term-level details of `static`, see [Terms](./terms.md#static) and [Primitives](./primitives.md#primitive-types).
 
 The compiler triggers recompilation when necessary by comparing the modification times of static resources and source files. In the code above, for example, the compiler recompiles `foo.nt` if you modify the content of `some-file.txt`.
 
-The field `text-file` is optional. The default value of `text-file` is `{}`.
+The field `static-file` is optional. The default value of `static-file` is `{}`.
 
 ## `preset`
 

--- a/book/src/primitives.md
+++ b/book/src/primitives.md
@@ -15,6 +15,7 @@ Neut supports the following primitive types:
 - float types: `float16, float32, float64`
 - rune type: `rune`
 - text type: `text`
+- blob type: `blob`
 
 You can also use `int` and `float`. These are just syntactic sugar for `int64` and `float64`, respectively.
 
@@ -81,4 +82,7 @@ data pair(a, b) {
 
 Functions for those types are also defined in the library. For more, please see [the source of the core library](https://github.com/vekatze/neut-core/tree/main/source).
 
-The core library also defines `string` and functions on it. String literals have type `&string`. In particular, `core.string.from-text` converts `text` to `&string`.
+The core library also defines `string`, `binary`, and functions on them. String literals are inferred as `text`, `blob`, `&string`, or `&binary` depending on the surrounding type context. In particular,
+
+- `core.binary.from-blob` converts `blob` to `&binary`,
+- `core.string.from-text` converts `text` to `&string`.

--- a/book/src/statements.md
+++ b/book/src/statements.md
@@ -68,15 +68,15 @@ define yo() -> unit {
 }
 ```
 
-You can also list text files in `import`:
+You can also list static files in `import`:
 
 ```neut
 import {
-  text-file {some-file, other-file}
+  static-file {some-file, other-file}
 }
 ```
 
-For more on text files, please see [the section in Modules](modules.md#text-file).
+For more on static files, please see [the section in Modules](modules.md#static-file).
 
 ## `define`
 

--- a/book/src/terms.md
+++ b/book/src/terms.md
@@ -492,7 +492,7 @@ define foo() -> unit {
 
 `` `A` ``, `` `\n` ``, `` `\u{123}` ``, etc.
 
-The available escape sequences in rune literals are the same as those of the literal form of [`static`](./terms.md#static).
+The available escape sequences in rune literals are the same as those of [string literals](./terms.md#strings).
 
 ### Semantics
 
@@ -536,7 +536,13 @@ define print-star() -> unit {
 
 ```neut
 define foo() -> unit {
+  let _: text = "test";
+  //            ^^^^^^
   let _: &string = "test";
+  //               ^^^^^^
+  let _: blob = "\x{FF}";
+  //            ^^^^^^
+  let _: &binary = "\x{FF}";
   //               ^^^^^^
   Unit
 }
@@ -545,24 +551,64 @@ define foo() -> unit {
 
 ### Syntax
 
-The syntax of a string literal is the same as that of the literal form of [`static`](#static).
+```neut
+"hello"
+"Hello, world!\n"
+"\u{1F338} ← Cherry Blossom"
+"\x{FF}"
+```
+
+Below is a list of all escape sequences available in Neut string literals:
+
+| Escape Sequence | Meaning                        |
+| --------------- | ------------------------------ |
+| `\0`            | U+0000 (null character)        |
+| `\t`            | U+0009 (horizontal tab)        |
+| `\n`            | U+000A (line feed)             |
+| `\r`            | U+000D (carriage return)       |
+| `\"`            | U+0022 (double quotation mark) |
+| `\\`            | U+005C (backslash)             |
+| `` \` ``        | U+0060 (backtick)              |
+| `\x{n}`         | byte with hexadecimal value n  |
+| `\u{n}`         | U+n                            |
+
+The `n` in `\x{n}` and `\u{n}` must be an uppercase hexadecimal number. For `\x{n}`, the value must be in the byte range `0` to `FF`.
 
 ### Semantics
 
-If `t` is a string literal, then `t` is shorthand for `magic cast(text, &string, static t)`.
+A string literal is resolved as `text`, `blob`, `&string`, or `&binary` according to the surrounding type context.
+
+When the resolved type is `text` or `&string`, the literal bytes must be valid UTF-8. When the resolved type is `blob` or `&binary`, any byte sequence is allowed. In particular, `\x{n}` can be used to write bytes that are not valid UTF-8.
+
+When the resolved type is `&string` or `&binary`, the literal is compiled as a static value and cast to that type.
 
 ### Type
 
 ```neut
 (Γ is a context)
 (t is a string literal)
------------------------
+--------------------------
+Γ ⊢ t: text
+
+(Γ is a context)
+(t is a string literal)
+--------------------------
+Γ ⊢ t: blob
+
+(Γ is a context)
+(t is a string literal)
+--------------------------
 Γ ⊢ t: &string
+
+(Γ is a context)
+(t is a string literal)
+--------------------------
+Γ ⊢ t: &binary
 ```
 
 ### Note
 
-- For the exact syntax and internal representation of the literal part, see [`static`](#static).
+- A string literal whose type cannot be inferred as `text`, `blob`, `&string`, or `&binary` is rejected.
 
 ## `(x1: a1, ..., xn: an) -> b`
 
@@ -2365,7 +2411,7 @@ define lift-either(x: either(bool, unit)) -> +either(bool, unit) {
 
 `lift` is there only for convenience.
 
-One useful example is `text`: since `static` has type `text`, you can lift embedded text directly. If you first convert it to `&string` using `core.string.from-text`, it is no longer liftable.
+A useful case is static data: primitive types such as `text` and `blob` are liftable, whereas noetic types such as `&string` and `&binary` are not.
 
 ## `pack-type`
 
@@ -2828,14 +2874,14 @@ The configuration value `default` is equal to any configuration value.
 
 ## `static`
 
-You can use `static` to create a value of type `text`.
+You can use `static` to embed file content as `text`, `blob`, `&string`, or `&binary`.
 
 ### Example
 
 ```neut
 import {
   core.string {from-text},
-  text-file {some-file},
+  static-file {some-file},
 }
 
 define use-some-file() -> unit {
@@ -2844,8 +2890,8 @@ define use-some-file() -> unit {
   print(s)
 }
 
-define use-static-literal() -> unit {
-  let t: text = static "hello";
+define use-string-literal() -> unit {
+  let t: text = "hello";
   let s: &string = "hello";
   print(from-text(t));
   print(s)
@@ -2856,35 +2902,15 @@ define use-static-literal() -> unit {
 
 ```neut
 static some-file
-static "hello"
-static "Hello, world!\n"
-static "\u{1F338} ← Cherry Blossom"
 ```
-
-Below is a list of all escape sequences available in Neut string literals:
-
-| Escape Sequence | Meaning                        |
-| --------------- | ------------------------------ |
-| `\0`            | U+0000 (null character)        |
-| `\t`            | U+0009 (horizontal tab)        |
-| `\n`            | U+000A (line feed)             |
-| `\r`            | U+000D (carriage return)       |
-| `\"`            | U+0022 (double quotation mark) |
-| `\\`            | U+005C (backslash)             |
-| `` \` ``        | U+0060 (backtick)              |
-| `\u{n}`         | U+n                            |
-
-The `n` in `\u{n}` must be an uppercase hexadecimal number.
 
 ### Semantics
 
 The compiler expands `static foo` into the content of `foo` at compile time.
 
-If `foo` isn't a key of a UTF-8 text file, `static foo` reports a compilation error.
+If `foo` isn't a key of a static file, `static foo` reports a compilation error.
 
-The expression `static "hello"` creates a value of type `text` from the given string literal.
-
-A static literal is compiled into a pointer to a tuple like the following:
+A string literal or `static` term whose type is resolved as `text`, `blob`, `&string`, or `&binary` is compiled into a pointer to a tuple like the following:
 
 ```text
 (0, length-of-string, array-of-characters)
@@ -2896,26 +2922,22 @@ This tuple is static. More specifically, a global constant like the following is
 @"text-hello" = private unnamed_addr constant {i64, i64, [5 x i8]} {i64 0, i64 5, [5 x i8] c"hello"}
 ```
 
-And a term like `static "hello": text` is compiled into `ptr @"text-hello"`.
+And a term like `"hello": text` or `static hello-file: text` is compiled into such a pointer.
+
+When the resolved type is `text` or `&string`, the embedded bytes must be valid UTF-8. When the resolved type is `blob` or `&binary`, any byte sequence is allowed.
 
 ### Type
 
 ```neut
 (Γ is a context)
-(k is a text file's key)
---------------------------------------------
-Γ ⊢ static k: text
-
-(Γ is a context)
-(s is a string literal)
--------------------------------------------
-Γ ⊢ static s: text
+(k is a static file's key)
+Γ ⊢ static k: text | blob | &string | &binary
 ```
 
 ### Note
 
-- Since `text` is primitive, `static` can be lifted.
-- You may also want to read [the section on text files in Modules](modules.md#text-file).
+- Since `text` and `blob` are primitive, `static` can be lifted when its resolved type is `text` or `blob`.
+- You may also want to read [the section on static files in Modules](modules.md#static-file).
 
 ## `admit`
 

--- a/src/Command/Archive/Archive.hs
+++ b/src/Command/Archive/Archive.hs
@@ -51,5 +51,5 @@ collectModuleFiles (MainModule baseModule) = do
   let relModuleSourceDir = Left $ moduleSourceDir baseModule
   let foreignContents = input $ moduleForeign baseModule
   let extraContents = moduleExtraContents baseModule
-  let staticContents = map (\(_, path) -> Right path) $ Map.toList $ moduleTextFiles baseModule
+  let staticContents = map (\(_, path) -> Right path) $ Map.toList $ moduleStaticFiles baseModule
   (moduleRootDir, relModuleSourceDir : foreignContents ++ staticContents ++ extraContents)

--- a/src/Command/Create/Internal.hs
+++ b/src/Command/Create/Internal.hs
@@ -77,7 +77,7 @@ constructDefaultModule moduleName mTargetName = do
         moduleExtraContents = [],
         moduleAntecedents = [],
         moduleLocation = moduleRootDir </> moduleFile,
-        moduleTextFiles = Map.empty,
+        moduleStaticFiles = Map.empty,
         moduleForeign = Foreign {input = [], output = [], script = []},
         moduleInlineLimit = Nothing,
         modulePresetMap = Map.empty

--- a/src/Kernel/Clarify/Clarify.hs
+++ b/src/Kernel/Clarify/Clarify.hs
@@ -619,6 +619,8 @@ clarifyTerm h context term =
           return $ C.UpIntro $ C.VarStaticBytes bytes
         PV.Text text ->
           return $ C.UpIntro $ C.VarStaticBytes $ TE.encodeUtf8 text
+        PV.Blob bytes ->
+          return $ C.UpIntro $ C.VarStaticBytes bytes
         PV.Rune r -> do
           let t = fromPrimNum m (PT.Int PNS.IntSize32)
           clarifyTerm h context $ m :< TM.Prim (PV.Int t PNS.IntSize32 (RU.asInt r))

--- a/src/Kernel/Clarify/Clarify.hs
+++ b/src/Kernel/Clarify/Clarify.hs
@@ -23,6 +23,7 @@ import Data.IntMap qualified as IntMap
 import Data.Maybe
 import Data.Set qualified as S
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import Gensym.Gensym qualified as Gensym
 import Gensym.Handle qualified as Gensym
 import Kernel.Clarify.Internal.Handle.AuxEnv qualified as AuxEnv
@@ -613,11 +614,11 @@ clarifyTerm h context term =
         PV.Op op -> do
           clarifyPrimOp h context op m
         PV.NoeticString _ text ->
-          return $ C.UpIntro $ C.VarStaticText text
+          return $ C.UpIntro $ C.VarStaticBytes $ TE.encodeUtf8 text
         PV.NoeticBinary _ bytes ->
           return $ C.UpIntro $ C.VarStaticBytes bytes
         PV.Text text ->
-          return $ C.UpIntro $ C.VarStaticText text
+          return $ C.UpIntro $ C.VarStaticBytes $ TE.encodeUtf8 text
         PV.Rune r -> do
           let t = fromPrimNum m (PT.Int PNS.IntSize32)
           clarifyTerm h context $ m :< TM.Prim (PV.Int t PNS.IntSize32 (RU.asInt r))

--- a/src/Kernel/Clarify/Clarify.hs
+++ b/src/Kernel/Clarify/Clarify.hs
@@ -614,6 +614,8 @@ clarifyTerm h context term =
           clarifyPrimOp h context op m
         PV.NoeticString _ text ->
           return $ C.UpIntro $ C.VarStaticText text
+        PV.NoeticBinary _ bytes ->
+          return $ C.UpIntro $ C.VarStaticBytes bytes
         PV.Text text ->
           return $ C.UpIntro $ C.VarStaticText text
         PV.Rune r -> do

--- a/src/Kernel/Common/Const.hs
+++ b/src/Kernel/Common/Const.hs
@@ -123,6 +123,10 @@ coreString :: T.Text
 coreString =
   core <> nsSep <> "string" <> nsSep <> "string"
 
+coreBinary :: T.Text
+coreBinary =
+  core <> nsSep <> "binary" <> nsSep <> "binary"
+
 coreCSize :: T.Text
 coreCSize =
   core <> nsSep <> "c-size" <> nsSep <> "c-size"

--- a/src/Kernel/Common/Handle/Local/Locator.hs
+++ b/src/Kernel/Common/Handle/Local/Locator.hs
@@ -4,7 +4,7 @@ module Kernel.Common.Handle.Local.Locator
     attachCurrentLocator,
     activateSpecifiedNames,
     getStaticFileContent,
-    activateTextFile,
+    activateStaticFile,
     getPossibleReferents,
     getCurrentGlobalLocator,
     constructGlobalLocator,
@@ -15,6 +15,7 @@ import App.App (App)
 import App.Run (raiseError, raiseError')
 import Control.Monad
 import Control.Monad.IO.Class
+import Data.ByteString qualified as BS
 import Data.Containers.ListUtils qualified as ListUtils
 import Data.HashMap.Strict qualified as Map
 import Data.IORef
@@ -37,7 +38,6 @@ import Language.Common.StrictGlobalLocator qualified as SGL
 import Logger.Hint
 import Path
 import Path.IO
-import Path.Read (readTextFromPath)
 
 -- the structure of a name of a global variable:
 --
@@ -51,7 +51,7 @@ data Handle = Handle
   { _tagHandle :: Tag.Handle,
     _envHandle :: Env.Handle,
     _activeDefiniteDescriptionListRef :: IORef (Map.HashMap LL.LocalLocator DD.DefiniteDescription),
-    _activeTextFileMapRef :: IORef (Map.HashMap T.Text (Path Abs File, T.Text)),
+    _activeStaticFileMapRef :: IORef (Map.HashMap T.Text (Path Abs File, BS.ByteString)),
     _activeGlobalLocatorList :: [SGL.StrictGlobalLocator],
     _currentGlobalLocator :: SGL.StrictGlobalLocator
   }
@@ -60,7 +60,7 @@ new :: Env.Handle -> Tag.Handle -> Source.Source -> App Handle
 new _envHandle _tagHandle source = do
   cgl <- constructGlobalLocator source
   _activeDefiniteDescriptionListRef <- liftIO $ newIORef Map.empty
-  _activeTextFileMapRef <- liftIO $ newIORef Map.empty
+  _activeStaticFileMapRef <- liftIO $ newIORef Map.empty
   let _activeGlobalLocatorList = [cgl, SGL.llvmGlobalLocator]
   let _currentGlobalLocator = cgl
   return $ Handle {..}
@@ -80,8 +80,9 @@ activateSpecifiedNames h currentSource topNameMap mustUpdateTag sgl lls = do
     case Map.lookup dd topNameMap of
       Nothing ->
         raiseError m $ "The name `" <> LL.reify ll <> "` is not defined in the file"
-      Just _ | not (AV.allows currentGlobalLocator dd) ->
-        raiseError m $ "The name `" <> LL.reify ll <> "` is not visible from this source"
+      Just _
+        | not (AV.allows currentGlobalLocator dd) ->
+            raiseError m $ "The name `" <> LL.reify ll <> "` is not visible from this source"
       Just (mDef, _tag, gn) -> do
         when mustUpdateTag $
           liftIO $
@@ -102,20 +103,20 @@ activateSpecifiedNames h currentSource topNameMap mustUpdateTag sgl lls = do
           _ ->
             liftIO $ modifyIORef' (_activeDefiniteDescriptionListRef h) $ Map.insert ll dd
 
-activateTextFile :: Handle -> Hint -> T.Text -> Path Abs File -> App ()
-activateTextFile h m key path = do
+activateStaticFile :: Handle -> Hint -> T.Text -> Path Abs File -> App ()
+activateStaticFile h m key path = do
   b <- doesFileExist path
   if b
     then do
-      content <- readTextFromPath path
-      liftIO $ modifyIORef' (_activeTextFileMapRef h) $ Map.insert key (path, content)
+      content <- liftIO $ BS.readFile $ toFilePath path
+      liftIO $ modifyIORef' (_activeStaticFileMapRef h) $ Map.insert key (path, content)
     else
       raiseError m $
-        "The text file `" <> key <> "` does not exist at: " <> T.pack (toFilePath path)
+        "The static file `" <> key <> "` does not exist at: " <> T.pack (toFilePath path)
 
-getStaticFileContent :: Handle -> T.Text -> IO (Maybe (Path Abs File, T.Text))
+getStaticFileContent :: Handle -> T.Text -> IO (Maybe (Path Abs File, BS.ByteString))
 getStaticFileContent h key = do
-  activeStaticFileList <- readIORef (_activeTextFileMapRef h)
+  activeStaticFileList <- readIORef (_activeStaticFileMapRef h)
   return $ Map.lookup key activeStaticFileList
 
 attachCurrentLocator ::

--- a/src/Kernel/Common/Import.hs
+++ b/src/Kernel/Common/Import.hs
@@ -8,4 +8,4 @@ import Path
 
 data ImportItem
   = ImportItem Source.Source [AI.AliasInfo]
-  | TextFileKey [(T.Text, (Hint, Path Abs File))]
+  | StaticFileKey [(T.Text, (Hint, Path Abs File))]

--- a/src/Kernel/Common/Module.hs
+++ b/src/Kernel/Common/Module.hs
@@ -28,7 +28,7 @@ module Kernel.Common.Module
     keyMirror,
     keyPreset,
     keySource,
-    keyTextFile,
+    keyStaticFile,
     keyTarget,
     keyZen,
     getSourceDir,
@@ -116,7 +116,7 @@ data Module = Module
     moduleAntecedents :: [ModuleDigest],
     moduleLocation :: Path Abs File,
     moduleForeign :: Foreign,
-    moduleTextFiles :: Map.HashMap T.Text (Path Rel File),
+    moduleStaticFiles :: Map.HashMap T.Text (Path Rel File),
     moduleInlineLimit :: Maybe Int,
     modulePresetMap :: PresetMap
   }
@@ -194,9 +194,9 @@ keyAntecedent :: T.Text
 keyAntecedent =
   "antecedent"
 
-keyTextFile :: T.Text
-keyTextFile =
-  "text-file"
+keyStaticFile :: T.Text
+keyStaticFile =
+  "static-file"
 
 keyForeign :: T.Text
 keyForeign =

--- a/src/Kernel/Common/Module/FromPath.hs
+++ b/src/Kernel/Common/Module/FromPath.hs
@@ -46,8 +46,8 @@ fromFilePath moduleFilePath = do
   extraContents <- mapM (interpretExtraPath $ parent moduleFilePath) $ SE.extract extraContentsEns
   (_, antecedentsEns) <- liftEither $ E.access' keyAntecedent E.emptyList ens >>= E.toList
   antecedents <- mapM interpretAntecedent $ SE.extract antecedentsEns
-  (_, textFileEns) <- liftEither $ E.access' keyTextFile E.emptyDict ens >>= E.toDictionary
-  textFileMap <- interpretStaticFiles textFileEns
+  (_, staticFileEns) <- liftEither $ E.access' keyStaticFile E.emptyDict ens >>= E.toDictionary
+  staticFileMap <- interpretStaticFiles staticFileEns
   archiveDirEns <- liftEither $ E.access' keyArchive (E.ensPath archiveRelDir) ens
   archiveDir <- interpretDirPath archiveDirEns
   cacheDirEns <- liftEither $ E.access' keyCache (E.ensPath cacheRelDir) ens
@@ -72,7 +72,7 @@ fromFilePath moduleFilePath = do
         moduleExtraContents = extraContents,
         moduleAntecedents = antecedents,
         moduleLocation = moduleFilePath,
-        moduleTextFiles = textFileMap,
+        moduleStaticFiles = staticFileMap,
         moduleForeign = foreignDict,
         moduleInlineLimit = mInlineLimit,
         modulePresetMap = presetMap

--- a/src/Kernel/Common/RawImportSummary.hs
+++ b/src/Kernel/Common/RawImportSummary.hs
@@ -23,5 +23,5 @@ fromRawImportItem rawImportItem = do
     RawImportItem _ (gl, _) llSeries -> do
       let llList = map (LL.reify . snd) $ SE.extract llSeries
       Just (gl, llList)
-    RawTextFileKey {} ->
+    RawStaticFileKey {} ->
       Nothing

--- a/src/Kernel/Elaborate/Elaborate.hs
+++ b/src/Kernel/Elaborate/Elaborate.hs
@@ -52,6 +52,7 @@ import Kernel.Parse.Internal.Handle.UnusedTopLevelName qualified as UnusedTopLev
 import Kernel.Parse.Internal.Handle.UsedTopLevelName qualified as UsedTopLevelName
 import Language.Common.Annotation qualified as AN
 import Language.Common.Attr.Lam qualified as AttrL
+import Language.Common.BaseName qualified as BN
 import Language.Common.BaseLowType qualified as BLT
 import Language.Common.BasePrimType qualified as BPT
 import Language.Common.Binder
@@ -709,6 +710,8 @@ elaboratePrimValue h m primValue =
       return $ PV.Float t' size x
     WPV.Op op ->
       return $ PV.Op op
+    WPV.String t text -> do
+      strictifyStringLiteral h m text t
     WPV.NoeticString t text -> do
       t' <- elaborateType h t
       return $ PV.NoeticString t' text
@@ -774,6 +777,32 @@ strictifyFloatType h m x t = do
           raiseNonFloatType m x (weakenType t')
     _ :< _ ->
       raiseNonFloatType m x (weakenType t')
+
+strictifyStringLiteral :: Handle -> Hint -> T.Text -> WT.WeakType -> App (PV.PrimValue TM.Type)
+strictifyStringLiteral h m text t = do
+  t' <- reduceWeakType h t >>= elaborateType h
+  case t' of
+    _ :< TM.PrimType PT.Text -> do
+      return $ PV.Text text
+    _ :< TM.BoxNoema inner
+      | isStringObjectType inner -> do
+          return $ PV.NoeticString inner text
+    _ :< _ ->
+      raiseNonStringType m text (weakenType t')
+
+isStringObjectType :: TM.Type -> Bool
+isStringObjectType t =
+  case t of
+    _ :< TM.TVar x ->
+      Ident.toText x == BN.reify BN.stringType
+    _ :< TM.TVarGlobal _ dd ->
+      DD.localLocator dd == BN.reify BN.stringType
+    _ :< TM.TyApp inner [] ->
+      isStringObjectType inner
+    _ :< TM.Data _ dd [] ->
+      DD.localLocator dd == BN.reify BN.stringType
+    _ ->
+      False
 
 elaborateWeakBinder :: Handle -> BinderF WT.WeakType -> App (BinderF TM.Type)
 elaborateWeakBinder h (m, k, x, t) = do
@@ -956,6 +985,14 @@ raiseNonFloatType m x t = do
     "The term `"
       <> T.pack (show x)
       <> "` is a float, but its type is: "
+      <> toTextType t
+
+raiseNonStringType :: Hint -> T.Text -> WT.WeakType -> App a
+raiseNonStringType m text t = do
+  raiseError m $
+    "The term `"
+      <> T.pack (show text)
+      <> "` is a string, but its type is: "
       <> toTextType t
 
 raiseLiteralNonExhaustivePatternMatching :: Hint -> App a

--- a/src/Kernel/Elaborate/Elaborate.hs
+++ b/src/Kernel/Elaborate/Elaborate.hs
@@ -20,7 +20,6 @@ import Data.IORef
 import Data.IntMap qualified as IntMap
 import Data.Set qualified as S
 import Data.Text qualified as T
-import Data.Text.Encoding qualified as TE
 import Gensym.Trick qualified as Gensym
 import Kernel.Common.Cache qualified as Cache
 import Kernel.Common.Const (holeLiteral)
@@ -79,6 +78,7 @@ import Language.Common.PiKind qualified as PK
 import Language.Common.PrimNumSize
 import Language.Common.PrimType qualified as PT
 import Language.Common.StmtKind qualified as SK
+import Language.Common.Text.Util (decodeUtf8Bytes)
 import Language.LowComp.DeclarationName qualified as DN
 import Language.Term.Inline qualified as Inline
 import Language.Term.PrimValue qualified as PV
@@ -801,11 +801,11 @@ strictifyStringLiteral h m bytes t = do
 
 decodeStringLiteralBytes :: Hint -> BS.ByteString -> App T.Text
 decodeStringLiteralBytes m bytes = do
-  case TE.decodeUtf8' bytes of
+  case decodeUtf8Bytes bytes of
     Right text ->
       return text
-    Left err ->
-      raiseError m $ "This string literal is not valid UTF-8: " <> T.pack (show err)
+    Left reason ->
+      raiseError m $ "This string literal is not valid UTF-8.\nReason: " <> reason
 
 isStringObjectType :: TM.Type -> Bool
 isStringObjectType t =

--- a/src/Kernel/Elaborate/Elaborate.hs
+++ b/src/Kernel/Elaborate/Elaborate.hs
@@ -53,8 +53,8 @@ import Kernel.Parse.Internal.Handle.UnusedTopLevelName qualified as UnusedTopLev
 import Kernel.Parse.Internal.Handle.UsedTopLevelName qualified as UsedTopLevelName
 import Language.Common.Annotation qualified as AN
 import Language.Common.Attr.Lam qualified as AttrL
-import Language.Common.BaseName qualified as BN
 import Language.Common.BaseLowType qualified as BLT
+import Language.Common.BaseName qualified as BN
 import Language.Common.BasePrimType qualified as BPT
 import Language.Common.Binder
 import Language.Common.CreateSymbol qualified as Gensym
@@ -73,11 +73,14 @@ import Language.Common.IsConstLike (IsConstLike)
 import Language.Common.LamKind qualified as LK
 import Language.Common.LowMagic qualified as LM
 import Language.Common.Magic qualified as M
+import Language.Common.ModuleID qualified as MID
 import Language.Common.PiElimKind qualified as PEK
 import Language.Common.PiKind qualified as PK
 import Language.Common.PrimNumSize
 import Language.Common.PrimType qualified as PT
+import Language.Common.SourceLocator qualified as SL
 import Language.Common.StmtKind qualified as SK
+import Language.Common.StrictGlobalLocator qualified as SGL
 import Language.Common.Text.Util (decodeUtf8Bytes)
 import Language.LowComp.DeclarationName qualified as DN
 import Language.Term.Inline qualified as Inline
@@ -712,8 +715,8 @@ elaboratePrimValue h m primValue =
       return $ PV.Float t' size x
     WPV.Op op ->
       return $ PV.Op op
-    WPV.String t text -> do
-      strictifyStringLiteral h m text t
+    WPV.String coreModuleID t bytes -> do
+      strictifyStringLiteral h m coreModuleID bytes t
     WPV.NoeticString t text -> do
       t' <- elaborateType h t
       return $ PV.NoeticString t' text
@@ -785,8 +788,10 @@ strictifyFloatType h m x t = do
     _ :< _ ->
       raiseNonFloatType m x (weakenType t')
 
-strictifyStringLiteral :: Handle -> Hint -> BS.ByteString -> WT.WeakType -> App (PV.PrimValue TM.Type)
-strictifyStringLiteral h m bytes t = do
+strictifyStringLiteral :: Handle -> Hint -> MID.ModuleID -> BS.ByteString -> WT.WeakType -> App (PV.PrimValue TM.Type)
+strictifyStringLiteral h m coreModuleID bytes t = do
+  let stringDD = makeCoreStringDD coreModuleID
+  let binaryDD = makeCoreBinaryDD coreModuleID
   t' <- reduceWeakType h t >>= elaborateType h
   case t' of
     _ :< TM.PrimType PT.Text -> do
@@ -794,12 +799,16 @@ strictifyStringLiteral h m bytes t = do
       return $ PV.Text text
     _ :< TM.PrimType PT.Blob -> do
       return $ PV.Blob bytes
-    _ :< TM.BoxNoema inner
-      | isStringObjectType inner -> do
+    _ :< TM.BoxNoema inner -> do
+      inner' <- reduceWeakType h (weakenType inner) >>= elaborateType h
+      if isStringObjectType stringDD inner'
+        then do
           text <- decodeStringLiteralBytes m bytes
-          return $ PV.NoeticString inner text
-      | isBinaryObjectType inner -> do
-          return $ PV.NoeticBinary inner bytes
+          return $ PV.NoeticString inner' text
+        else
+          if isBinaryObjectType binaryDD inner'
+            then return $ PV.NoeticBinary inner bytes
+            else raiseNonStringType m bytes (weakenType t')
     _ :< _ ->
       raiseNonStringType m bytes (weakenType t')
 
@@ -811,35 +820,31 @@ decodeStringLiteralBytes m bytes = do
     Left reason ->
       raiseError m $ "This string literal is not valid UTF-8.\nReason: " <> reason
 
-isStringObjectType :: TM.Type -> Bool
-isStringObjectType t =
+isStringObjectType :: DD.DefiniteDescription -> TM.Type -> Bool
+isStringObjectType stringDD t =
   case t of
-    _ :< TM.TVar x ->
-      Ident.toText x == BN.reify BN.stringType
-    _ :< TM.TVarGlobal _ dd ->
-      DD.localLocator dd == BN.reify BN.stringType
-    _ :< TM.TyApp inner [] ->
-      isStringObjectType inner
     _ :< TM.Data _ dd [] ->
-      DD.localLocator dd == BN.reify BN.stringType
+      dd == stringDD
     _ ->
       False
 
-isBinaryObjectType :: TM.Type -> Bool
-isBinaryObjectType t =
+isBinaryObjectType :: DD.DefiniteDescription -> TM.Type -> Bool
+isBinaryObjectType binaryDD t =
   case t of
-    _ :< TM.TVar x ->
-      Ident.toText x == BN.reify BN.binary
-    _ :< TM.TVarGlobal _ dd ->
-      DD.localLocator dd == BN.reify BN.binary
-    _ :< TM.TyApp inner [] ->
-      isBinaryObjectType inner
-    _ :< TM.Data _ dd [] ->
-      DD.localLocator dd == BN.reify BN.binary
     _ :< TM.Resource dd _ ->
-      DD.localLocator dd == BN.reify BN.binary
+      dd == binaryDD
     _ ->
       False
+
+makeCoreStringDD :: MID.ModuleID -> DD.DefiniteDescription
+makeCoreStringDD moduleID = do
+  let stringSGL = SGL.StrictGlobalLocator {moduleID, sourceLocator = SL.stringLocator}
+  DD.newByGlobalLocator stringSGL BN.stringType
+
+makeCoreBinaryDD :: MID.ModuleID -> DD.DefiniteDescription
+makeCoreBinaryDD moduleID = do
+  let binarySGL = SGL.StrictGlobalLocator {moduleID, sourceLocator = SL.binaryLocator}
+  DD.newByGlobalLocator binarySGL BN.binary
 
 elaborateWeakBinder :: Handle -> BinderF WT.WeakType -> App (BinderF TM.Type)
 elaborateWeakBinder h (m, k, x, t) = do

--- a/src/Kernel/Elaborate/Elaborate.hs
+++ b/src/Kernel/Elaborate/Elaborate.hs
@@ -15,10 +15,12 @@ import Control.Monad.Except (MonadError (throwError))
 import Control.Monad.IO.Class
 import Data.Bifunctor
 import Data.Bitraversable (bimapM)
+import Data.ByteString qualified as BS
 import Data.IORef
 import Data.IntMap qualified as IntMap
 import Data.Set qualified as S
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import Gensym.Trick qualified as Gensym
 import Kernel.Common.Cache qualified as Cache
 import Kernel.Common.Const (holeLiteral)
@@ -715,6 +717,9 @@ elaboratePrimValue h m primValue =
     WPV.NoeticString t text -> do
       t' <- elaborateType h t
       return $ PV.NoeticString t' text
+    WPV.NoeticBinary t bytes -> do
+      t' <- elaborateType h t
+      return $ PV.NoeticBinary t' bytes
     WPV.Text text ->
       return $ PV.Text text
     WPV.Rune r ->
@@ -778,17 +783,29 @@ strictifyFloatType h m x t = do
     _ :< _ ->
       raiseNonFloatType m x (weakenType t')
 
-strictifyStringLiteral :: Handle -> Hint -> T.Text -> WT.WeakType -> App (PV.PrimValue TM.Type)
-strictifyStringLiteral h m text t = do
+strictifyStringLiteral :: Handle -> Hint -> BS.ByteString -> WT.WeakType -> App (PV.PrimValue TM.Type)
+strictifyStringLiteral h m bytes t = do
   t' <- reduceWeakType h t >>= elaborateType h
   case t' of
     _ :< TM.PrimType PT.Text -> do
+      text <- decodeStringLiteralBytes m bytes
       return $ PV.Text text
     _ :< TM.BoxNoema inner
       | isStringObjectType inner -> do
+          text <- decodeStringLiteralBytes m bytes
           return $ PV.NoeticString inner text
+      | isBinaryObjectType inner -> do
+          return $ PV.NoeticBinary inner bytes
     _ :< _ ->
-      raiseNonStringType m text (weakenType t')
+      raiseNonStringType m bytes (weakenType t')
+
+decodeStringLiteralBytes :: Hint -> BS.ByteString -> App T.Text
+decodeStringLiteralBytes m bytes = do
+  case TE.decodeUtf8' bytes of
+    Right text ->
+      return text
+    Left err ->
+      raiseError m $ "This string literal is not valid UTF-8: " <> T.pack (show err)
 
 isStringObjectType :: TM.Type -> Bool
 isStringObjectType t =
@@ -801,6 +818,20 @@ isStringObjectType t =
       isStringObjectType inner
     _ :< TM.Data _ dd [] ->
       DD.localLocator dd == BN.reify BN.stringType
+    _ ->
+      False
+
+isBinaryObjectType :: TM.Type -> Bool
+isBinaryObjectType t =
+  case t of
+    _ :< TM.TVar x ->
+      Ident.toText x == BN.reify BN.binary
+    _ :< TM.TVarGlobal _ dd ->
+      DD.localLocator dd == BN.reify BN.binary
+    _ :< TM.TyApp inner [] ->
+      isBinaryObjectType inner
+    _ :< TM.Data _ dd [] ->
+      DD.localLocator dd == BN.reify BN.binary
     _ ->
       False
 
@@ -987,12 +1018,12 @@ raiseNonFloatType m x t = do
       <> "` is a float, but its type is: "
       <> toTextType t
 
-raiseNonStringType :: Hint -> T.Text -> WT.WeakType -> App a
-raiseNonStringType m text t = do
+raiseNonStringType :: Hint -> BS.ByteString -> WT.WeakType -> App a
+raiseNonStringType m bytes t = do
   raiseError m $
     "The term `"
-      <> T.pack (show text)
-      <> "` is a string, but its type is: "
+      <> T.pack (show bytes)
+      <> "` is a string literal, but its type is neither text, &string, nor &binary: "
       <> toTextType t
 
 raiseLiteralNonExhaustivePatternMatching :: Hint -> App a

--- a/src/Kernel/Elaborate/Elaborate.hs
+++ b/src/Kernel/Elaborate/Elaborate.hs
@@ -722,6 +722,8 @@ elaboratePrimValue h m primValue =
       return $ PV.NoeticBinary t' bytes
     WPV.Text text ->
       return $ PV.Text text
+    WPV.Blob bytes ->
+      return $ PV.Blob bytes
     WPV.Rune r ->
       return $ PV.Rune r
 
@@ -790,6 +792,8 @@ strictifyStringLiteral h m bytes t = do
     _ :< TM.PrimType PT.Text -> do
       text <- decodeStringLiteralBytes m bytes
       return $ PV.Text text
+    _ :< TM.PrimType PT.Blob -> do
+      return $ PV.Blob bytes
     _ :< TM.BoxNoema inner
       | isStringObjectType inner -> do
           text <- decodeStringLiteralBytes m bytes
@@ -831,6 +835,8 @@ isBinaryObjectType t =
     _ :< TM.TyApp inner [] ->
       isBinaryObjectType inner
     _ :< TM.Data _ dd [] ->
+      DD.localLocator dd == BN.reify BN.binary
+    _ :< TM.Resource dd _ ->
       DD.localLocator dd == BN.reify BN.binary
     _ ->
       False
@@ -1023,7 +1029,7 @@ raiseNonStringType m bytes t = do
   raiseError m $
     "The term `"
       <> T.pack (show bytes)
-      <> "` is a string literal, but its type is neither text, &string, nor &binary: "
+      <> "` is a string literal, but its type is neither text, blob, &string, nor &binary: "
       <> toTextType t
 
 raiseLiteralNonExhaustivePatternMatching :: Hint -> App a

--- a/src/Kernel/Elaborate/Internal/Infer.hs
+++ b/src/Kernel/Elaborate/Internal/Infer.hs
@@ -362,6 +362,8 @@ infer h term =
           return (m :< WT.Prim (WPV.NoeticBinary t' bytes), m :< WT.BoxNoema t')
         WPV.Text text -> do
           return (m :< WT.Prim (WPV.Text text), m :< WT.PrimType PT.Text)
+        WPV.Blob bytes -> do
+          return (m :< WT.Prim (WPV.Blob bytes), m :< WT.PrimType PT.Blob)
         WPV.Rune _ -> do
           return (m :< WT.Prim prim, m :< WT.PrimType PT.Rune)
     m :< WT.Magic (M.WeakMagic magic) -> do

--- a/src/Kernel/Elaborate/Internal/Infer.hs
+++ b/src/Kernel/Elaborate/Internal/Infer.hs
@@ -351,9 +351,9 @@ infer h term =
         WPV.Op op -> do
           primOpType <- liftIO $ primOpToType h m op
           return (m :< WT.Prim prim, primOpType)
-        WPV.String t text -> do
+        WPV.String coreModuleID t text -> do
           t' <- inferType (h {varEnv = []}) t
-          return (m :< WT.Prim (WPV.String t' text), t')
+          return (m :< WT.Prim (WPV.String coreModuleID t' text), t')
         WPV.NoeticString t text -> do
           t' <- inferType (h {varEnv = []}) t
           return (m :< WT.Prim (WPV.NoeticString t' text), m :< WT.BoxNoema t')

--- a/src/Kernel/Elaborate/Internal/Infer.hs
+++ b/src/Kernel/Elaborate/Internal/Infer.hs
@@ -351,6 +351,9 @@ infer h term =
         WPV.Op op -> do
           primOpType <- liftIO $ primOpToType h m op
           return (m :< WT.Prim prim, primOpType)
+        WPV.String t text -> do
+          t' <- inferType (h {varEnv = []}) t
+          return (m :< WT.Prim (WPV.String t' text), t')
         WPV.NoeticString t text -> do
           t' <- inferType (h {varEnv = []}) t
           return (m :< WT.Prim (WPV.NoeticString t' text), m :< WT.BoxNoema t')

--- a/src/Kernel/Elaborate/Internal/Infer.hs
+++ b/src/Kernel/Elaborate/Internal/Infer.hs
@@ -357,6 +357,9 @@ infer h term =
         WPV.NoeticString t text -> do
           t' <- inferType (h {varEnv = []}) t
           return (m :< WT.Prim (WPV.NoeticString t' text), m :< WT.BoxNoema t')
+        WPV.NoeticBinary t bytes -> do
+          t' <- inferType (h {varEnv = []}) t
+          return (m :< WT.Prim (WPV.NoeticBinary t' bytes), m :< WT.BoxNoema t')
         WPV.Text text -> do
           return (m :< WT.Prim (WPV.Text text), m :< WT.PrimType PT.Text)
         WPV.Rune _ -> do

--- a/src/Kernel/Emit/PrimType.hs
+++ b/src/Kernel/Emit/PrimType.hs
@@ -20,5 +20,7 @@ emitPrimType lowType =
       emitPrimType $ PT.Int IntSize32
     PT.Text ->
       "ptr"
+    PT.Blob ->
+      "ptr"
     PT.Pointer ->
       "ptr"

--- a/src/Kernel/Lower/Lower.hs
+++ b/src/Kernel/Lower/Lower.hs
@@ -16,6 +16,7 @@ import App.App (App)
 import Codec.Binary.UTF8.String
 import Control.Monad
 import Control.Monad.Writer.Lazy
+import Data.ByteString qualified as BS
 import Data.ByteString.Builder
 import Data.HashMap.Strict qualified as Map
 import Data.IORef
@@ -669,6 +670,13 @@ lowerValue h resultVar v cont =
       let name = "text;" <> T.pack (show i)
       let encodedText = foldMap (\w -> "\\" <> word8HexFixed w) i8s
       liftIO $ insertStaticText h name encodedText len
+      uncast h resultVar (LC.VarTextName name) LT.Pointer cont
+    C.VarStaticBytes bytes -> do
+      let len = BS.length bytes
+      i <- liftIO $ Gensym.newCount (gensymHandle h)
+      let name = "bytes;" <> T.pack (show i)
+      let encodedBytes = foldMap (\w -> "\\" <> word8HexFixed w) (BS.unpack bytes)
+      liftIO $ insertStaticText h name encodedBytes len
       uncast h resultVar (LC.VarTextName name) LT.Pointer cont
     C.SigmaIntro size ds -> do
       let arrayType = AggTypeArray size LT.Pointer

--- a/src/Kernel/Lower/Lower.hs
+++ b/src/Kernel/Lower/Lower.hs
@@ -13,7 +13,6 @@ module Kernel.Lower.Lower
 where
 
 import App.App (App)
-import Codec.Binary.UTF8.String
 import Control.Monad
 import Control.Monad.Writer.Lazy
 import Data.ByteString qualified as BS
@@ -663,14 +662,6 @@ lowerValue h resultVar v cont =
       uncast h resultVar (LC.VarGlobal globalName) LT.Pointer cont
     C.VarLocal y ->
       return $ LC.Let resultVar (LC.nop $ LC.VarLocal y) cont
-    C.VarStaticText text -> do
-      let i8s = encode $ T.unpack text
-      let len = length i8s
-      i <- liftIO $ Gensym.newCount (gensymHandle h)
-      let name = "text;" <> T.pack (show i)
-      let encodedText = foldMap (\w -> "\\" <> word8HexFixed w) i8s
-      liftIO $ insertStaticText h name encodedText len
-      uncast h resultVar (LC.VarTextName name) LT.Pointer cont
     C.VarStaticBytes bytes -> do
       let len = BS.length bytes
       i <- liftIO $ Gensym.newCount (gensymHandle h)

--- a/src/Kernel/Parse/Internal/Discern.hs
+++ b/src/Kernel/Parse/Internal/Discern.hs
@@ -631,13 +631,16 @@ discern h term =
       discern h clause
     m :< RT.Static _ mKey staticItem -> do
       case staticItem of
-        RT.TextFileKey key -> do
+        RT.StaticFileKey key -> do
           contentOrNone <- liftIO $ Locator.getStaticFileContent (H.locatorHandle h) key
           case contentOrNone of
             Just (path, content) -> do
               liftIO $ Unused.deleteStaticFile (H.unusedHandle h) key
               liftIO $ Tag.insertStaticFile (H.tagHandle h) mKey key (newSourceHint path)
-              return $ m :< WT.Prim (WPV.Text content)
+              ensureStringLiteralTypes h m
+              coreModuleID <- Alias.resolveModuleAlias (H.aliasHandle h) m coreModuleAlias
+              hole <- liftIO $ WT.createTypeHole (H.gensymHandle h) m []
+              return $ m :< WT.Prim (WPV.String coreModuleID hole content)
             Nothing ->
               raiseError m $ "No such static file is defined: `" <> key <> "`"
     m :< RT.String str -> do

--- a/src/Kernel/Parse/Internal/Discern.hs
+++ b/src/Kernel/Parse/Internal/Discern.hs
@@ -641,12 +641,12 @@ discern h term =
             Nothing ->
               raiseError m $ "No such static file is defined: `" <> key <> "`"
     m :< RT.String str -> do
-      case parseText str of
+      case parseBytes str of
         Left reason ->
           raiseError m $ "Could not interpret the following as a string: " <> str <> "\nReason: " <> reason
-        Right str' -> do
+        Right bytes -> do
           hole <- liftIO $ WT.createTypeHole (H.gensymHandle h) m []
-          return $ m :< WT.Prim (WPV.String hole str')
+          return $ m :< WT.Prim (WPV.String hole bytes)
     m :< RT.NoeticString s str -> do
       s' <- discernType h s
       case parseText str of

--- a/src/Kernel/Parse/Internal/Discern.hs
+++ b/src/Kernel/Parse/Internal/Discern.hs
@@ -645,8 +645,10 @@ discern h term =
         Left reason ->
           raiseError m $ "Could not interpret the following as a string: " <> str <> "\nReason: " <> reason
         Right bytes -> do
+          ensureStringLiteralTypes h m
+          coreModuleID <- Alias.resolveModuleAlias (H.aliasHandle h) m coreModuleAlias
           hole <- liftIO $ WT.createTypeHole (H.gensymHandle h) m []
-          return $ m :< WT.Prim (WPV.String hole bytes)
+          return $ m :< WT.Prim (WPV.String coreModuleID hole bytes)
     m :< RT.With withClause -> do
       let (binder, body) = RT.extractFromKeywordClause withClause
       case body of
@@ -1434,6 +1436,13 @@ constructDefaultKeyMap :: H.Handle -> Hint -> [Key] -> IO (Map.HashMap Key (Hint
 constructDefaultKeyMap h m keyList = do
   names <- mapM (const $ Gensym.newTextForHole (H.gensymHandle h)) keyList
   return $ Map.fromList $ zipWith (\k v -> (k, (m, RP.Var VK.Normal (Var v)))) keyList names
+
+ensureStringLiteralTypes :: H.Handle -> Hint -> App ()
+ensureStringLiteralTypes h m = do
+  stringName <- liftEither $ locatorToName m coreString
+  binaryName <- liftEither $ locatorToName m coreBinary
+  void $ resolveName h (blur m) stringName
+  void $ resolveName h (blur m) binaryName
 
 locatorToName :: Hint -> T.Text -> Either E.Error Name
 locatorToName m text = do

--- a/src/Kernel/Parse/Internal/Discern.hs
+++ b/src/Kernel/Parse/Internal/Discern.hs
@@ -631,12 +631,6 @@ discern h term =
       discern h clause
     m :< RT.Static _ mKey staticItem -> do
       case staticItem of
-        RT.TextContent content -> do
-          case parseText content of
-            Left reason ->
-              raiseError m $ "Could not interpret the following as a text: " <> content <> "\nReason: " <> reason
-            Right str' -> do
-              return $ m :< WT.Prim (WPV.Text str')
         RT.TextFileKey key -> do
           contentOrNone <- liftIO $ Locator.getStaticFileContent (H.locatorHandle h) key
           case contentOrNone of
@@ -646,6 +640,13 @@ discern h term =
               return $ m :< WT.Prim (WPV.Text content)
             Nothing ->
               raiseError m $ "No such static file is defined: `" <> key <> "`"
+    m :< RT.String str -> do
+      case parseText str of
+        Left reason ->
+          raiseError m $ "Could not interpret the following as a string: " <> str <> "\nReason: " <> reason
+        Right str' -> do
+          hole <- liftIO $ WT.createTypeHole (H.gensymHandle h) m []
+          return $ m :< WT.Prim (WPV.String hole str')
     m :< RT.NoeticString s str -> do
       s' <- discernType h s
       case parseText str of

--- a/src/Kernel/Parse/Internal/Discern.hs
+++ b/src/Kernel/Parse/Internal/Discern.hs
@@ -618,11 +618,11 @@ discern h term =
       if isCompileStage h
         then do
           stringType <- discernType h stringTypeRaw
-          message' <- discern h $ m :< RT.NoeticString stringTypeRaw messageText
+          message' <- discern h $ m :< RT.String messageText
           let body = m :< WT.Magic (M.WeakMagic $ M.CompileError stringType message')
           return $ m :< WT.Annotation L.Warning (AN.Type (doNotCare m)) body
         else do
-          let message' = m :< RT.NoeticString stringTypeRaw (messageText <> "\n")
+          let message' = m :< RT.String (messageText <> "\n")
           panic <- liftEither $ locatorToVarGlobal m coreDebugPanic
           discern h $ asOpaqueValue $ m :< RT.Annotation L.Warning (AN.Type ()) (m :< RT.piElim panic [message'])
     m :< RT.Introspect _ key _ clauseList -> do
@@ -647,13 +647,6 @@ discern h term =
         Right bytes -> do
           hole <- liftIO $ WT.createTypeHole (H.gensymHandle h) m []
           return $ m :< WT.Prim (WPV.String hole bytes)
-    m :< RT.NoeticString s str -> do
-      s' <- discernType h s
-      case parseText str of
-        Left reason ->
-          raiseError m $ "Could not interpret the following as a string: " <> str <> "\nReason: " <> reason
-        Right str' -> do
-          return $ m :< WT.Prim (WPV.NoeticString s' str')
     m :< RT.With withClause -> do
       let (binder, body) = RT.extractFromKeywordClause withClause
       case body of

--- a/src/Kernel/Parse/Internal/Import.hs
+++ b/src/Kernel/Parse/Internal/Import.hs
@@ -85,21 +85,21 @@ interpretImport h m currentSource importList = do
           RawImportItem mItem (locatorText, _) localLocatorList -> do
             let localLocatorList' = SE.extract localLocatorList
             interpretImportItem h True mItem locatorText localLocatorList'
-          RawTextFileKey _ _ keys -> do
+          RawStaticFileKey _ _ keys -> do
             let keys' = SE.extract keys
-            interpretImportItemTextFile h (Source.sourceModule currentSource) keys'
+            interpretImportItemStaticFile h (Source.sourceModule currentSource) keys'
       return $ presetImportList ++ importItemList'
 
-interpretImportItemTextFile ::
+interpretImportItemStaticFile ::
   Handle ->
   Module ->
   [(Hint, T.Text)] ->
   App [ImportItem]
-interpretImportItemTextFile h currentModule keyList = do
+interpretImportItemStaticFile h currentModule keyList = do
   currentModule' <- STL.shiftToLatestModule (shiftToLatestHandle h) currentModule
   let moduleRootDir = getModuleRootDir currentModule'
   pathList <- forM keyList $ \(mKey, key) -> do
-    case Map.lookup key (moduleTextFiles currentModule') of
+    case Map.lookup key (moduleStaticFiles currentModule') of
       Just path -> do
         let fullPath = moduleRootDir </> path
         liftIO $ Tag.insertStaticFile (tagHandle h) mKey key (newSourceHint fullPath)
@@ -107,7 +107,7 @@ interpretImportItemTextFile h currentModule keyList = do
         return (key, (mKey, fullPath))
       Nothing ->
         raiseError mKey $ "No such static file is defined: " <> key
-  return [TextFileKey pathList]
+  return [StaticFileKey pathList]
 
 interpretImportItem ::
   Handle ->

--- a/src/Kernel/Parse/Internal/Program.hs
+++ b/src/Kernel/Parse/Internal/Program.hs
@@ -50,9 +50,9 @@ parseSingleImport = do
     mImportItem <- getCurrentHint
     locator <- symbol
     case fst locator of
-      "text-file" -> do
+      "static-file" -> do
         (ks, c) <- parseStaticKeyList
-        return (RawTextFileKey m c1 ks, c)
+        return (RawStaticFileKey m c1 ks, c)
       _ -> do
         (lls, c) <- parseLocalLocatorList'
         return (RawImportItem mImportItem locator lls, c)

--- a/src/Kernel/Parse/Internal/RawTerm.hs
+++ b/src/Kernel/Parse/Internal/RawTerm.hs
@@ -31,7 +31,6 @@ import CodeParser.GetInfo
 import CodeParser.Parser
 import Control.Comonad.Cofree
 import Control.Monad
-import Control.Monad.Except (liftEither)
 import Control.Monad.Trans
 import Data.Maybe (fromMaybe)
 import Data.Set qualified as S
@@ -1223,14 +1222,8 @@ rawTermIntrospectiveClause h = do
 rawTermStatic :: Hint -> C -> Parser (RT.RawTerm, C)
 rawTermStatic m c1 = do
   mKey <- getCurrentHint
-  choice
-    [ do
-        (s, c) <- string
-        return (m :< RT.Static c1 mKey (RT.TextContent s), c),
-      do
-        (key, c) <- symbol
-        return (m :< RT.Static c1 mKey (RT.TextFileKey key), c)
-    ]
+  (key, c) <- symbol
+  return (m :< RT.Static c1 mKey (RT.TextFileKey key), c)
 
 interpretVarName :: Hint -> T.Text -> Parser Name
 interpretVarName m varText = do
@@ -1255,8 +1248,7 @@ rawTermTextIntro :: Parser (RT.RawTerm, C)
 rawTermTextIntro = do
   m <- getCurrentHint
   (s, c) <- string
-  stringType <- lift $ locatorToTypeVar (blur m) coreString
-  return (m :< RT.NoeticString stringType s, c)
+  return (m :< RT.String s, c)
 
 rawTypeRune :: Hint -> C -> Parser (RT.RawType, C)
 rawTypeRune m c = do
@@ -1271,11 +1263,6 @@ rawTermRuneIntro = do
       return (m :< RT.RuneIntro r, c)
     Left e ->
       lift $ raiseError m e
-
-locatorToTypeVar :: Hint -> T.Text -> App RT.RawType
-locatorToTypeVar m text = do
-  (gl, ll) <- liftEither $ DD.getLocatorPair (blur m) text
-  return $ blur m :< RT.TyVar (Locator (gl, ll))
 
 var :: Handle -> Parser ((Hint, T.Text), C)
 var h = do

--- a/src/Kernel/Parse/Internal/RawTerm.hs
+++ b/src/Kernel/Parse/Internal/RawTerm.hs
@@ -1223,7 +1223,7 @@ rawTermStatic :: Hint -> C -> Parser (RT.RawTerm, C)
 rawTermStatic m c1 = do
   mKey <- getCurrentHint
   (key, c) <- symbol
-  return (m :< RT.Static c1 mKey (RT.TextFileKey key), c)
+  return (m :< RT.Static c1 mKey (RT.StaticFileKey key), c)
 
 interpretVarName :: Hint -> T.Text -> Parser Name
 interpretVarName m varText = do

--- a/src/Kernel/Parse/Interpret.hs
+++ b/src/Kernel/Parse/Interpret.hs
@@ -121,9 +121,9 @@ activateImport h m currentSource sourceInfoList = do
         liftIO $ NameMap.activateTopLevelNames (nameMapHandle h) namesInSource
         forM_ aliasInfoList $ \aliasInfo ->
           Alias.activateAliasInfo (aliasHandle h) currentSource namesInSource aliasInfo
-      TextFileKey pathList -> do
+      StaticFileKey pathList -> do
         forM_ pathList $ \(key, (mKey, path)) -> do
-          Locator.activateTextFile (locatorHandle h) mKey key path
+          Locator.activateStaticFile (locatorHandle h) mKey key path
 
 registerUnusedVariableRemarks :: Handle -> IO [L.Log]
 registerUnusedVariableRemarks h = do

--- a/src/Kernel/Unravel/Unravel.hs
+++ b/src/Kernel/Unravel/Unravel.hs
@@ -222,7 +222,7 @@ unravelImportItem h t importItem = do
   case importItem of
     ImportItem source _ ->
       unravel'' h t source
-    TextFileKey staticFileList -> do
+    StaticFileKey staticFileList -> do
       let pathList = map snd staticFileList
       itemModTime <- forM pathList $ \(m, p) -> do
         ensureFileExistence p m

--- a/src/Language/Common/PrimType.hs
+++ b/src/Language/Common/PrimType.hs
@@ -9,6 +9,7 @@ data PrimType
   | Float FloatSize
   | Rune
   | Text
+  | Blob
   | Pointer
   deriving (Show, G.Generic, Eq, Ord)
 

--- a/src/Language/Common/PrimType/FromText.hs
+++ b/src/Language/Common/PrimType/FromText.hs
@@ -23,6 +23,8 @@ fromText dataSize name
       Just $ PT.Float floatSize
   | name == textTypeName =
       Just PT.Text
+  | name == blobTypeName =
+      Just PT.Blob
   | otherwise =
       Nothing
 
@@ -66,3 +68,6 @@ asLowFloat dataSize s =
 
 textTypeName :: T.Text
 textTypeName = "text"
+
+blobTypeName :: T.Text
+blobTypeName = "blob"

--- a/src/Language/Common/PrimType/ToByteSize.hs
+++ b/src/Language/Common/PrimType/ToByteSize.hs
@@ -15,6 +15,8 @@ primTypeToByteSize dataSize primType =
       4
     PT.Text ->
       fromIntegral $ DS.reify dataSize `div` 8
+    PT.Blob ->
+      fromIntegral $ DS.reify dataSize `div` 8
     PT.Pointer ->
       fromIntegral $ DS.reify dataSize `div` 8
 

--- a/src/Language/Common/PrimType/ToText.hs
+++ b/src/Language/Common/PrimType/ToText.hs
@@ -15,5 +15,7 @@ toText primNum =
       "rune"
     PT.Text ->
       "text"
+    PT.Blob ->
+      "blob"
     PT.Pointer ->
       "pointer"

--- a/src/Language/Common/Text/Util.hs
+++ b/src/Language/Common/Text/Util.hs
@@ -1,5 +1,6 @@
 module Language.Common.Text.Util
-  ( parseBytes,
+  ( decodeUtf8Bytes,
+    parseBytes,
     parseText,
   )
 where
@@ -10,7 +11,8 @@ import Data.ByteString.Lazy qualified as LBS
 import Data.Char
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
-import Numeric (readHex)
+import Data.Word (Word8)
+import Numeric (readHex, showHex)
 
 isUpperHexDigit :: Char -> Bool
 isUpperHexDigit c =
@@ -102,11 +104,111 @@ parseBytes t = do
   builder <- parseBytes' mempty t
   return $ LBS.toStrict $ Builder.toLazyByteString builder
 
+isContinuationByte :: Word8 -> Bool
+isContinuationByte w =
+  0x80 <= w && w <= 0xBF
+
+formatByte :: Word8 -> T.Text
+formatByte w = do
+  let hex = T.pack $ map toUpper $ showHexByte w
+  "0x" <> T.replicate (2 - T.length hex) "0" <> hex
+
+showHexByte :: Word8 -> String
+showHexByte w =
+  case showHex (fromIntegral w :: Int) "" of
+    [] ->
+      "0"
+    hex ->
+      hex
+
+readContinuationByte :: Int -> [Word8] -> Either T.Text (Word8, [Word8])
+readContinuationByte offset ws = do
+  case ws of
+    [] ->
+      Left $ "Invalid UTF-8 byte sequence at byte offset " <> T.pack (show offset) <> ": unexpected end of string literal"
+    w : rest
+      | isContinuationByte w ->
+          return (w, rest)
+      | otherwise ->
+          Left $
+            "Invalid UTF-8 byte sequence at byte offset "
+              <> T.pack (show offset)
+              <> ": expected a continuation byte, but got "
+              <> formatByte w
+
+readBoundedContinuationByte :: Int -> Word8 -> Word8 -> [Word8] -> Either T.Text [Word8]
+readBoundedContinuationByte offset lower upper ws = do
+  (w, rest) <- readContinuationByte offset ws
+  if lower <= w && w <= upper
+    then return rest
+    else
+      Left $
+        "Invalid UTF-8 byte sequence at byte offset "
+          <> T.pack (show offset)
+          <> ": expected a byte in "
+          <> formatByte lower
+          <> ".."
+          <> formatByte upper
+          <> ", but got "
+          <> formatByte w
+
+consumeContinuationBytes :: Int -> Int -> [Word8] -> Either T.Text [Word8]
+consumeContinuationBytes offset count ws = do
+  if count <= 0
+    then return ws
+    else do
+      (_, rest) <- readContinuationByte offset ws
+      consumeContinuationBytes (offset + 1) (count - 1) rest
+
+validateUtf8Bytes' :: Int -> [Word8] -> Either T.Text ()
+validateUtf8Bytes' offset ws = do
+  case ws of
+    [] ->
+      return ()
+    w : rest
+      | w <= 0x7F ->
+          validateUtf8Bytes' (offset + 1) rest
+      | 0xC2 <= w && w <= 0xDF -> do
+          rest' <- consumeContinuationBytes (offset + 1) 1 rest
+          validateUtf8Bytes' (offset + 2) rest'
+      | w == 0xE0 -> do
+          rest' <- readBoundedContinuationByte (offset + 1) 0xA0 0xBF rest
+          rest'' <- consumeContinuationBytes (offset + 2) 1 rest'
+          validateUtf8Bytes' (offset + 3) rest''
+      | 0xE1 <= w && w <= 0xEC -> do
+          rest' <- consumeContinuationBytes (offset + 1) 2 rest
+          validateUtf8Bytes' (offset + 3) rest'
+      | w == 0xED -> do
+          rest' <- readBoundedContinuationByte (offset + 1) 0x80 0x9F rest
+          rest'' <- consumeContinuationBytes (offset + 2) 1 rest'
+          validateUtf8Bytes' (offset + 3) rest''
+      | 0xEE <= w && w <= 0xEF -> do
+          rest' <- consumeContinuationBytes (offset + 1) 2 rest
+          validateUtf8Bytes' (offset + 3) rest'
+      | w == 0xF0 -> do
+          rest' <- readBoundedContinuationByte (offset + 1) 0x90 0xBF rest
+          rest'' <- consumeContinuationBytes (offset + 2) 2 rest'
+          validateUtf8Bytes' (offset + 4) rest''
+      | 0xF1 <= w && w <= 0xF3 -> do
+          rest' <- consumeContinuationBytes (offset + 1) 3 rest
+          validateUtf8Bytes' (offset + 4) rest'
+      | w == 0xF4 -> do
+          rest' <- readBoundedContinuationByte (offset + 1) 0x80 0x8F rest
+          rest'' <- consumeContinuationBytes (offset + 2) 2 rest'
+          validateUtf8Bytes' (offset + 4) rest''
+      | otherwise ->
+          Left $
+            "Invalid UTF-8 byte sequence at byte offset "
+              <> T.pack (show offset)
+              <> ": invalid leading byte "
+              <> formatByte w
+
+decodeUtf8Bytes :: BS.ByteString -> Either T.Text T.Text
+decodeUtf8Bytes bytes = do
+  validateUtf8Bytes' 0 $ BS.unpack bytes
+  return $ TE.decodeUtf8 bytes
+
 parseText :: T.Text -> Either T.Text T.Text
 parseText t = do
   bytes <- parseBytes t
-  case TE.decodeUtf8' bytes of
-    Right text ->
-      return text
-    Left err ->
-      Left $ T.pack $ show err
+  decodeUtf8Bytes bytes

--- a/src/Language/Common/Text/Util.hs
+++ b/src/Language/Common/Text/Util.hs
@@ -1,8 +1,15 @@
-module Language.Common.Text.Util (parseText) where
+module Language.Common.Text.Util
+  ( parseBytes,
+    parseText,
+  )
+where
 
+import Data.ByteString qualified as BS
+import Data.ByteString.Builder qualified as Builder
+import Data.ByteString.Lazy qualified as LBS
 import Data.Char
-import Data.List qualified as List
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import Numeric (readHex)
 
 isUpperHexDigit :: Char -> Bool
@@ -31,46 +38,75 @@ readChar c t = do
     Nothing ->
       Left $ "Expected `" <> T.singleton c <> "`, but got: end of text"
 
-unquoteText :: T.Text -> Either T.Text [T.Text]
-unquoteText t = do
+readByteEscape :: T.Text -> Either T.Text (Integer, T.Text)
+readByteEscape t = do
+  rest <- readChar '{' t
+  let (byteText, rest') = T.span isUpperHexDigit rest
+  rest'' <- readChar '}' rest'
+  case readHex (T.unpack byteText) :: [(Integer, String)] of
+    [(value, _)]
+      | 0 <= value && value <= 0xFF ->
+          return (value, rest'')
+      | otherwise ->
+          Left $ "The value `" <> byteText <> "` is outside the byte range"
+    _ ->
+      Left $ "Could not parse `" <> byteText <> "` as a hexadecimal byte"
+
+readEscapeBytes :: T.Text -> Either T.Text (Builder.Builder, T.Text)
+readEscapeBytes t = do
   case T.uncons t of
     Nothing ->
-      Right ["\\"]
+      Right (Builder.word8 0x5C, "")
     Just (c, rest) -> do
       case c of
         '0' ->
-          Right ["\0", rest]
+          Right (Builder.word8 0x00, rest)
         't' ->
-          Right ["\t", rest]
+          Right (Builder.word8 0x09, rest)
         'n' ->
-          Right ["\n", rest]
+          Right (Builder.word8 0x0A, rest)
         'r' ->
-          Right ["\r", rest]
+          Right (Builder.word8 0x0D, rest)
         '`' ->
-          Right ["`", rest]
+          Right (Builder.word8 0x60, rest)
         '"' ->
-          Right ["\"", rest]
+          Right (Builder.word8 0x22, rest)
+        '\\' ->
+          Right (Builder.word8 0x5C, rest)
+        'x' -> do
+          (byte, rest') <- readByteEscape rest
+          Right (Builder.word8 $ fromIntegral byte, rest')
         'u' -> do
           rest' <- readChar '{' rest
           let (scalarValueText, rest'') = T.span isUpperHexDigit rest'
           rest''' <- readChar '}' rest''
           ch <- readUnicodeScalarValueMaybe scalarValueText
-          Right [T.singleton ch, rest''']
+          Right (Builder.byteString $ TE.encodeUtf8 $ T.singleton ch, rest''')
         _ ->
           Left $ "Unknown escape sequence: \\" <> T.singleton c
 
-parseTextFragment :: T.Text -> Either T.Text [T.Text]
-parseTextFragment t = do
-  case T.splitOn "\\" t of
-    [] ->
-      -- unreachable
-      Left "Got an empty list from `Data.Text.splitOn`"
-    t' : rest -> do
-      fragments <- concat <$> mapM unquoteText rest
-      Right $ t' : fragments
+parseBytes' :: Builder.Builder -> T.Text -> Either T.Text Builder.Builder
+parseBytes' builder t = do
+  case T.uncons t of
+    Nothing ->
+      return builder
+    Just ('\\', rest) -> do
+      (escaped, rest') <- readEscapeBytes rest
+      parseBytes' (builder <> escaped) rest'
+    Just (c, rest) -> do
+      let encoded = Builder.byteString $ TE.encodeUtf8 $ T.singleton c
+      parseBytes' (builder <> encoded) rest
+
+parseBytes :: T.Text -> Either T.Text BS.ByteString
+parseBytes t = do
+  builder <- parseBytes' mempty t
+  return $ LBS.toStrict $ Builder.toLazyByteString builder
 
 parseText :: T.Text -> Either T.Text T.Text
 parseText t = do
-  let ts = T.splitOn "\\\\" t
-  ts' <- mapM parseTextFragment ts
-  return $ T.concat $ List.intercalate ["\\"] ts'
+  bytes <- parseBytes t
+  case TE.decodeUtf8' bytes of
+    Right text ->
+      return text
+    Left err ->
+      Left $ T.pack $ show err

--- a/src/Language/Comp/Comp.hs
+++ b/src/Language/Comp/Comp.hs
@@ -23,10 +23,10 @@ module Language.Comp.Comp
 where
 
 import Data.HashMap.Strict qualified as Map
+import Data.ByteString qualified as BS
 import Data.IntMap qualified as IntMap
 import Data.List (intercalate)
 import Data.Maybe (mapMaybe)
-import Data.ByteString qualified as BS
 import Data.Text qualified as T
 import Language.Common.ArgNum
 import Language.Common.BaseLowType
@@ -47,7 +47,6 @@ import Prelude hiding (null)
 data Value
   = VarLocal Ident
   | VarGlobal DD.DefiniteDescription ArgNum (FCT.ForeignCodType BaseLowType)
-  | VarStaticText T.Text
   | VarStaticBytes BS.ByteString
   | SigmaIntro Int [Value]
   | Int IntSize Integer
@@ -61,8 +60,6 @@ instance Show Value where
         T.unpack $ toText' x
       VarGlobal dd _ _ ->
         T.unpack $ DD.reify dd
-      VarStaticText dd ->
-        T.unpack $ "\"" <> dd <> "\""
       VarStaticBytes bytes ->
         show $ BS.unpack bytes
       SigmaIntro size vs ->

--- a/src/Language/Comp/Comp.hs
+++ b/src/Language/Comp/Comp.hs
@@ -26,6 +26,7 @@ import Data.HashMap.Strict qualified as Map
 import Data.IntMap qualified as IntMap
 import Data.List (intercalate)
 import Data.Maybe (mapMaybe)
+import Data.ByteString qualified as BS
 import Data.Text qualified as T
 import Language.Common.ArgNum
 import Language.Common.BaseLowType
@@ -47,6 +48,7 @@ data Value
   = VarLocal Ident
   | VarGlobal DD.DefiniteDescription ArgNum (FCT.ForeignCodType BaseLowType)
   | VarStaticText T.Text
+  | VarStaticBytes BS.ByteString
   | SigmaIntro Int [Value]
   | Int IntSize Integer
   | Float FloatSize Double
@@ -61,6 +63,8 @@ instance Show Value where
         T.unpack $ DD.reify dd
       VarStaticText dd ->
         T.unpack $ "\"" <> dd <> "\""
+      VarStaticBytes bytes ->
+        show $ BS.unpack bytes
       SigmaIntro size vs ->
         "[" ++ show size ++ "](" ++ intercalate ", " (map show vs) ++ ")"
       Language.Comp.Comp.Int _ i ->

--- a/src/Language/Comp/Subst.hs
+++ b/src/Language/Comp/Subst.hs
@@ -98,6 +98,8 @@ substValue sub term =
       term
     C.VarStaticText {} ->
       term
+    C.VarStaticBytes {} ->
+      term
     C.SigmaIntro size vs -> do
       let vs' = map (substValue sub) vs
       C.SigmaIntro size vs'

--- a/src/Language/Comp/Subst.hs
+++ b/src/Language/Comp/Subst.hs
@@ -96,8 +96,6 @@ substValue sub term =
           term
     C.VarGlobal {} ->
       term
-    C.VarStaticText {} ->
-      term
     C.VarStaticBytes {} ->
       term
     C.SigmaIntro size vs -> do

--- a/src/Language/RawTerm/RawStmt.hs
+++ b/src/Language/RawTerm/RawStmt.hs
@@ -132,18 +132,18 @@ data PostRawStmt
 
 data RawImportItem
   = RawImportItem Hint (T.Text, C) (SE.Series (Hint, LL.LocalLocator))
-  | RawTextFileKey Hint C (SE.Series (Hint, T.Text))
+  | RawStaticFileKey Hint C (SE.Series (Hint, T.Text))
 
 compareImportItem :: RawImportItem -> RawImportItem -> Ordering
 compareImportItem item1 item2 = do
   case (item1, item2) of
     (RawImportItem _ locator1 _, RawImportItem _ locator2 _) ->
       compare locator1 locator2
-    (RawImportItem {}, RawTextFileKey {}) ->
+    (RawImportItem {}, RawStaticFileKey {}) ->
       LT
-    (RawTextFileKey {}, RawImportItem {}) ->
+    (RawStaticFileKey {}, RawImportItem {}) ->
       GT
-    (RawTextFileKey {}, RawTextFileKey {}) ->
+    (RawStaticFileKey {}, RawStaticFileKey {}) ->
       EQ
 
 data RawForeignItemF a

--- a/src/Language/RawTerm/RawStmt/ToDoc.hs
+++ b/src/Language/RawTerm/RawStmt/ToDoc.hs
@@ -80,7 +80,7 @@ filterImport importInfo = do
 filterUnused :: ImportInfo -> RawImportItem -> Either C RawImportItem
 filterUnused importInfo rawImportItem = do
   case rawImportItem of
-    RawTextFileKey {} ->
+    RawStaticFileKey {} ->
       return rawImportItem
     RawImportItem m (loc, c) lls -> do
       if isUsedGL (unusedGlobalLocators importInfo) loc
@@ -92,7 +92,7 @@ filterUnused importInfo rawImportItem = do
 filterPreset :: ImportInfo -> RawImportItem -> Either C RawImportItem
 filterPreset importInfo item = do
   case item of
-    RawTextFileKey {} ->
+    RawStaticFileKey {} ->
       return item
     RawImportItem m (loc, c) lls -> do
       case lookup loc (presetNames importInfo) of
@@ -127,8 +127,8 @@ mergeAdjacentImport importList = do
       [item]
     (c1, item1) : (c2, item2) : rest -> do
       case (item1, item2) of
-        (RawTextFileKey m1 c1' ks1, RawTextFileKey _ c2' ks2) -> do
-          let item = RawTextFileKey m1 (c1' ++ c2') (SE.appendLeftBiased ks1 ks2)
+        (RawStaticFileKey m1 c1' ks1, RawStaticFileKey _ c2' ks2) -> do
+          let item = RawStaticFileKey m1 (c1' ++ c2') (SE.appendLeftBiased ks1 ks2)
           mergeAdjacentImport $ (c1 ++ c2, item) : rest
         (RawImportItem m1 (locator1, c1') localLocatorList1, RawImportItem _ (locator2, c2') localLocatorList2)
           | locator1 == locator2 -> do
@@ -144,9 +144,9 @@ sortLocalLocators rawImportItem = do
     RawImportItem m locator localLocators -> do
       let cmp (_, x) (_, y) = compare x y
       RawImportItem m locator $ SE.sortSeriesBy cmp localLocators
-    RawTextFileKey m c ks -> do
+    RawStaticFileKey m c ks -> do
       let cmp (_, x) (_, y) = compare x y
-      RawTextFileKey m c $ SE.sortSeriesBy cmp ks
+      RawStaticFileKey m c $ SE.sortSeriesBy cmp ks
 
 nubLocalLocators :: RawImportItem -> RawImportItem
 nubLocalLocators rawImportItem = do
@@ -154,9 +154,9 @@ nubLocalLocators rawImportItem = do
     RawImportItem m locator localLocators -> do
       let eq (_, x) (_, y) = x == y
       RawImportItem m locator $ SE.nubSeriesBy eq localLocators
-    RawTextFileKey m c ks -> do
+    RawStaticFileKey m c ks -> do
       let eq (_, x) (_, y) = x == y
-      RawTextFileKey m c $ SE.nubSeriesBy eq ks
+      RawStaticFileKey m c $ SE.nubSeriesBy eq ks
 
 decImportItem :: RawImportItem -> (D.Doc, C)
 decImportItem rawImportItem = do
@@ -168,12 +168,12 @@ decImportItem rawImportItem = do
           let args' = SE.pushComment c args
           let args'' = SE.decode $ fmap decImportItemLocator args'
           (D.join [D.text item, D.text " ", args''], [])
-    RawTextFileKey _ c ks -> do
+    RawStaticFileKey _ c ks -> do
       if SE.isEmpty ks
         then (D.Nil, c)
         else do
           let ks' = D.text . snd <$> SE.pushComment c ks
-          (D.join [D.text "text-file", D.text " ", SE.decode ks'], [])
+          (D.join [D.text "static-file", D.text " ", SE.decode ks'], [])
 
 decImportItemLocator :: (a, LL.LocalLocator) -> D.Doc
 decImportItemLocator (_, l) =

--- a/src/Language/RawTerm/RawTerm.hs
+++ b/src/Language/RawTerm/RawTerm.hs
@@ -149,7 +149,7 @@ data RawTermF a
   | Int Integer
 
 data StaticItem
-  = TextFileKey T.Text
+  = StaticFileKey T.Text
 
 type PatParam a =
   (Hint, RP.RawPattern, C, C, a)

--- a/src/Language/RawTerm/RawTerm.hs
+++ b/src/Language/RawTerm/RawTerm.hs
@@ -143,6 +143,7 @@ data RawTermF a
   | Admit
   | Introspect C T.Text C (SE.Series (Maybe T.Text, C, a))
   | Static C Hint StaticItem
+  | String T.Text
   | NoeticString RawType T.Text
   | With (KeywordClause a)
   | Brace C (a, C)
@@ -150,7 +151,6 @@ data RawTermF a
 
 data StaticItem
   = TextFileKey T.Text
-  | TextContent T.Text
 
 type PatParam a =
   (Hint, RP.RawPattern, C, C, a)

--- a/src/Language/RawTerm/RawTerm.hs
+++ b/src/Language/RawTerm/RawTerm.hs
@@ -144,7 +144,6 @@ data RawTermF a
   | Introspect C T.Text C (SE.Series (Maybe T.Text, C, a))
   | Static C Hint StaticItem
   | String T.Text
-  | NoeticString RawType T.Text
   | With (KeywordClause a)
   | Brace C (a, C)
   | Int Integer

--- a/src/Language/RawTerm/RawTerm/ToDoc.hs
+++ b/src/Language/RawTerm/RawTerm/ToDoc.hs
@@ -247,6 +247,8 @@ toDoc term =
           D.line,
           attachComment c5 $ toDoc e2
         ]
+    _ :< String txt -> do
+      D.text $ "\"" <> txt <> "\""
     _ :< NoeticString _ txt -> do
       D.text $ "\"" <> txt <> "\""
     _ :< RuneIntro r -> do
@@ -470,8 +472,6 @@ toDoc term =
             case staticItem of
               RT.TextFileKey path ->
                 D.text path
-              RT.TextContent content ->
-                D.text $ "\"" <> content <> "\""
         ]
     _ :< Brace c1 (e, c2) -> do
       decodeBrace False c1 e c2

--- a/src/Language/RawTerm/RawTerm/ToDoc.hs
+++ b/src/Language/RawTerm/RawTerm/ToDoc.hs
@@ -468,7 +468,7 @@ toDoc term =
         [ PI.horizontal $ attachComment c1 $ D.text "static",
           PI.inject $
             case staticItem of
-              RT.TextFileKey path ->
+              RT.StaticFileKey path ->
                 D.text path
         ]
     _ :< Brace c1 (e, c2) -> do

--- a/src/Language/RawTerm/RawTerm/ToDoc.hs
+++ b/src/Language/RawTerm/RawTerm/ToDoc.hs
@@ -249,8 +249,6 @@ toDoc term =
         ]
     _ :< String txt -> do
       D.text $ "\"" <> txt <> "\""
-    _ :< NoeticString _ txt -> do
-      D.text $ "\"" <> txt <> "\""
     _ :< RuneIntro r -> do
       D.text $ "`" <> T.replace "`" "\\`" (RU.asText r) <> "`"
     _ :< Magic c magic -> do

--- a/src/Language/Term/FreeVars.hs
+++ b/src/Language/Term/FreeVars.hs
@@ -67,6 +67,8 @@ freeVars term =
           freeVarsType t
         PV.Text _ ->
           mempty
+        PV.Blob _ ->
+          mempty
         PV.Int t _ _ ->
           freeVarsType t
         PV.Float t _ _ ->

--- a/src/Language/Term/FreeVars.hs
+++ b/src/Language/Term/FreeVars.hs
@@ -63,6 +63,8 @@ freeVars term =
       case prim of
         PV.NoeticString t _ ->
           freeVarsType t
+        PV.NoeticBinary t _ ->
+          freeVarsType t
         PV.Text _ ->
           mempty
         PV.Int t _ _ ->

--- a/src/Language/Term/FreeVarsWithHints.hs
+++ b/src/Language/Term/FreeVarsWithHints.hs
@@ -68,6 +68,8 @@ freeVarsWithHints term =
           freeVarsWithHintsType t
         PV.Text _ ->
           mempty
+        PV.Blob _ ->
+          mempty
         PV.Int t _ _ ->
           freeVarsWithHintsType t
         PV.Float t _ _ ->

--- a/src/Language/Term/FreeVarsWithHints.hs
+++ b/src/Language/Term/FreeVarsWithHints.hs
@@ -64,6 +64,8 @@ freeVarsWithHints term =
       case prim of
         PV.NoeticString t _ ->
           freeVarsWithHintsType t
+        PV.NoeticBinary t _ ->
+          freeVarsWithHintsType t
         PV.Text _ ->
           mempty
         PV.Int t _ _ ->

--- a/src/Language/Term/Inline.hs
+++ b/src/Language/Term/Inline.hs
@@ -309,6 +309,9 @@ inline' h term = do
         PV.NoeticString stringType text -> do
           stringType' <- inlineType' h stringType
           return $ m :< TM.Prim (PV.NoeticString stringType' text)
+        PV.NoeticBinary binaryType bytes -> do
+          binaryType' <- inlineType' h binaryType
+          return $ m :< TM.Prim (PV.NoeticBinary binaryType' bytes)
         PV.Text text ->
           return $ m :< TM.Prim (PV.Text text)
         PV.Rune {} ->

--- a/src/Language/Term/Inline.hs
+++ b/src/Language/Term/Inline.hs
@@ -314,6 +314,8 @@ inline' h term = do
           return $ m :< TM.Prim (PV.NoeticBinary binaryType' bytes)
         PV.Text text ->
           return $ m :< TM.Prim (PV.Text text)
+        PV.Blob bytes ->
+          return $ m :< TM.Prim (PV.Blob bytes)
         PV.Rune {} ->
           return term
     m :< TM.Magic magic -> do

--- a/src/Language/Term/Inline/Magic.hs
+++ b/src/Language/Term/Inline/Magic.hs
@@ -87,6 +87,10 @@ evaluateInspectType h m moduleID typeExpr = do
       returnTypeValueIntValue m moduleID (TypeValue.fromIntSize size)
     _ :< TM.PrimType (PT.Float size) ->
       returnTypeValueIntValue m moduleID (TypeValue.fromFloatSize size)
+    _ :< TM.PrimType PT.Text ->
+      returnTypeValueIntValue m moduleID TypeValue.Opaque
+    _ :< TM.PrimType PT.Blob ->
+      returnTypeValueIntValue m moduleID TypeValue.Opaque
     _ :< TM.PrimType PT.Pointer ->
       returnTypeValueIntValue m moduleID TypeValue.Pointer
     _ :< TM.PrimType PT.Rune ->

--- a/src/Language/Term/PrimValue.hs
+++ b/src/Language/Term/PrimValue.hs
@@ -18,6 +18,7 @@ data PrimValue a
   | NoeticString a T.Text
   | NoeticBinary a BS.ByteString
   | Text T.Text
+  | Blob BS.ByteString
   | Rune RU.Rune
   deriving (Show, Generic)
 

--- a/src/Language/Term/PrimValue.hs
+++ b/src/Language/Term/PrimValue.hs
@@ -4,6 +4,7 @@ module Language.Term.PrimValue
 where
 
 import Data.Binary
+import Data.ByteString qualified as BS
 import Data.Text qualified as T
 import GHC.Generics (Generic)
 import Language.Common.PrimNumSize
@@ -15,6 +16,7 @@ data PrimValue a
   | Float a FloatSize Double
   | Op PrimOp
   | NoeticString a T.Text
+  | NoeticBinary a BS.ByteString
   | Text T.Text
   | Rune RU.Rune
   deriving (Show, Generic)

--- a/src/Language/Term/Weaken.hs
+++ b/src/Language/Term/Weaken.hs
@@ -222,6 +222,8 @@ weakenPrimValue prim =
       WPV.NoeticBinary (weakenType t) bytes
     PV.Text text ->
       WPV.Text text
+    PV.Blob bytes ->
+      WPV.Blob bytes
     PV.Rune r ->
       WPV.Rune r
 

--- a/src/Language/Term/Weaken.hs
+++ b/src/Language/Term/Weaken.hs
@@ -218,6 +218,8 @@ weakenPrimValue prim =
       WPV.Op op
     PV.NoeticString t text ->
       WPV.NoeticString (weakenType t) text
+    PV.NoeticBinary t bytes ->
+      WPV.NoeticBinary (weakenType t) bytes
     PV.Text text ->
       WPV.Text text
     PV.Rune r ->

--- a/src/Language/WeakTerm/ToText.hs
+++ b/src/Language/WeakTerm/ToText.hs
@@ -350,7 +350,7 @@ showPrimValue primValue =
           T.pack (show name)
         PO.PrimConvOp name _ _ ->
           T.pack (show name)
-    WPV.String _ bytes ->
+    WPV.String _ _ bytes ->
       T.pack $ show $ BS.unpack bytes
     WPV.NoeticString _ text ->
       T.pack $ show text

--- a/src/Language/WeakTerm/ToText.hs
+++ b/src/Language/WeakTerm/ToText.hs
@@ -7,6 +7,7 @@ module Language.WeakTerm.ToText
 where
 
 import Control.Comonad.Cofree
+import Data.ByteString qualified as BS
 import Data.Maybe (fromMaybe)
 import Data.Text qualified as T
 import Kernel.Common.Module (Module)
@@ -349,10 +350,12 @@ showPrimValue primValue =
           T.pack (show name)
         PO.PrimConvOp name _ _ ->
           T.pack (show name)
-    WPV.String _ text ->
-      T.pack $ show text
+    WPV.String _ bytes ->
+      T.pack $ show $ BS.unpack bytes
     WPV.NoeticString _ text ->
       T.pack $ show text
+    WPV.NoeticBinary _ bytes ->
+      T.pack $ show $ BS.unpack bytes
     WPV.Text text ->
       T.pack $ show text
     WPV.Rune r ->

--- a/src/Language/WeakTerm/ToText.hs
+++ b/src/Language/WeakTerm/ToText.hs
@@ -358,6 +358,8 @@ showPrimValue primValue =
       T.pack $ show $ BS.unpack bytes
     WPV.Text text ->
       T.pack $ show text
+    WPV.Blob bytes ->
+      T.pack $ show $ BS.unpack bytes
     WPV.Rune r ->
       "`" <> T.replace "`" "\\`" (RU.asText r) <> "`"
 

--- a/src/Language/WeakTerm/ToText.hs
+++ b/src/Language/WeakTerm/ToText.hs
@@ -349,6 +349,8 @@ showPrimValue primValue =
           T.pack (show name)
         PO.PrimConvOp name _ _ ->
           T.pack (show name)
+    WPV.String _ text ->
+      T.pack $ show text
     WPV.NoeticString _ text ->
       T.pack $ show text
     WPV.Text text ->

--- a/src/Language/WeakTerm/WeakPrimValue.hs
+++ b/src/Language/WeakTerm/WeakPrimValue.hs
@@ -27,6 +27,7 @@ data WeakPrimValue a
   | NoeticString a T.Text
   | NoeticBinary a BS.ByteString
   | Text T.Text
+  | Blob BS.ByteString
   | Rune RU.Rune
   deriving (Show, Generic)
 
@@ -49,6 +50,8 @@ instance Functor WeakPrimValue where
         NoeticBinary (f t) bytes
       Text text ->
         Text text
+      Blob bytes ->
+        Blob bytes
       Rune r ->
         Rune r
 
@@ -68,6 +71,8 @@ instance Foldable WeakPrimValue where
       NoeticBinary t _ ->
         f t
       Text _ ->
+        mempty
+      Blob _ ->
         mempty
       Rune _ ->
         mempty
@@ -89,6 +94,8 @@ instance Traversable WeakPrimValue where
         NoeticBinary <$> f t <*> pure bytes
       Text text ->
         pure $ Text text
+      Blob bytes ->
+        pure $ Blob bytes
       Rune r ->
         pure $ Rune r
 

--- a/src/Language/WeakTerm/WeakPrimValue.hs
+++ b/src/Language/WeakTerm/WeakPrimValue.hs
@@ -22,6 +22,7 @@ data WeakPrimValue a
   = Int a Integer
   | Float a Double
   | Op PrimOp
+  | String a T.Text
   | NoeticString a T.Text
   | Text T.Text
   | Rune RU.Rune
@@ -38,6 +39,8 @@ instance Functor WeakPrimValue where
         Float (f t) v
       Op op ->
         Op op
+      String t text ->
+        String (f t) text
       NoeticString t text ->
         NoeticString (f t) text
       Text text ->
@@ -54,6 +57,8 @@ instance Foldable WeakPrimValue where
         f t
       Op _ ->
         mempty
+      String t _ ->
+        f t
       NoeticString t _ ->
         f t
       Text _ ->
@@ -70,6 +75,8 @@ instance Traversable WeakPrimValue where
         Float <$> f t <*> pure v
       Op op ->
         pure $ Op op
+      String t text ->
+        String <$> f t <*> pure text
       NoeticString t text ->
         NoeticString <$> f t <*> pure text
       Text text ->

--- a/src/Language/WeakTerm/WeakPrimValue.hs
+++ b/src/Language/WeakTerm/WeakPrimValue.hs
@@ -12,6 +12,7 @@ import Data.Binary
 import Data.ByteString qualified as BS
 import Data.Text qualified as T
 import GHC.Generics (Generic)
+import Language.Common.ModuleID qualified as MID
 import Language.Common.PrimOp
 import Language.Common.PrimOp.BinaryOp
 import Language.Common.PrimOp.CmpOp
@@ -23,7 +24,7 @@ data WeakPrimValue a
   = Int a Integer
   | Float a Double
   | Op PrimOp
-  | String a BS.ByteString
+  | String MID.ModuleID a BS.ByteString
   | NoeticString a T.Text
   | NoeticBinary a BS.ByteString
   | Text T.Text
@@ -42,8 +43,8 @@ instance Functor WeakPrimValue where
         Float (f t) v
       Op op ->
         Op op
-      String t text ->
-        String (f t) text
+      String coreModuleID t bytes ->
+        String coreModuleID (f t) bytes
       NoeticString t text ->
         NoeticString (f t) text
       NoeticBinary t bytes ->
@@ -64,7 +65,7 @@ instance Foldable WeakPrimValue where
         f t
       Op _ ->
         mempty
-      String t _ ->
+      String _ t _ ->
         f t
       NoeticString t _ ->
         f t
@@ -86,8 +87,8 @@ instance Traversable WeakPrimValue where
         Float <$> f t <*> pure v
       Op op ->
         pure $ Op op
-      String t text ->
-        String <$> f t <*> pure text
+      String coreModuleID t bytes ->
+        String coreModuleID <$> f t <*> pure bytes
       NoeticString t text ->
         NoeticString <$> f t <*> pure text
       NoeticBinary t bytes ->

--- a/src/Language/WeakTerm/WeakPrimValue.hs
+++ b/src/Language/WeakTerm/WeakPrimValue.hs
@@ -9,6 +9,7 @@ module Language.WeakTerm.WeakPrimValue
 where
 
 import Data.Binary
+import Data.ByteString qualified as BS
 import Data.Text qualified as T
 import GHC.Generics (Generic)
 import Language.Common.PrimOp
@@ -22,8 +23,9 @@ data WeakPrimValue a
   = Int a Integer
   | Float a Double
   | Op PrimOp
-  | String a T.Text
+  | String a BS.ByteString
   | NoeticString a T.Text
+  | NoeticBinary a BS.ByteString
   | Text T.Text
   | Rune RU.Rune
   deriving (Show, Generic)
@@ -43,6 +45,8 @@ instance Functor WeakPrimValue where
         String (f t) text
       NoeticString t text ->
         NoeticString (f t) text
+      NoeticBinary t bytes ->
+        NoeticBinary (f t) bytes
       Text text ->
         Text text
       Rune r ->
@@ -60,6 +64,8 @@ instance Foldable WeakPrimValue where
       String t _ ->
         f t
       NoeticString t _ ->
+        f t
+      NoeticBinary t _ ->
         f t
       Text _ ->
         mempty
@@ -79,6 +85,8 @@ instance Traversable WeakPrimValue where
         String <$> f t <*> pure text
       NoeticString t text ->
         NoeticString <$> f t <*> pure text
+      NoeticBinary t bytes ->
+        NoeticBinary <$> f t <*> pure bytes
       Text text ->
         pure $ Text text
       Rune r ->

--- a/test/misc/adder/module.ens
+++ b/test/misc/adder/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/args/module.ens
+++ b/test/misc/args/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/calc/module.ens
+++ b/test/misc/calc/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/check/module.ens
+++ b/test/misc/check/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/codata-basic/module.ens
+++ b/test/misc/codata-basic/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/complex-cancel/module.ens
+++ b/test/misc/complex-cancel/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/destpass/module.ens
+++ b/test/misc/destpass/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/ex-falso/module.ens
+++ b/test/misc/ex-falso/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/fact/module.ens
+++ b/test/misc/fact/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/file/module.ens
+++ b/test/misc/file/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/fix-and-free-vars/module.ens
+++ b/test/misc/fix-and-free-vars/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/fold-tails/module.ens
+++ b/test/misc/fold-tails/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/foreign/module.ens
+++ b/test/misc/foreign/module.ens
@@ -20,9 +20,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/hello/module.ens
+++ b/test/misc/hello/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/lambda-list-noetic/module.ens
+++ b/test/misc/lambda-list-noetic/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/lambda-list/module.ens
+++ b/test/misc/lambda-list/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/loop-and-resource/module.ens
+++ b/test/misc/loop-and-resource/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/mim/module.ens
+++ b/test/misc/mim/module.ens
@@ -11,9 +11,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/multi-targets/module.ens
+++ b/test/misc/multi-targets/module.ens
@@ -12,9 +12,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/mutable/module.ens
+++ b/test/misc/mutable/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/nat-fact/module.ens
+++ b/test/misc/nat-fact/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/nat-list/module.ens
+++ b/test/misc/nat-list/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/nested-enums/module.ens
+++ b/test/misc/nested-enums/module.ens
@@ -6,9 +6,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/num-literals/module.ens
+++ b/test/misc/num-literals/module.ens
@@ -6,9 +6,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/print-float/module.ens
+++ b/test/misc/print-float/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/static-file/module.ens
+++ b/test/misc/static-file/module.ens
@@ -7,14 +7,14 @@
       ],
     },
   },
-  text-file {
+  static-file {
     some-file "expected",
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/misc/static-file/source/static-file.nt
+++ b/test/misc/static-file/source/static-file.nt
@@ -1,6 +1,7 @@
 import {
+  core.binary,
   core.string {from-text},
-  text-file {some-file},
+  static-file {some-file},
 }
 
 define main() -> unit {

--- a/test/misc/unpack-adt/module.ens
+++ b/test/misc/unpack-adt/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/binary-search-tree/module.ens
+++ b/test/pfds/binary-search-tree/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/binomial-heap/module.ens
+++ b/test/pfds/binomial-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/custom-stack/module.ens
+++ b/test/pfds/custom-stack/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/finite-map/module.ens
+++ b/test/pfds/finite-map/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/leftist-heap/module.ens
+++ b/test/pfds/leftist-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/naive-queue/module.ens
+++ b/test/pfds/naive-queue/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/pairing-heap/module.ens
+++ b/test/pfds/pairing-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/random-access-list/module.ens
+++ b/test/pfds/random-access-list/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/red-black-tree/module.ens
+++ b/test/pfds/red-black-tree/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/splay-heap/module.ens
+++ b/test/pfds/splay-heap/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/pfds/stack/module.ens
+++ b/test/pfds/stack/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
     },
   },

--- a/test/pfds/stream/module.ens
+++ b/test/pfds/stream/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
     },
   },

--- a/test/statement/default-args/module.ens
+++ b/test/statement/default-args/module.ens
@@ -6,9 +6,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/define/module.ens
+++ b/test/statement/define/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/define/source/define.nt
+++ b/test/statement/define/source/define.nt
@@ -60,8 +60,8 @@ define implicit-2<a, b>(x: a, y: b) -> pair(a, b) {
 
 define main() -> unit {
   let _ = is-even(12345);
-  let _ = implicit-1("hello");
-  let _ = implicit-2("hello", pack-type {type});
+  let _: &binary = implicit-1("hello");
+  let _: pair(blob, type) = implicit-2("hello", pack-type {type});
   let local-func-with-imp-args =
     <a>(x: a) => {
       x

--- a/test/statement/import-names/module.ens
+++ b/test/statement/import-names/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/resource-basic/module.ens
+++ b/test/statement/resource-basic/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/statement/variant-struct/module.ens
+++ b/test/statement/variant-struct/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/box/module.ens
+++ b/test/term/box/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/flow/module.ens
+++ b/test/term/flow/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/noema/module.ens
+++ b/test/term/noema/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/noema/source/noema.nt
+++ b/test/term/noema/source/noema.nt
@@ -149,7 +149,7 @@ define unbalanced-freevars-in-branches<a>(t: &term(a)) -> term(a) {
     }
   | App(t1, _) =>
     let _ = g;
-    let !k =
+    let !k: () -> term(&string) =
       if False {
         h
       } else {

--- a/test/term/pi/module.ens
+++ b/test/term/pi/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/prim/module.ens
+++ b/test/term/prim/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/prim/source/prim.nt
+++ b/test/term/prim/source/prim.nt
@@ -11,6 +11,8 @@ define test-syntax() -> unit {
   let _ = pack-type {float32};
   let _ = pack-type {float64};
   let _ = pack-type {float};
+  let _ = pack-type {text};
+  let _ = pack-type {blob};
   let _: int = 3;
   let _: int = 0b1100;
   let _: int = 0b_1100_0010_0000;
@@ -87,9 +89,13 @@ define opaque<a>(x: a) -> a {
 }
 
 define test-string() -> unit {
-  let _ = opaque("");
-  let _ = opaque("test");
-  let _ = opaque("🌟あ♥️a🌕亜\n\u{33}\u{333}\u{1F338}\0\t\n\r\"\\\`");
+  let _: text = opaque("");
+  let _: text = opaque("test");
+  let _: text = opaque("🌟あ♥️a🌕亜\n\u{33}\u{333}\u{1F338}\0\t\n\r\"\\\`");
+  let _: text = "utf-8";
+  let _: blob = "\x{FF}\0A";
+  let _: &string = "borrowed string";
+  let _: &binary = "\x{FF}\0A";
   Unit
 }
 

--- a/test/term/rune/module.ens
+++ b/test/term/rune/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/tau/module.ens
+++ b/test/term/tau/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/unary/module.ens
+++ b/test/term/unary/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/var/module.ens
+++ b/test/term/var/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/variant/module.ens
+++ b/test/term/variant/module.ens
@@ -9,9 +9,9 @@
   },
   dependency {
     core {
-      digest "GKmi5E12FLZUuCxhHX2f65YsMYnGwrS6U6maZlhUhh4",
+      digest "yuUKFiEFXHOJIgCT8mLjczed0yHk6X6ZsGRhaOTJ8aU",
       mirror [
-        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-3.tar.zst",
+        "https://github.com/vekatze/neut-core/raw/main/archive/0-55-8.tar.zst",
       ],
       enable-preset true,
     },

--- a/test/term/variant/source/variant.nt
+++ b/test/term/variant/source/variant.nt
@@ -200,7 +200,7 @@ define unbalanced-freevars-in-branches<a>(!t: term(a)) -> term(a) {
     }
   | App(t1, _) =>
     let _ = g;
-    let !k =
+    let !k: () -> term(&string) =
       if False {
         h
       } else {
@@ -310,9 +310,9 @@ define test-resource() -> unit {
 }
 
 define test-match() -> unit {
-  let !t1 = Var("text");
-  let !t2 = Abs("foo", Var("foo"));
-  let !t3 = App(Abs("foo", Var("foo")), Var("buz"));
+  let !t1: term(&string) = Var("text");
+  let !t2: term(&string) = Abs("foo", Var("foo"));
+  let !t3: term(&string) = App(Abs("foo", Var("foo")), Var("buz"));
   let _ = local-completeness(t1);
   let _ = local-completeness(t2);
   let _ = local-completeness(t3);


### PR DESCRIPTION
The string literal `"foo"` can now have type `text`, `blob`, `&string`, or `&binary`.