### PR TITLE
resolve `actual`/`integer` constraints after inlining

### DIFF
--- a/book/src/modal-metaprogramming.md
+++ b/book/src/modal-metaprogramming.md
@@ -184,6 +184,26 @@ This is the same as:
 unquote {foo(quote {bar}, quote {baz})[width := quote {80}]}
 ```
 
+### Delayed Checks in Specialized Code
+
+The requirement of `lift` is checked against the specialized generated code, not the generic meta function body. This allows the following pattern:
+
+```neut
+define-meta lift-value<a>(x: 'a) -> '+a {
+  quote {
+    let y = unquote {x};
+    lift {y} // `lift`ing `y: a`
+  }
+}
+
+define use-meta() -> +unit {
+  lift-value::(Unit)
+}
+
+```
+
+`lift-value` typechecks even though it uses `lift` on `y: a`, since it is a meta function. Later, `use-meta` specializes it with `a := unit`, and `unit` is liftable, so `use-meta` is well-typed. Conversely, specializing with `a := &string` would be a type error, since `&string` is not liftable.
+
 ## Compile-Time Primitives
 
 Neut provides some compile-time primitives that can only be used at stage 1 or above, including:

--- a/book/src/statements.md
+++ b/book/src/statements.md
@@ -210,6 +210,24 @@ define-meta bad<a>(x: int) -> 'int {
 }
 ```
 
+The requirement of `lift` is checked against the specialized generated code, not the generic meta function body. This allows the following pattern:
+
+```neut
+define-meta lift-value<a>(x: 'a) -> '+a {
+  quote {
+    let y = unquote {x};
+    lift {y} // `lift`ing `y: a`
+  }
+}
+
+define use-meta() -> +unit {
+  lift-value::(Unit)
+}
+
+```
+
+`lift-value` typechecks even though it uses `lift` on `y: a`, since it is a meta function. Later, `use-meta` specializes it with `a := unit`, and `unit` is liftable, so `use-meta` is well-typed. Conversely, specializing with `a := &string` would be a type error, since `&string` is not liftable.
+
 ## `inline-meta`
 
 `inline-meta` defines an inline meta function. It should look like the following:

--- a/book/theme/book.js
+++ b/book/theme/book.js
@@ -42,6 +42,7 @@ hljs.registerLanguage("neut", function (hljs) {
         "let",
         "letbox",
         "letbox-T",
+        "lift",
         "match",
         "nominal",
         "of",

--- a/src/Kernel/Clarify/Clarify.hs
+++ b/src/Kernel/Clarify/Clarify.hs
@@ -587,6 +587,8 @@ clarifyTerm h context term =
       return $ Utility.irreducibleBindLet (zip xs es') tree'
     _ :< TM.BoxIntro letSeq e -> do
       embody h context letSeq e
+    _ :< TM.BoxIntroLift _ e -> do
+      clarifyTerm h context e
     _ :< TM.BoxElim castSeq mxt e1 uncastSeq e2 -> do
       clarifyTerm h context $
         TM.fromLetSeqOpaque castSeq $
@@ -599,6 +601,8 @@ clarifyTerm h context term =
       clarifyType h context ty
     m :< TM.TauElim (mx, x) e1 e2 -> do
       clarifyTerm h context $ m :< TM.Let O.Clear (mx, VK.Normal, x, mx :< TM.Tau) e1 e2
+    _ :< TM.Actual _ e -> do
+      clarifyTerm h context e
     _ :< TM.Let opacity mxt@(_, _, x, _) e1 e2 -> do
       e2' <- clarifyTerm h (extendContext [mxt] context) e2
       mxts' <- dropFst <$> clarifyBinder h context [mxt]

--- a/src/Kernel/Elaborate/Constraint.hs
+++ b/src/Kernel/Elaborate/Constraint.hs
@@ -17,8 +17,6 @@ import Language.WeakTerm.WeakTerm qualified as WT
 
 data Constraint
   = Eq WT.WeakType WT.WeakType -- (expected-type, actual-type)
-  | Actual WT.WeakType
-  | Integer WT.WeakType
 
 type MetaVarSet =
   S.Set HID.HoleID
@@ -31,10 +29,6 @@ showConstraint constraint =
   case constraint of
     Eq expected actual ->
       ToText.toTextType expected <> " == " <> ToText.toTextType actual
-    Actual t ->
-      "actual " <> ToText.toTextType t
-    Integer t ->
-      "integer " <> ToText.toTextType t
 
 showConstraints :: [Constraint] -> T.Text
 showConstraints constraints =

--- a/src/Kernel/Elaborate/Elaborate.hs
+++ b/src/Kernel/Elaborate/Elaborate.hs
@@ -97,6 +97,7 @@ import Language.WeakTerm.WeakStmt
 import Language.WeakTerm.WeakTerm qualified as WT
 import Logger.Hint
 import Logger.Log qualified as L
+import Logger.LogLevel qualified as LL
 
 getWeakTypeEnv :: Handle -> IO WeakType.WeakTypeEnv
 getWeakTypeEnv h =
@@ -134,6 +135,10 @@ synthesizeStmtList h t logs globalReferenceList stmtList = do
     throwError $ E.MakeError affineErrorList
   generatedStmtList <- liftIO $ reverse <$> readIORef (pendingSpecializationDefs h)
   let stmtList'' = stmtList' ++ generatedStmtList
+  residualCheckList' <- liftIO $ reverse <$> readIORef (residualCheckList h)
+  residualErrorList <- concat <$> mapM (checkResidualCheck h) residualCheckList'
+  unless (null residualErrorList) $ do
+    throwError $ E.MakeError residualErrorList
   -- mapM_ (liftIO . viewStmt . weakenStmt) stmtList'
   countSnapshot <- liftIO $ Gensym.getCount (gensymHandle h)
   localLogs <- liftIO $ LocalLogs.get (localLogsHandle h)
@@ -162,11 +167,11 @@ elaborateStmt h stmt = do
       codType' <- elaborateType h codType
       let mDefKind = stmtKindToDefKind stmtKind defaultArgs'
       e' <- elaborate' h e
-      defaultArgsForSelf <- forM defaultArgs' $ \(binder, value) -> do
-        value' <- inline h m value
-        return (binder, value')
       case mDefKind of
-        Just Inline.NoInline ->
+        Just Inline.NoInline -> do
+          defaultArgsForSelf <- forM defaultArgs' $ \(binder, value) -> do
+            value' <- inline h m value
+            return (binder, value')
           liftIO $ Definition.insert' (defHandle h) x impArgs' expArgs' defaultArgsForSelf e' codType' mDefKind
         _ ->
           return ()
@@ -181,7 +186,10 @@ elaborateStmt h stmt = do
       impArgs'' <- mapM (inlineBinder h) impArgs'
       defaultArgs'' <- forM defaultArgs' $ \(binder, value) -> do
         binder' <- inlineBinder h binder
-        value' <- inline h m value
+        value' <-
+          if SK.isMacroStmtKind stmtKind
+            then inlineWithoutResidualChecks h m value
+            else inline h m value
         return (binder', value')
       expArgs'' <- mapM (inlineBinder h) expArgs'
       codType'' <- inlineType h m codType'
@@ -251,6 +259,90 @@ elaborateGeist h (G.Geist {..}) = do
   expArgs' <- mapM (elaborateWeakBinder h) expArgs
   cod' <- elaborateType h cod
   return $ G.Geist {impArgs = impArgs', defaultArgs = defaultArgs', expArgs = expArgs', cod = cod', ..}
+
+checkResidualCheck :: Handle -> Inline.ResidualCheck -> App [L.Log]
+checkResidualCheck h check =
+  case check of
+    Inline.CheckActuality m t ->
+      checkActualityType h m S.empty t
+    Inline.CheckInteger m t ->
+      checkIntegerCursorType h m t
+
+checkActualityType :: Handle -> Hint -> S.Set DD.DefiniteDescription -> TM.Type -> App [L.Log]
+checkActualityType h m dataNameSet t = do
+  t' <- inlineType h m t
+  case t' of
+    _ :< TM.Tau ->
+      return []
+    _ :< TM.Data _ dataName dataArgs -> do
+      let dataNameSet' = S.insert dataName dataNameSet
+      logsFromArgs <- concat <$> mapM (checkActualityType h m dataNameSet') dataArgs
+      if S.member dataName dataNameSet
+        then return logsFromArgs
+        else do
+          dataConsArgsList <- getActualityConsArgTypes h m dataName dataArgs
+          logsFromCons <- fmap concat $ forM dataConsArgsList $ \dataConsArgs -> do
+            fmap concat $ forM dataConsArgs $ \(_, _, _, consArg) -> do
+              checkActualityType h m dataNameSet' consArg
+          return $ logsFromArgs ++ logsFromCons
+    _ :< TM.Box tInner ->
+      checkActualityType h m dataNameSet tInner
+    _ :< TM.PrimType {} ->
+      return []
+    _ :< TM.Void ->
+      return []
+    _ :< TM.Resource {} ->
+      return []
+    _ ->
+      return
+        [ L.newLog m LL.Error $
+            "A term of the following type might be noetic:\n  "
+              <> toTextType (weakenType t')
+        ]
+
+getActualityConsArgTypes ::
+  Handle ->
+  Hint ->
+  DD.DefiniteDescription ->
+  [TM.Type] ->
+  App [[BinderF TM.Type]]
+getActualityConsArgTypes h m dataName dataArgs = do
+  dataInfo <- lookupDataInfoFull h m dataName
+  let dataBinders = DI.dataArgs dataInfo
+  if length dataBinders == length dataArgs
+    then do
+      let binderIds = map (\(_, _, x, _) -> x) dataBinders
+      let sub = IntMap.fromList $ zip (map Ident.toInt binderIds) (map TmSubst.Type dataArgs)
+      forM (DI.consInfoList dataInfo) $ \consInfo -> do
+        liftIO $ substActualityConsArgs h sub (DI.consArgs consInfo)
+    else
+      raiseCritical m $ "Could not specialize constructor metadata for `" <> DD.reify dataName <> "` due to arity mismatch"
+
+substActualityConsArgs :: Handle -> TmSubst.Subst -> [BinderF TM.Type] -> IO [BinderF TM.Type]
+substActualityConsArgs h sub consArgs =
+  case consArgs of
+    [] ->
+      return []
+    (m, k, x, t) : rest -> do
+      let substHandle' = TmSubst.new (gensymHandle h)
+      t' <- TmSubst.substType substHandle' sub t
+      let opaque = m :< TM.Tau
+      let sub' = IntMap.insert (Ident.toInt x) (TmSubst.Type opaque) sub
+      rest' <- substActualityConsArgs h sub' rest
+      return $ (m, k, x, t') : rest'
+
+checkIntegerCursorType :: Handle -> Hint -> TM.Type -> App [L.Log]
+checkIntegerCursorType h m t = do
+  t' <- inlineType h m t
+  case t' of
+    _ :< TM.PrimType (PT.Int _) ->
+      return []
+    _ ->
+      return
+        [ L.newLog m LL.Error $
+            "Expected:\n  an integer type\nFound:\n  "
+              <> toTextType (weakenType t')
+        ]
 
 insertStmt :: Handle -> Stmt -> App ()
 insertStmt h stmt = do
@@ -529,8 +621,10 @@ elaborate' h term = do
       letSeq' <- mapM (elaborateLet h) letSeq
       e' <- elaborate' h e
       return $ m :< TM.BoxIntro letSeq' e'
-    _ :< WT.BoxIntroLift e -> do
-      elaborate' h e
+    m :< WT.BoxIntroLift mt e -> do
+      e' <- elaborate' h e
+      t <- elaborateActualityMarkerType h m mt
+      return $ m :< TM.BoxIntroLift t e'
     m :< WT.BoxElim castSeq mxt e1 uncastSeq e2 -> do
       castSeq' <- mapM (elaborateLet h) castSeq
       mxt' <- elaborateWeakBinder h mxt
@@ -551,13 +645,20 @@ elaborate' h term = do
       e1' <- elaborate' h e1
       e2' <- elaborate' h e2
       return $ m :< TM.TauElim (mx, x) e1' e2'
-    _ :< WT.Actual e -> do
-      elaborate' h e
+    m :< WT.Actual mt e -> do
+      e' <- elaborate' h e
+      t <- elaborateActualityMarkerType h m mt
+      return $ m :< TM.Actual t e'
     m :< WT.Let opacity (mx, k, x, t) e1 e2 -> do
       e1' <- elaborate' h e1
       t' <- reduceWeakType h t >>= elaborateType h
       e2' <- elaborate' h e2
-      return $ m :< TM.Let (WT.reifyOpacity opacity) (mx, k, x, t') e1' e2'
+      let letTerm = m :< TM.Let (WT.reifyOpacity opacity) (mx, k, x, t') e1' e2'
+      case opacity of
+        WT.Noetic ->
+          return $ m :< TM.Actual t' letTerm
+        _ ->
+          return letTerm
     m :< WT.Prim primValue -> do
       primValue' <- elaboratePrimValue h m primValue
       return $ m :< TM.Prim primValue'
@@ -659,6 +760,14 @@ elaborate' h term = do
           let typeRemark = L.newLog m remarkLevel message
           liftIO $ LocalLogs.insert (localLogsHandle h) typeRemark
           return e'
+
+elaborateActualityMarkerType :: Handle -> Hint -> Maybe WT.WeakType -> App TM.Type
+elaborateActualityMarkerType h m mt =
+  case mt of
+    Just t ->
+      elaborateType h t
+    Nothing ->
+      raiseCritical m "Found an untyped actuality marker during elaboration"
 
 elaborateType :: Handle -> WT.WeakType -> App TM.Type
 elaborateType h ty =
@@ -855,7 +964,7 @@ inlineType :: Handle -> Hint -> TM.Type -> App TM.Type
 inlineType h m t = do
   dmap <- liftIO $ Definition.get' (defHandle h)
   typeDefMap <- liftIO $ TypeDef.get' (typeDefHandle h)
-  inlineHandle <- liftIO $ Inline.new (gensymHandle h) dmap typeDefMap (dataHandle h) m (inlineLimit h) (specializationTable h) (pendingSpecializationDefs h)
+  inlineHandle <- liftIO $ Inline.new (gensymHandle h) dmap typeDefMap (dataHandle h) m (inlineLimit h) (specializationTable h) (pendingSpecializationDefs h) (residualCheckList h) False
   Inline.inlineType inlineHandle t
 
 elaborateLet :: Handle -> (BinderF WT.WeakType, WT.WeakTerm) -> App (BinderF TM.Type, TM.Term)
@@ -951,7 +1060,7 @@ elaborateDecisionTree h ctx mOrig m tree =
       return DT.Unreachable
     DT.Switch (cursor, cursorType) (fallbackClause, clauseList) -> do
       cursorType' <- reduceWeakType h cursorType >>= elaborateType h
-      switchSpec <- getSwitchSpec h m cursorType'
+      switchSpec <- getSwitchSpecForCaseList h m cursorType' clauseList
       case switchSpec of
         LiteralSwitch -> do
           when (DT.isUnreachable fallbackClause) $ do
@@ -1063,6 +1172,20 @@ getSwitchSpec h m cursorType = do
       raiseError m $
         "This term is expected to be an ADT value or a literal, but found:\n"
           <> toTextType (weakenType cursorType)
+
+getSwitchSpecForCaseList :: Handle -> Hint -> TM.Type -> [DT.Case t a] -> App SwitchSpec
+getSwitchSpecForCaseList h m cursorType caseList =
+  if any isLiteralCase caseList
+    then return LiteralSwitch
+    else getSwitchSpec h m cursorType
+
+isLiteralCase :: DT.Case t a -> Bool
+isLiteralCase decisionCase =
+  case decisionCase of
+    DT.LiteralCase {} ->
+      True
+    _ ->
+      False
 
 reduceWeakType :: Handle -> WT.WeakType -> App WT.WeakType
 reduceWeakType h t = do

--- a/src/Kernel/Elaborate/Internal/EnsureAffinity.hs
+++ b/src/Kernel/Elaborate/Internal/EnsureAffinity.hs
@@ -183,6 +183,10 @@ analyze h term = do
       (cs1, h') <- analyzeLet h letSeq
       cs2 <- analyze h' e
       return $ cs1 ++ cs2
+    _ :< TM.BoxIntroLift t e -> do
+      cs1 <- analyzeType h t
+      cs2 <- analyze h e
+      return $ cs1 ++ cs2
     _ :< TM.BoxElim castSeq mxt e1 uncastSeq e2 -> do
       (cs, h') <- analyzeLet h $ castSeq ++ [(mxt, e1)] ++ uncastSeq
       cs' <- analyze h' e2
@@ -197,6 +201,10 @@ analyze h term = do
       let mxt = (mx, VK.Normal, x, mx :< TM.Tau)
       (cs1, h') <- analyzeLet h [(mxt, e1)]
       cs2 <- analyze h' e2
+      return $ cs1 ++ cs2
+    _ :< TM.Actual t e -> do
+      cs1 <- analyzeType h t
+      cs2 <- analyze h e
       return $ cs1 ++ cs2
     _ :< TM.Let _ mxt e1 e2 -> do
       (cs1, h') <- analyzeLet h [(mxt, e1)]

--- a/src/Kernel/Elaborate/Internal/Handle/Constraint.hs
+++ b/src/Kernel/Elaborate/Internal/Handle/Constraint.hs
@@ -4,8 +4,6 @@ module Kernel.Elaborate.Internal.Handle.Constraint
     get,
     set,
     insert,
-    insertActualityConstraint,
-    insertIntegerConstraint,
     getSuspendedConstraints,
     setSuspendedConstraints,
   )
@@ -29,14 +27,6 @@ new = do
 insert :: Handle -> WT.WeakType -> WT.WeakType -> IO ()
 insert h expected actual = do
   modifyIORef' (constraintEnvRef h) $ (:) (C.Eq expected actual)
-
-insertActualityConstraint :: Handle -> WT.WeakType -> IO ()
-insertActualityConstraint h t = do
-  modifyIORef' (constraintEnvRef h) $ (:) (C.Actual t)
-
-insertIntegerConstraint :: Handle -> WT.WeakType -> IO ()
-insertIntegerConstraint h t = do
-  modifyIORef' (constraintEnvRef h) $ (:) (C.Integer t)
 
 get :: Handle -> IO [C.Constraint]
 get h = do

--- a/src/Kernel/Elaborate/Internal/Handle/Elaborate.hs
+++ b/src/Kernel/Elaborate/Internal/Handle/Elaborate.hs
@@ -4,6 +4,7 @@ module Kernel.Elaborate.Internal.Handle.Elaborate
     reduceType,
     fillType,
     inline,
+    inlineWithoutResidualChecks,
     inlineBinder,
   )
 where
@@ -75,7 +76,8 @@ data Handle = Handle
     currentStep :: Int,
     varEnv :: BoundVarEnv,
     specializationTable :: IORef InlineHandle.SpecializationTable,
-    pendingSpecializationDefs :: IORef [Stmt.Stmt]
+    pendingSpecializationDefs :: IORef [Stmt.Stmt],
+    residualCheckList :: IORef [Inline.ResidualCheck]
   }
 
 type BoundVarEnv = [BinderF WT.WeakType]
@@ -92,6 +94,7 @@ new globalHandle@(Global.Handle {..}) (Local.Handle {..}) currentSource = do
   let currentStep = 0
   specializationTable <- newIORef mempty
   pendingSpecializationDefs <- newIORef []
+  residualCheckList <- newIORef []
   return $ Handle {..}
 
 reduceType :: Handle -> WT.WeakType -> App WT.WeakType
@@ -107,16 +110,24 @@ fillType h sub t = do
   Fill.fillType fillHandle sub t
 
 inline :: Handle -> Hint -> TM.Term -> App TM.Term
-inline h m e = do
+inline h m e =
+  inline' h m True e
+
+inlineWithoutResidualChecks :: Handle -> Hint -> TM.Term -> App TM.Term
+inlineWithoutResidualChecks h m e =
+  inline' h m False e
+
+inline' :: Handle -> Hint -> Bool -> TM.Term -> App TM.Term
+inline' h m shouldEmitResidualChecks e = do
   dmap <- liftIO $ Definition.get' (defHandle h)
   typeDefMap <- liftIO $ TypeDef.get' (typeDefHandle h)
-  inlineHandle <- liftIO $ Inline.new (gensymHandle h) dmap typeDefMap (dataHandle h) m (inlineLimit h) (specializationTable h) (pendingSpecializationDefs h)
+  inlineHandle <- liftIO $ Inline.new (gensymHandle h) dmap typeDefMap (dataHandle h) m (inlineLimit h) (specializationTable h) (pendingSpecializationDefs h) (residualCheckList h) shouldEmitResidualChecks
   Inline.inline inlineHandle e
 
 inlineBinder :: Handle -> BinderF TM.Type -> App (BinderF TM.Type)
 inlineBinder h (m, k, x, t) = do
   dmap <- liftIO $ Definition.get' (defHandle h)
   typeDefMap <- liftIO $ TypeDef.get' (typeDefHandle h)
-  inlineHandle <- liftIO $ Inline.new (gensymHandle h) dmap typeDefMap (dataHandle h) m (inlineLimit h) (specializationTable h) (pendingSpecializationDefs h)
+  inlineHandle <- liftIO $ Inline.new (gensymHandle h) dmap typeDefMap (dataHandle h) m (inlineLimit h) (specializationTable h) (pendingSpecializationDefs h) (residualCheckList h) False
   t' <- Inline.inlineType inlineHandle t
   return (m, k, x, t')

--- a/src/Kernel/Elaborate/Internal/Infer.hs
+++ b/src/Kernel/Elaborate/Internal/Infer.hs
@@ -293,10 +293,9 @@ infer h term =
       letSeq' <- inferQuoteSeq h letSeq FromNoema
       (e', t) <- infer h e
       return (m :< WT.BoxIntro letSeq' e', m :< WT.Box t)
-    m :< WT.BoxIntroLift e -> do
+    m :< WT.BoxIntroLift _ e -> do
       (e', t) <- infer h e
-      liftIO $ Constraint.insertActualityConstraint (constraintHandle h) t
-      return (m :< WT.BoxIntroLift e', m :< WT.Box t)
+      return (m :< WT.BoxIntroLift (Just t) e', m :< WT.Box t)
     m :< WT.BoxElim castSeq mxt e1 uncastSeq e2 -> do
       castSeq' <- inferQuoteSeq h castSeq ToNoema
       (e1', t1) <- infer h e1
@@ -324,19 +323,13 @@ infer h term =
       let h' = extendHandle (mx, VK.Normal, x, tau) h
       (e2', t2') <- infer h' e2
       return (m :< WT.TauElim (mx, x) e1' e2', t2')
-    _ :< WT.Actual e -> do
+    m :< WT.Actual _ e -> do
       (e', t') <- infer h e
-      liftIO $ Constraint.insertActualityConstraint (constraintHandle h) t'
-      return (e', t')
+      return (m :< WT.Actual (Just t') e', t')
     m :< WT.Let opacity (mx, k, x, t) e1 e2 -> do
       (e1', t1') <- infer h e1
       t' <- inferType h t >>= resolveType h
       liftIO $ WeakType.insert (weakTypeHandle h) x t'
-      case opacity of
-        WT.Noetic ->
-          liftIO $ Constraint.insertActualityConstraint (constraintHandle h) t'
-        _ ->
-          return ()
       liftIO $ Constraint.insert (constraintHandle h) t' t1'
       (e2', t2') <- infer h e2
       return (m :< WT.Let opacity (mx, k, x, t') e1' e2', t2')
@@ -814,7 +807,7 @@ inferClause h cursorType decisionCase =
       (cont', tCont) <- inferDecisionTree mPat h cont
       case literal of
         L.Int _ ->
-          liftIO $ Constraint.insertIntegerConstraint (constraintHandle h) cursorType
+          return ()
         L.Rune _ ->
           liftIO $ Constraint.insert (constraintHandle h) cursorType (mPat :< WT.PrimType PT.Rune)
       return (DT.LiteralCase mPat literal cont', tCont)

--- a/src/Kernel/Elaborate/Internal/Unify.hs
+++ b/src/Kernel/Elaborate/Internal/Unify.hs
@@ -6,7 +6,6 @@ where
 
 import App.App (App)
 import App.Error qualified as E
-import App.Run (raiseCritical)
 import Control.Comonad.Cofree
 import Control.Monad
 import Control.Monad.Except (MonadError (throwError))
@@ -16,7 +15,6 @@ import Data.IntMap qualified as IntMap
 import Data.List (partition)
 import Data.Set qualified as S
 import Data.Text qualified as T
-import Kernel.Common.Handle.Global.Data qualified as Data
 import Kernel.Common.ReadableDD qualified as ReadableDD
 import Kernel.Common.Source (sourceModule)
 import Kernel.Elaborate.Constraint (SuspendedConstraint)
@@ -29,12 +27,10 @@ import Kernel.Elaborate.Stuck qualified as Stuck
 import Kernel.Elaborate.TypeHoleSubst qualified as THS
 import Language.Common.Binder
 import Language.Common.CreateSymbol qualified as Gensym
-import Language.Common.DataInfo qualified as DI
 import Language.Common.DefiniteDescription qualified as DD
 import Language.Common.HoleID qualified as HID
 import Language.Common.Ident
 import Language.Common.Ident.Reify qualified as Ident
-import Language.Common.PrimType qualified as PT
 import Language.Common.VarKind qualified as VK
 import Language.WeakTerm.Eq qualified as WT
 import Language.WeakTerm.FreeVars
@@ -81,12 +77,6 @@ throwTypeErrors h susList = do
 constraintToRemark :: Handle -> THS.TypeHoleSubst -> C.Constraint -> App L.Log
 constraintToRemark h sub c = do
   case c of
-    C.Actual t -> do
-      t' <- fillAsMuchAsPossible h sub t
-      return $ L.newLog (WT.metaOfType t) L.Error $ constructErrorMessageActual t'
-    C.Integer t -> do
-      t' <- fillAsMuchAsPossible h sub t
-      return $ L.newLog (WT.metaOfType t) L.Error $ constructErrorMessageInteger t'
     C.Eq expected actual -> do
       expected' <- fillAsMuchAsPossible h sub expected
       actual' <- fillAsMuchAsPossible h sub actual
@@ -145,18 +135,6 @@ collectGlobalDDs ty =
     _ ->
       []
 
-constructErrorMessageActual :: WT.WeakType -> T.Text
-constructErrorMessageActual t =
-  "A term of the following type might be noetic:\n  "
-    <> toTextType t
-
-constructErrorMessageInteger :: WT.WeakType -> T.Text
-constructErrorMessageInteger t =
-  "Expected:\n  "
-    <> "an integer type"
-    <> "\nFound:\n  "
-    <> toTextType t
-
 detectPossibleInfiniteLoop :: Handle -> C.Constraint -> App ()
 detectPossibleInfiniteLoop h c = do
   let Handle {inlineLimit, currentStep} = h
@@ -174,12 +152,6 @@ simplify h susList constraintList =
   case constraintList of
     [] ->
       return susList
-    (C.Actual t, orig) : cs -> do
-      susList' <- simplifyActual h (WT.metaOfType t) S.empty t orig
-      simplify h (susList' ++ susList) cs
-    (C.Integer t, orig) : cs -> do
-      susList' <- simplifyInteger h (WT.metaOfType t) t orig
-      simplify h (susList' ++ susList) cs
     headConstraint@(C.Eq expected actual, orig) : cs -> do
       detectPossibleInfiniteLoop h orig
       expected' <- reduceType h expected
@@ -369,115 +341,6 @@ toLinearIdentSet' xs acc =
       | otherwise ->
           toLinearIdentSet' rest (S.insert x acc)
 
-simplifyActual ::
-  Handle ->
-  Hint ->
-  S.Set DD.DefiniteDescription ->
-  WT.WeakType ->
-  C.Constraint ->
-  App [SuspendedConstraint]
-simplifyActual h m dataNameSet t orig = do
-  detectPossibleInfiniteLoop h orig
-  t' <- reduceType h t
-  case t' of
-    _ :< WT.Tau -> do
-      return []
-    _ :< WT.Data _ dataName dataArgs -> do
-      let dataNameSet' = S.insert dataName dataNameSet
-      constraintsFromDataArgs <- fmap concat $ forM dataArgs $ \dataArg ->
-        simplifyActual h m dataNameSet' dataArg orig
-      dataConsArgsList <-
-        if S.member dataName dataNameSet
-          then return []
-          else getConsArgTypes h m dataName dataArgs
-      constraintsFromDataConsArgs <- fmap concat $ forM dataConsArgsList $ \dataConsArgs -> do
-        fmap concat $ forM dataConsArgs $ \(_, _, _, consArg) -> do
-          simplifyActual h m dataNameSet' consArg orig
-      return $ constraintsFromDataArgs ++ constraintsFromDataConsArgs
-    _ :< WT.Box t'' -> do
-      simplifyActual h m dataNameSet t'' orig
-    _ :< WT.PrimType {} -> do
-      return []
-    _ :< WT.Void -> do
-      return []
-    _ :< WT.Resource {} -> do
-      return []
-    _ -> do
-      sub <- liftIO $ Hole.getTypeSubst (holeHandle h)
-      let fmvs = holesType t'
-      case lookupAnyType (S.toList fmvs) sub of
-        Just (hole, (xs, body)) -> do
-          let s = THS.singleton hole xs body
-          t'' <- fillType h s t'
-          simplifyActual h m dataNameSet t'' orig
-        Nothing -> do
-          defMap <- liftIO $ WeakTypeDef.read' (weakTypeDefHandle h)
-          case Stuck.asStuckedType t' of
-            Just (Stuck.VarGlobal dd, evalCtx)
-              | Just lam <- Map.lookup dd defMap -> do
-                  let h' = increment h
-                  mt'' <- liftIO $ Stuck.resume (substHandle h) lam evalCtx
-                  case mt'' of
-                    Just t'' -> do
-                      simplifyActual h' m dataNameSet t'' orig
-                    Nothing -> do
-                      return [C.SuspendedConstraint (fmvs, (C.Actual t', orig))]
-            _ -> do
-              return [C.SuspendedConstraint (fmvs, (C.Actual t', orig))]
-
-getConsArgTypes ::
-  Handle ->
-  Hint ->
-  DD.DefiniteDescription ->
-  [WT.WeakType] ->
-  App [[BinderF WT.WeakType]]
-getConsArgTypes h m dataName dataArgs = do
-  dataInfoOrNone <- liftIO $ Data.lookupWeak (dataHandle h) dataName
-  case dataInfoOrNone of
-    Just DI.DataInfo {DI.dataArgs = dataBinders, DI.consInfoList = consInfoList}
-      | length dataBinders == length dataArgs -> do
-          let binderIds = map (\(_, _, x, _) -> x) dataBinders
-          let sub = IntMap.fromList $ zip (map Ident.toInt binderIds) (map Type dataArgs)
-          liftIO $ mapM (substConsArgs h sub . DI.consArgs) consInfoList
-      | otherwise ->
-          raiseCritical m $ "Could not specialize constructor metadata for `" <> DD.reify dataName <> "` due to arity mismatch"
-    Nothing ->
-      raiseCritical m $ "Could not find constructor metadata for `" <> DD.reify dataName <> "`"
-
-simplifyInteger ::
-  Handle ->
-  Hint ->
-  WT.WeakType ->
-  C.Constraint ->
-  App [SuspendedConstraint]
-simplifyInteger h m t orig = do
-  detectPossibleInfiniteLoop h orig
-  t' <- reduceType h t
-  case t' of
-    _ :< WT.PrimType (PT.Int _) -> do
-      return []
-    _ -> do
-      sub <- liftIO $ Hole.getTypeSubst (holeHandle h)
-      let fmvs = holesType t'
-      case lookupAnyType (S.toList fmvs) sub of
-        Just (hole, (xs, body)) -> do
-          t'' <- fillType h (THS.singleton hole xs body) t'
-          simplifyInteger h m t'' orig
-        Nothing -> do
-          defMap <- liftIO $ WeakTypeDef.read' (weakTypeDefHandle h)
-          case Stuck.asStuckedType t' of
-            Just (Stuck.VarGlobal dd, evalCtx)
-              | Just lam <- Map.lookup dd defMap -> do
-                  let h' = increment h
-                  mt'' <- liftIO $ Stuck.resume (substHandle h) lam evalCtx
-                  case mt'' of
-                    Just t'' -> do
-                      simplifyInteger h' m t'' orig
-                    Nothing -> do
-                      return [C.SuspendedConstraint (fmvs, (C.Integer t', orig))]
-            _ -> do
-              return [C.SuspendedConstraint (fmvs, (C.Integer t', orig))]
-
 lookupAnyType :: [HID.HoleID] -> THS.TypeHoleSubst -> Maybe (HID.HoleID, ([Ident], WT.WeakType))
 lookupAnyType is sub =
   case is of
@@ -489,18 +352,6 @@ lookupAnyType is sub =
           Just (j, v)
         _ ->
           lookupAnyType js sub
-
-substConsArgs :: Handle -> Subst -> [BinderF WT.WeakType] -> IO [BinderF WT.WeakType]
-substConsArgs h sub consArgs =
-  case consArgs of
-    [] ->
-      return []
-    (m, k, x, t) : rest -> do
-      t' <- Subst.substType (substHandle h) sub t
-      let opaque = m :< WT.Tau -- allow `a` in `Cons(a: type, x: a)`
-      let sub' = IntMap.insert (Ident.toInt x) (Type opaque) sub
-      rest' <- substConsArgs h sub' rest
-      return $ (m, k, x, t') : rest'
 
 zipBinders :: [BinderF WT.WeakType] -> [BinderF WT.WeakType] -> Maybe [(BinderF WT.WeakType, BinderF WT.WeakType)]
 zipBinders args1 args2 =

--- a/src/Kernel/Parse/Internal/Discern.hs
+++ b/src/Kernel/Parse/Internal/Discern.hs
@@ -475,7 +475,7 @@ discern h term =
     m :< RT.BoxIntroLift _ _ (body, _) -> do
       ensureRuntimeStage m h "meta operation (`lift`)"
       body' <- discern h body
-      return $ m :< WT.BoxIntroLift body'
+      return $ m :< WT.BoxIntroLift Nothing body'
     m :< RT.BoxElim nv mustIgnoreRelayedVars _ (mx, pat, c1, c2, t) _ mys _ e1 _ startLoc _ e2 endLoc -> do
       ensureRuntimeStage m h "meta operation (`letbox`)"
       case nv of

--- a/src/Language/Term/Chain.hs
+++ b/src/Language/Term/Chain.hs
@@ -53,6 +53,8 @@ chainOf' tenv term =
     _ :< TM.BoxIntro letSeq e -> do
       let (xts, es) = unzip letSeq
       chainOfBinder tenv xts (e : es)
+    _ :< TM.BoxIntroLift t e ->
+      chainOfType tenv t ++ chainOf' tenv e
     _ :< TM.BoxElim castSeq mxt e1 uncastSeq e2 -> do
       let (xts, es) = unzip $ castSeq ++ [(mxt, e1)] ++ uncastSeq
       chainOfBinder tenv xts (es ++ [e2])
@@ -67,6 +69,8 @@ chainOf' tenv term =
       let mxt = (mx, VK.Normal, x, mx :< TM.Tau)
       let xs2 = chainOfBinder tenv [mxt] [e2]
       xs1 ++ xs2
+    _ :< TM.Actual t e ->
+      chainOfType tenv t ++ chainOf' tenv e
     _ :< TM.Let _ mxt e1 e2 -> do
       let xs1 = chainOf' tenv e1
       let xs2 = chainOfBinder tenv [mxt] [e2]

--- a/src/Language/Term/Compress.hs
+++ b/src/Language/Term/Compress.hs
@@ -35,6 +35,8 @@ compress term =
       () :< TM.DataElim isNoetic (zip3 os es' ts) tree'
     _ :< TM.BoxIntro letSeq e ->
       () :< TM.BoxIntro (map compressLet letSeq) (compress e)
+    _ :< TM.BoxIntroLift t e ->
+      () :< TM.BoxIntroLift t (compress e)
     _ :< TM.BoxElim castSeq mxt e1 uncastSeq e2 ->
       () :< TM.BoxElim (map compressLet castSeq) mxt (compress e1) (map compressLet uncastSeq) (compress e2)
     _ :< TM.CodeIntro e ->
@@ -45,6 +47,8 @@ compress term =
       () :< TM.TauIntro ty
     _ :< TM.TauElim (mx, x) e1 e2 ->
       () :< TM.TauElim (mx, x) (compress e1) (compress e2)
+    _ :< TM.Actual t e ->
+      () :< TM.Actual t (compress e)
     _ :< TM.Let opacity mxt e1 e2 ->
       () :< TM.Let opacity mxt (compress e1) (compress e2)
     _ :< TM.Prim prim ->

--- a/src/Language/Term/Extend.hs
+++ b/src/Language/Term/Extend.hs
@@ -43,6 +43,8 @@ extend term =
        in _m :< TM.DataElim isNoetic (zip3 os es' ts) tree'
     () :< TM.BoxIntro letSeq e ->
       _m :< TM.BoxIntro (map extendLet letSeq) (extend e)
+    () :< TM.BoxIntroLift t e ->
+      _m :< TM.BoxIntroLift t (extend e)
     () :< TM.BoxElim castSeq mxt e1 uncastSeq e2 ->
       _m :< TM.BoxElim (map extendLet castSeq) mxt (extend e1) (map extendLet uncastSeq) (extend e2)
     () :< TM.CodeIntro e ->
@@ -53,6 +55,8 @@ extend term =
       _m :< TM.TauIntro ty
     () :< TM.TauElim (mx, x) e1 e2 ->
       _m :< TM.TauElim (mx, x) (extend e1) (extend e2)
+    () :< TM.Actual t e ->
+      _m :< TM.Actual t (extend e)
     () :< TM.Let opacity mxt e1 e2 ->
       _m :< TM.Let opacity mxt (extend e1) (extend e2)
     () :< TM.Prim prim ->

--- a/src/Language/Term/FreeVars.hs
+++ b/src/Language/Term/FreeVars.hs
@@ -44,6 +44,8 @@ freeVars term =
     _ :< TM.BoxIntro letSeq e -> do
       let (xts, es) = unzip letSeq
       freeVarsBinderType xts (S.unions $ map freeVars (e : es))
+    _ :< TM.BoxIntroLift t e ->
+      S.union (freeVarsType t) (freeVars e)
     _ :< TM.BoxElim castSeq mxt e1 uncastSeq e2 -> do
       let (xts, es) = unzip $ castSeq ++ [(mxt, e1)] ++ uncastSeq
       freeVarsBinderType xts (S.unions $ map freeVars $ es ++ [e2])
@@ -55,6 +57,8 @@ freeVars term =
       freeVarsType ty
     _ :< TM.TauElim (_, x) e1 e2 ->
       S.union (freeVars e1) (S.delete x (freeVars e2))
+    _ :< TM.Actual t e ->
+      S.union (freeVarsType t) (freeVars e)
     _ :< TM.Let _ mxt e1 e2 -> do
       let set1 = freeVars e1
       let set2 = freeVarsBinderType [mxt] (freeVars e2)

--- a/src/Language/Term/FreeVarsWithHints.hs
+++ b/src/Language/Term/FreeVarsWithHints.hs
@@ -45,6 +45,8 @@ freeVarsWithHints term =
     _ :< TM.BoxIntro letSeq e -> do
       let (xts, es) = unzip letSeq
       freeVarsWithHintsBinderType xts (S.unions $ map freeVarsWithHints (e : es))
+    _ :< TM.BoxIntroLift t e ->
+      S.union (freeVarsWithHintsType t) (freeVarsWithHints e)
     _ :< TM.BoxElim castSeq mxt e1 uncastSeq e2 -> do
       let (xts, es) = unzip $ castSeq ++ [(mxt, e1)] ++ uncastSeq
       freeVarsWithHintsBinderType xts (S.unions $ map freeVarsWithHints $ es ++ [e2])
@@ -56,6 +58,8 @@ freeVarsWithHints term =
       freeVarsWithHintsType ty
     _ :< TM.TauElim (m, x) e1 e2 ->
       S.union (freeVarsWithHints e1) (S.delete (m, x) (freeVarsWithHints e2))
+    _ :< TM.Actual t e ->
+      S.union (freeVarsWithHintsType t) (freeVarsWithHints e)
     _ :< TM.Let _ mxt e1 e2 -> do
       let set1 = freeVarsWithHints e1
       let set2 = freeVarsWithHintsBinderType [mxt] (freeVarsWithHints e2)

--- a/src/Language/Term/Inline.hs
+++ b/src/Language/Term/Inline.hs
@@ -5,6 +5,7 @@ module Language.Term.Inline
     inlineType,
     DefInfo (..),
     DefKind (..),
+    ResidualCheck (..),
   )
 where
 
@@ -52,8 +53,8 @@ import Language.Term.Subst qualified as Subst
 import Language.Term.Term qualified as TM
 import Logger.Hint
 
-new :: GensymHandle.Handle -> DefMap -> TypeDefMap -> Data.Handle -> Hint -> Int -> IORef SpecializationTable -> IORef [Stmt.Stmt] -> IO Handle
-new gensymHandle dmap typeDefMap dataHandle location inlineLimit specializationTable pendingSpecializationDefs = do
+new :: GensymHandle.Handle -> DefMap -> TypeDefMap -> Data.Handle -> Hint -> Int -> IORef SpecializationTable -> IORef [Stmt.Stmt] -> IORef [ResidualCheck] -> Bool -> IO Handle
+new gensymHandle dmap typeDefMap dataHandle location inlineLimit specializationTable pendingSpecializationDefs residualCheckList shouldEmitResidualChecks = do
   let substHandle = Subst.new gensymHandle
   let refreshHandle = Refresh.new gensymHandle
   currentStepRef <- liftIO $ newIORef 0
@@ -257,6 +258,11 @@ inline' h term = do
       es' <- mapM (inline' h) es
       e' <- inline' h e
       return $ m :< TM.BoxIntro (zip xts' es') e'
+    m :< TM.BoxIntroLift t e -> do
+      t' <- inlineType' h t
+      e' <- inline' h e
+      emitActualityCheck h m t'
+      return $ m :< TM.BoxIntroLift t' e'
     m :< TM.BoxElim castSeq mxt e1 uncastSeq e2 -> do
       castSeq' <- mapM (bimapM (inlineTypeBinder h) (inline' h)) castSeq
       (mxt', e1') <- bimapM (inlineTypeBinder h) (inline' h) (mxt, e1)
@@ -285,6 +291,11 @@ inline' h term = do
         _ -> do
           e2' <- inline' h e2
           return $ m :< TM.TauElim (mx, x) e1' e2'
+    m :< TM.Actual t e -> do
+      t' <- inlineType' h t
+      e' <- inline' h e
+      emitActualityCheck h m t'
+      return $ m :< TM.Actual t' e'
     m :< TM.Let opacity mxt@(_, _, x, _) e1 e2 -> do
       e1' <- inline' h e1
       case opacity of
@@ -470,25 +481,28 @@ inlineDecisionTree h tree =
       return DT.Unreachable
     DT.Switch (cursorVar, cursor) clauseList -> do
       cursor' <- inlineType' h cursor
-      clauseList' <- inlineCaseList h clauseList
+      clauseList' <- inlineCaseList h cursor' clauseList
       return $ DT.Switch (cursorVar, cursor') clauseList'
 
 inlineCaseList ::
   Handle ->
+  TM.Type ->
   DT.CaseList TM.Type TM.Term ->
   App (DT.CaseList TM.Type TM.Term)
-inlineCaseList h (fallbackTree, clauseList) = do
+inlineCaseList h cursorType (fallbackTree, clauseList) = do
   fallbackTree' <- inlineDecisionTree h fallbackTree
-  clauseList' <- mapM (inlineCase h) clauseList
+  clauseList' <- mapM (inlineCase h cursorType) clauseList
   return (fallbackTree', clauseList')
 
 inlineCase ::
   Handle ->
+  TM.Type ->
   DT.Case TM.Type TM.Term ->
   App (DT.Case TM.Type TM.Term)
-inlineCase h decisionCase = do
+inlineCase h cursorType decisionCase = do
   case decisionCase of
     DT.LiteralCase mPat i cont -> do
+      emitIntegerCheck h mPat cursorType i
       cont' <- inlineDecisionTree h cont
       return $ DT.LiteralCase mPat i cont'
     DT.ConsCase record@(DT.ConsCaseRecord {..}) -> do
@@ -504,6 +518,35 @@ inlineCase h decisionCase = do
               DT.consArgs = consArgs',
               DT.cont = cont'
             }
+
+emitActualityCheck :: Handle -> Hint -> TM.Type -> App ()
+emitActualityCheck h m t = do
+  when (shouldEmitResidualChecks h) $ do
+    mReport <- getReportHint h m
+    emitResidualCheck h $ CheckActuality mReport t
+
+emitIntegerCheck :: Handle -> Hint -> TM.Type -> L.Literal -> App ()
+emitIntegerCheck h m t literal =
+  case literal of
+    L.Int _ -> do
+      when (shouldEmitResidualChecks h) $ do
+        mReport <- getReportHint h m
+        emitResidualCheck h $ CheckInteger mReport t
+    L.Rune _ ->
+      return ()
+
+emitResidualCheck :: Handle -> ResidualCheck -> App ()
+emitResidualCheck h check = do
+  liftIO $ modifyIORef' (residualCheckList h) (check :)
+
+getReportHint :: Handle -> Hint -> App Hint
+getReportHint h m = do
+  stack <- liftIO $ readIORef (macroCallStack h)
+  case stack of
+    (_, mReport) : _ ->
+      return mReport
+    [] ->
+      return m
 
 findClause ::
   D.Discriminant ->

--- a/src/Language/Term/Inline/Handle.hs
+++ b/src/Language/Term/Inline/Handle.hs
@@ -6,6 +6,7 @@ module Language.Term.Inline.Handle
     DefInfo (..),
     DefKind (..),
     SpecializationEntry (..),
+    ResidualCheck (..),
   )
 where
 
@@ -53,6 +54,10 @@ data SpecializationEntry = SpecializationEntry
 type SpecializationTable =
   Map.HashMap DD.DefiniteDescription [SpecializationEntry]
 
+data ResidualCheck
+  = CheckActuality Hint TM.Type
+  | CheckInteger Hint TM.Type
+
 data Handle = Handle
   { substHandle :: Subst.Handle,
     refreshHandle :: Refresh.Handle,
@@ -64,6 +69,8 @@ data Handle = Handle
     location :: Hint,
     specializationTable :: IORef SpecializationTable,
     pendingSpecializationDefs :: IORef [Stmt.Stmt],
+    residualCheckList :: IORef [ResidualCheck],
+    shouldEmitResidualChecks :: Bool,
     macroCallStack :: IORef [(DD.DefiniteDescription, Hint)],
     gensymHandle :: GensymHandle.Handle
   }

--- a/src/Language/Term/Refresh.hs
+++ b/src/Language/Term/Refresh.hs
@@ -78,6 +78,10 @@ refresh h term =
       letSeq' <- mapM (refreshLet h) letSeq
       e' <- refresh h e
       return $ m :< TM.BoxIntro letSeq' e'
+    m :< TM.BoxIntroLift t e -> do
+      t' <- refreshType h t
+      e' <- refresh h e
+      return $ m :< TM.BoxIntroLift t' e'
     m :< TM.BoxElim castSeq mxt e1 uncastSeq e2 -> do
       castSeq' <- mapM (refreshLet h) castSeq
       (mxt', e1') <- refreshLet h (mxt, e1)
@@ -97,6 +101,10 @@ refresh h term =
       e1' <- refresh h e1
       e2' <- refresh h e2
       return $ m :< TM.TauElim mx e1' e2'
+    m :< TM.Actual t e -> do
+      t' <- refreshType h t
+      e' <- refresh h e
+      return $ m :< TM.Actual t' e'
     m :< TM.Let opacity mxt e1 e2 -> do
       e1' <- refresh h e1
       ([mxt'], e2') <- refresh' h [mxt] e2

--- a/src/Language/Term/Subst.hs
+++ b/src/Language/Term/Subst.hs
@@ -114,6 +114,10 @@ subst h sub term =
       (letSeq', sub') <- substLetSeq h sub letSeq
       e' <- subst h sub' e
       return $ m :< TM.BoxIntro letSeq' e'
+    m :< TM.BoxIntroLift t e -> do
+      t' <- substType h sub t
+      e' <- subst h sub e
+      return $ m :< TM.BoxIntroLift t' e'
     m :< TM.BoxElim castSeq mxt e1 uncastSeq e2 -> do
       (castSeq', sub1) <- substLetSeq h sub castSeq
       ((mxt', e1'), sub2) <- substLet h sub1 (mxt, e1)
@@ -135,6 +139,10 @@ subst h sub term =
       let sub' = IntMap.insert (Ident.toInt x) (Var x') sub
       e2' <- subst h sub' e2
       return $ m :< TM.TauElim (mx, x') e1' e2'
+    m :< TM.Actual t e -> do
+      t' <- substType h sub t
+      e' <- subst h sub e
+      return $ m :< TM.Actual t' e'
     m :< TM.Let opacity mxt e1 e2 -> do
       e1' <- subst h sub e1
       ([mxt'], e2') <- subst' h sub [mxt] e2

--- a/src/Language/Term/Term.hs
+++ b/src/Language/Term/Term.hs
@@ -72,11 +72,13 @@ data TermF a
   | DataIntro AttrDI.Attr DD.DefiniteDescription [Type] [a]
   | DataElim N.IsNoetic [(Ident, a, Type)] (DT.DecisionTree Type a)
   | BoxIntro [(BinderF Type, a)] a
+  | BoxIntroLift Type a
   | BoxElim [(BinderF Type, a)] (BinderF Type) a [(BinderF Type, a)] a
   | CodeIntro a
   | CodeElim a
   | TauIntro Type
   | TauElim (Hint, Ident) a a
+  | Actual Type a
   | Let O.Opacity (BinderF Type) a a
   | Prim (PV.PrimValue Type)
   | Magic (Magic BLT.BaseLowType Type a)
@@ -114,6 +116,10 @@ isValue term =
       True
     _ :< TauIntro _ ->
       True
+    _ :< BoxIntroLift _ e ->
+      isValue e
+    _ :< Actual _ e ->
+      isValue e
     _ :< Prim {} ->
       True
     _ :< Magic (LowMagic (LM.OpaqueValue _)) ->

--- a/src/Language/Term/Weaken.hs
+++ b/src/Language/Term/Weaken.hs
@@ -94,6 +94,8 @@ weaken term =
       m :< WT.DataElim isNoetic (zip3 os es' ts') tree'
     m :< TM.BoxIntro letSeq e -> do
       m :< WT.BoxIntro (map weakenLet letSeq) (weaken e)
+    m :< TM.BoxIntroLift t e ->
+      m :< WT.BoxIntroLift (Just $ weakenType t) (weaken e)
     m :< TM.BoxElim castSeq mxt e1 uncastSeq e2 -> do
       let castSeq' = map weakenLet castSeq
       let (mxt', e1') = weakenLet (mxt, e1)
@@ -108,6 +110,8 @@ weaken term =
       m :< WT.TauIntro (weakenType ty)
     m :< TM.TauElim mx e1 e2 ->
       m :< WT.TauElim mx (weaken e1) (weaken e2)
+    m :< TM.Actual t e ->
+      m :< WT.Actual (Just $ weakenType t) (weaken e)
     m :< TM.Let opacity mxt e1 e2 ->
       m :< WT.Let (reflectOpacity opacity) (weakenTypeBinder mxt) (weaken e1) (weaken e2)
     m :< TM.Prim prim ->

--- a/src/Language/WeakTerm/FreeVars.hs
+++ b/src/Language/WeakTerm/FreeVars.hs
@@ -45,7 +45,7 @@ freeVars term =
     _ :< WT.BoxIntro letSeq e -> do
       let (mxts, es) = unzip letSeq
       freeVarsBinders mxts (S.unions $ map freeVars (e : es))
-    _ :< WT.BoxIntroLift e ->
+    _ :< WT.BoxIntroLift _ e ->
       freeVars e
     _ :< WT.BoxElim castSeq mxt e1 uncastSeq e2 -> do
       let (xts, es) = unzip $ castSeq ++ [(mxt, e1)] ++ uncastSeq
@@ -58,7 +58,7 @@ freeVars term =
       S.empty
     _ :< WT.TauElim (_, x) e1 e2 ->
       S.union (freeVars e1) (S.delete x (freeVars e2))
-    _ :< WT.Actual e ->
+    _ :< WT.Actual _ e ->
       freeVars e
     _ :< WT.Let _ mxt e1 e2 -> do
       let set1 = freeVars e1
@@ -183,7 +183,7 @@ freeVarsAll term =
     _ :< WT.BoxIntro letSeq e -> do
       let (mxts, es) = unzip letSeq
       freeVarsBindersType mxts (S.unions $ map freeVarsAll (e : es))
-    _ :< WT.BoxIntroLift e ->
+    _ :< WT.BoxIntroLift _ e ->
       freeVarsAll e
     _ :< WT.BoxElim castSeq mxt e1 uncastSeq e2 -> do
       let (xts, es) = unzip $ castSeq ++ [(mxt, e1)] ++ uncastSeq
@@ -194,7 +194,7 @@ freeVarsAll term =
       freeVarsAll e
     _ :< WT.TauIntro ty ->
       freeVarsType ty
-    _ :< WT.Actual e ->
+    _ :< WT.Actual _ e ->
       freeVarsAll e
     _ :< WT.Let _ mxt e1 e2 -> do
       let set1 = freeVarsAll e1

--- a/src/Language/WeakTerm/Subst.hs
+++ b/src/Language/WeakTerm/Subst.hs
@@ -120,9 +120,10 @@ subst h sub term =
       (letSeq', sub') <- substLetSeq h sub letSeq
       e' <- subst h sub' e
       return $ m :< WT.BoxIntro letSeq' e'
-    m :< WT.BoxIntroLift e -> do
+    m :< WT.BoxIntroLift mt e -> do
+      mt' <- traverse (substType h sub) mt
       e' <- subst h sub e
-      return $ m :< WT.BoxIntroLift e'
+      return $ m :< WT.BoxIntroLift mt' e'
     m :< WT.BoxElim castSeq mxt e1 uncastSeq e2 -> do
       (castSeq', sub1) <- substLetSeq h sub castSeq
       ((mxt', e1'), sub2) <- substLet h sub1 (mxt, e1)
@@ -144,9 +145,10 @@ subst h sub term =
       let sub' = IntMap.insert (Ident.toInt x) (Var x') sub
       e2' <- subst h sub' e2
       return $ m :< WT.TauElim (mx, x') e1' e2'
-    m :< WT.Actual e -> do
+    m :< WT.Actual mt e -> do
+      mt' <- traverse (substType h sub) mt
       e' <- subst h sub e
-      return $ m :< WT.Actual e'
+      return $ m :< WT.Actual mt' e'
     m :< WT.Let opacity mxt e1 e2 -> do
       e1' <- subst h sub e1
       (mxt', _, e2') <- subst'' h sub mxt [] e2

--- a/src/Language/WeakTerm/ToText.hs
+++ b/src/Language/WeakTerm/ToText.hs
@@ -98,7 +98,7 @@ toText term =
     _ :< WT.BoxIntro letSeq t -> do
       let kes = map (\((_, _, x, _), e) -> (x, e)) letSeq
       "box " <> T.intercalate ", " (map (\(k, e) -> inParen $ Ident.toText k <> ", " <> toText e) kes) <> inBrace (toText t)
-    _ :< WT.BoxIntroLift e ->
+    _ :< WT.BoxIntroLift _ e ->
       "lift " <> inBrace (toText e)
     _ :< WT.BoxElim castSeq (_, k, x, t) e1 _ e2 -> do
       let ks = map (\((_, _, y, _), _) -> y) castSeq
@@ -120,7 +120,7 @@ toText term =
       "pack-type" <> inParen (toTextType ty)
     _ :< WT.TauElim (_, x) e1 e2 ->
       "unpack-type " <> showVariable x <> " = " <> toText e1 <> "; " <> toText e2
-    _ :< WT.Actual e ->
+    _ :< WT.Actual _ e ->
       "ACTUAL(" <> toText e <> ")"
     _ :< WT.Let opacity (_, k, x, t) e1 e2 -> do
       case opacity of

--- a/src/Language/WeakTerm/WeakTerm.hs
+++ b/src/Language/WeakTerm/WeakTerm.hs
@@ -70,13 +70,13 @@ data WeakTermF a
   | DataIntro AttrDI.Attr DD.DefiniteDescription [WeakType] [a]
   | DataElim N.IsNoetic [(Ident, a, WeakType)] (DT.DecisionTree WeakType a)
   | BoxIntro [(BinderF WeakType, a)] a
-  | BoxIntroLift a
+  | BoxIntroLift (Maybe WeakType) a
   | BoxElim [(BinderF WeakType, a)] (BinderF WeakType) a [(BinderF WeakType, a)] a
   | CodeIntro a
   | CodeElim a
   | TauIntro WeakType
   | TauElim (Hint, Ident) a a
-  | Actual a
+  | Actual (Maybe WeakType) a
   | Let LetOpacity (BinderF WeakType) a a
   | Prim (WPV.WeakPrimValue WeakType)
   | Magic (WeakMagic WeakType WeakType a)


### PR DESCRIPTION
Allows programs such as:

```neut
define-meta lift-value<a>(x: 'a) -> '+a {
  quote {
    let y = unquote {x};
    lift {y} // `lift`ing `y: a`
  }
}

define use-meta() -> +unit {
  lift-value::(Unit)
}
```
