### PR TITLE
fix: match trace targets using canonical names

### DIFF
--- a/src/Kernel/Common/Handle/Global/ModulePath.hs
+++ b/src/Kernel/Common/Handle/Global/ModulePath.hs
@@ -7,7 +7,7 @@ module Kernel.Common.Handle.Global.ModulePath
     set,
     build,
     renderDD,
-    renderVerboseDD,
+    renderCanonicalDD,
     renderSource,
   )
 where
@@ -113,8 +113,8 @@ renderDD :: ModulePathMap -> DD.DefiniteDescription -> T.Text
 renderDD =
   renderDDWith True
 
-renderVerboseDD :: ModulePathMap -> DD.DefiniteDescription -> T.Text
-renderVerboseDD =
+renderCanonicalDD :: ModulePathMap -> DD.DefiniteDescription -> T.Text
+renderCanonicalDD =
   renderDDWith False
 
 renderDDWith :: Bool -> ModulePathMap -> DD.DefiniteDescription -> T.Text

--- a/src/Kernel/Common/Trace.hs
+++ b/src/Kernel/Common/Trace.hs
@@ -48,7 +48,7 @@ matches config modulePathMap phase dd = do
       False
     Just mainModule' ->
       phase `elem` phaseList config
-        && any (`isPrefixOfLocator` ModulePath.renderDD modulePathMap dd) (prefixList config)
+        && any (`isPrefixOfLocator` ModulePath.renderCanonicalDD modulePathMap dd) (prefixList config)
 
 isPrefixOfLocator :: T.Text -> T.Text -> Bool
 isPrefixOfLocator prefix name = do

--- a/src/Kernel/Parse/Internal/Discern/Name.hs
+++ b/src/Kernel/Parse/Internal/Discern/Name.hs
@@ -20,7 +20,7 @@ import Data.Maybe qualified as Maybe
 import Data.Text qualified as T
 import Kernel.Common.Const qualified as C
 import Kernel.Common.GlobalName qualified as GN
-import Kernel.Common.Handle.Global.ModulePath (renderDD, renderVerboseDD)
+import Kernel.Common.Handle.Global.ModulePath (renderCanonicalDD, renderDD)
 import Kernel.Common.Handle.Local.Locator qualified as Locator
 import Kernel.Common.Handle.Local.Tag qualified as Tag
 import Kernel.Parse.Internal.Discern.Handle qualified as H
@@ -92,7 +92,7 @@ resolveVarOrErr h m name = do
       let foundNameList' =
             if length (List.nub abbreviatedList) == length abbreviatedList
               then abbreviatedList
-              else map (renderVerboseDD $ H.modulePathMap h) ddList
+              else map (renderCanonicalDD $ H.modulePathMap h) ddList
       let candInfo = T.concat $ map ("\n- " <>) foundNameList'
       return $ Left $ "This `" <> name <> "` is ambiguous since it could refer to:" <> candInfo
 


### PR DESCRIPTION
yo