### PR TITLE
improve compilation speed

### DIFF
--- a/src/Command/Common/Build.hs
+++ b/src/Command/Common/Build.hs
@@ -16,6 +16,7 @@ import Command.Common.Build.Generate qualified as Gen
 import Command.Common.Build.Install qualified as Install
 import Command.Common.Build.Link qualified as Link
 import Console.Handle qualified as Console
+import Control.Concurrent (getNumCapabilities)
 import Control.Monad
 import Control.Monad.Except (MonadError (throwError))
 import Control.Monad.IO.Class
@@ -131,8 +132,15 @@ buildTarget h (M.MainModule baseModule) target = do
 
 compile :: Handle -> Trace.Config -> Target -> [OutputKind] -> [(Source, Either Cache T.Text)] -> App ()
 compile h traceConfig target outputKindList contentSeq = do
+  withSystemTempDir "neut-object" $ \stagingDir -> do
+    compile' h traceConfig target outputKindList contentSeq stagingDir
+
+compile' :: Handle -> Trace.Config -> Target -> [OutputKind] -> [(Source, Either Cache T.Text)] -> Path Abs Dir -> App ()
+compile' h traceConfig target outputKindList contentSeq stagingDir = do
+  numCapabilities <- liftIO getNumCapabilities
+  generateHandle <- liftIO $ Gen.new (globalHandle h) stagingDir numCapabilities
   let cacheHandle = Cache.new (globalHandle h)
-  bs <- mapM (needsCodeGeneration cacheHandle . fst) contentSeq
+  bs <- mapM (needsCodeGeneration traceConfig cacheHandle outputKindList . fst) contentSeq
   forM_ (zip contentSeq bs) $ \((source, _), shouldGenerateCode) -> do
     let sourcePath = T.pack $ toFilePath $ sourceFilePath source
     let message =
@@ -161,7 +169,7 @@ compile h traceConfig target outputKindList contentSeq = do
     let ensureMainHandle = EnsureMain.new (Global.envHandle (globalHandle h))
     stmtList <- Elaborate.elaborate elaborateHandle target logs cacheOrStmt
     EnsureMain.ensureMain ensureMainHandle target source (map snd $ getStmtName stmtList)
-    b <- needsCodeGeneration cacheHandle source
+    b <- needsCodeGeneration traceConfig cacheHandle outputKindList source
     if b
       then do
         fmap Just $ liftIO $ async $ runApp $ do
@@ -171,23 +179,31 @@ compile h traceConfig target outputKindList contentSeq = do
           liftIO $ Logger.report (Global.loggerHandle (globalHandle h)) $ "Lowering: " <> T.pack (toFilePath $ sourceFilePath source)
           lowerHandle <- Lower.new gensymHandle (globalHandle h) traceConfig target defMap
           virtualCode <- Lower.lower lowerHandle stmtList' auxStmtList
-          emit h gensymHandle hp currentTime target outputKindList (Right source) virtualCode
+          emit h generateHandle gensymHandle hp currentTime target outputKindList (Right source) virtualCode
       else return Nothing
   when (shouldRegisterUnusedTopLevelNameRemarks target) $
     registerUnusedTopLevelNameRemarks h
   entryPointVirtualCode <- compileEntryPoint h target outputKindList
   entryPointAsync <- forM entryPointVirtualCode $ \(gensymHandle, src, code) -> liftIO $ do
-    async $ runApp $ emit h gensymHandle hp currentTime target outputKindList src code
+    async $ runApp $ emit h generateHandle gensymHandle hp currentTime target outputKindList src code
   errors <- fmap lefts $ mapM wait $ entryPointAsync ++ contentAsync
+  objectErrors <-
+    if null errors
+      then do
+        result <- liftIO $ runApp $ Gen.flushObjects generateHandle
+        return $ lefts [result]
+      else return []
   liftIO $ Indicator.close hp
-  if null errors
+  let allErrors = errors <> objectErrors
+  if null allErrors
     then return ()
-    else throwError $ E.join errors
-  where
-    needsCodeGeneration cacheHandle source = do
-      if Trace.isEnabled traceConfig
-        then return True
-        else Cache.needsCompilation cacheHandle outputKindList source
+    else throwError $ E.join allErrors
+
+needsCodeGeneration :: Trace.Config -> Cache.Handle -> [OutputKind] -> Source -> App Bool
+needsCodeGeneration traceConfig cacheHandle outputKindList source = do
+  if Trace.isEnabled traceConfig
+    then return True
+    else Cache.needsCompilation cacheHandle outputKindList source
 
 registerUnusedTopLevelNameRemarks :: Handle -> App ()
 registerUnusedTopLevelNameRemarks h = do
@@ -217,6 +233,7 @@ getWorkingTitle numOfItems = do
 
 emit ::
   Handle ->
+  Gen.Handle ->
   Gensym.Handle ->
   Indicator.Handle ->
   UTCTime ->
@@ -225,18 +242,17 @@ emit ::
   Either MainTarget Source ->
   LC.LowCode ->
   App ()
-emit h gensymHandle progressBar currentTime target outputKindList src code = do
+emit h generateHandle gensymHandle progressBar currentTime target outputKindList src code = do
   emitHandle <- Emit.new gensymHandle (globalHandle h) target
-  let llvmHandle = Gen.new (globalHandle h)
   let clangOptions = getCompileOption target
   llvmIR' <- liftIO $ Emit.emit emitHandle code
+  progressLabel <- liftIO $ getProgressLabel h src
   forM_ outputKindList $ \outputKind -> do
     case outputKind of
       OK.Object -> do
-        Gen.generateObject llvmHandle target clangOptions currentTime src llvmIR'
+        Gen.generateObject generateHandle target clangOptions currentTime progressLabel src llvmIR'
       OK.LLVM -> do
-        Gen.generateAsm llvmHandle target currentTime src llvmIR'
-  progressLabel <- liftIO $ getProgressLabel h src
+        Gen.generateAsm generateHandle target currentTime src llvmIR'
   liftIO $ Indicator.increment progressBar progressLabel
 
 getProgressLabel :: Handle -> Either MainTarget Source -> IO T.Text

--- a/src/Command/Common/Build/Generate.hs
+++ b/src/Command/Common/Build/Generate.hs
@@ -2,15 +2,21 @@ module Command.Common.Build.Generate
   ( Handle,
     new,
     generateObject,
+    flushObjects,
     generateAsm,
   )
 where
 
 import App.App (App)
 import App.Error (newError')
+import App.Run (forP_)
+import Control.Monad (forM_)
 import Control.Monad.Except (MonadError (throwError))
 import Control.Monad.IO.Class
 import Data.ByteString.Lazy qualified as L
+import Data.Char (isAlphaNum, isAscii)
+import Data.IORef
+import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 import Data.Time.Clock
 import Kernel.Common.CreateGlobalHandle qualified as Global
@@ -31,13 +37,27 @@ data Handle = Handle
   { loggerHandle :: Logger.Handle,
     pathHandle :: Path.Handle,
     platformHandle :: Platform.Handle,
-    runProcessHandle :: RunProcess.Handle
+    runProcessHandle :: RunProcess.Handle,
+    stagingDir :: Path Abs Dir,
+    numCapabilities :: Int,
+    nextObjectIndexRef :: IORef Int,
+    pendingObjectListRef :: IORef [PendingObject]
   }
 
-new :: Global.Handle -> Handle
-new (Global.Handle {..}) = do
+data PendingObject = PendingObject
+  { stagingLLVMPath :: Path Rel File,
+    stagingObjectPath :: Path Rel File,
+    finalObjectPath :: Path Abs File,
+    objectTimeStamp :: UTCTime,
+    additionalClangOptions :: [ClangOption]
+  }
+
+new :: Global.Handle -> Path Abs Dir -> Int -> IO Handle
+new (Global.Handle {..}) stagingDir numCapabilities = do
   let runProcessHandle = RunProcess.new loggerHandle
-  Handle {..}
+  nextObjectIndexRef <- newIORef 0
+  pendingObjectListRef <- newIORef []
+  return $ Handle {..}
 
 type ClangOption = String
 
@@ -48,21 +68,20 @@ generateObject ::
   Target ->
   [ClangOption] ->
   UTCTime ->
+  T.Text ->
   Either MainTarget Source ->
   L.ByteString ->
   App ()
-generateObject h target clangOptions timeStamp sourceOrNone llvmCode = do
+generateObject h target clangOptions timeStamp sourceLabel sourceOrNone llvmCode = do
   case sourceOrNone of
     Right source -> do
       (_, outputPath) <- Path.attachOutputPath (pathHandle h) target OK.Object source
       ensureDir $ parent outputPath
-      generateObject' h clangOptions llvmCode outputPath
-      setModificationTime outputPath timeStamp
+      stageObject h sourceLabel clangOptions llvmCode outputPath timeStamp
     Left mainTarget -> do
       (_, outputPath) <- Path.getOutputPathForEntryPoint (pathHandle h) OK.Object mainTarget
       ensureDir $ parent outputPath
-      generateObject' h clangOptions llvmCode outputPath
-      setModificationTime outputPath timeStamp
+      stageObject h sourceLabel clangOptions llvmCode outputPath timeStamp
 
 generateAsm ::
   Handle ->
@@ -89,32 +108,83 @@ generateAsm' h llvmCode path = do
   liftIO $ Logger.report (loggerHandle h) $ "Saving: " <> T.pack (toFilePath path)
   liftIO $ writeLazyByteString path llvmCode
 
-generateObject' :: Handle -> [ClangOption] -> L.ByteString -> Path Abs File -> App ()
-generateObject' h additionalClangOptions llvm outputPath = do
+stageObject :: Handle -> T.Text -> [ClangOption] -> L.ByteString -> Path Abs File -> UTCTime -> App ()
+stageObject h sourceLabel additionalClangOptions llvm outputPath timeStamp = do
+  objectIndex <- liftIO $ atomicModifyIORef' (nextObjectIndexRef h) $ \index -> (index + 1, index)
+  let stagingBaseName = makeStagingBaseName objectIndex sourceLabel
+  llvmPath <- parseRelFile $ stagingBaseName <> ".ll"
+  objectPath <- parseRelFile $ stagingBaseName <> ".o"
+  liftIO $ writeLazyByteString (stagingDir h </> llvmPath) llvm
+  let pendingObject =
+        PendingObject
+          { stagingLLVMPath = llvmPath,
+            stagingObjectPath = objectPath,
+            finalObjectPath = outputPath,
+            objectTimeStamp = timeStamp,
+            additionalClangOptions
+          }
+  liftIO $ atomicModifyIORef' (pendingObjectListRef h) $ \pendingList -> (pendingObject : pendingList, ())
+
+makeStagingBaseName :: Int -> T.Text -> String
+makeStagingBaseName objectIndex sourceLabel = do
+  let normalizedLabel = T.take 120 $ T.map normalizeStagingFileNameChar sourceLabel
+  let label = if T.null normalizedLabel then "object" else T.unpack normalizedLabel
+  show objectIndex <> "-" <> label
+
+normalizeStagingFileNameChar :: Char -> Char
+normalizeStagingFileNameChar char
+  | isAscii char && (isAlphaNum char || char `elem` ("-_." :: String)) =
+      char
+  | otherwise =
+      '#'
+
+flushObjects :: Handle -> App ()
+flushObjects h = do
+  pendingObjectList <- liftIO $ readIORef (pendingObjectListRef h)
+  let objectMap = Map.fromListWith (<>) $ map (\object -> (additionalClangOptions object, [object])) pendingObjectList
+  forM_ (Map.toList objectMap) $ \(clangOptions, objectList) -> do
+    let batchSize = max 1 $ ceilingDiv (length objectList) (numCapabilities h)
+    forP_ (chunksOf batchSize objectList) $ compileObjectBatch h clangOptions
+
+compileObjectBatch :: Handle -> [ClangOption] -> [PendingObject] -> App ()
+compileObjectBatch h clangOptions objectList = do
   clang <- liftIO Platform.getClang
   let targetTriple = Platform.getClangTargetTriple (platformHandle h)
-  let optionList = clangBaseOpt targetTriple outputPath ++ additionalClangOptions
+  let inputPathList = map (toFilePath . stagingLLVMPath) objectList
+  let optionList = clangBaseOpt targetTriple ++ clangOptions ++ inputPathList
   let spec =
         RunProcess.Spec
           { cmdspec = RawCommand clang optionList,
-            cwd = Nothing
+            cwd = Just $ toFilePath $ stagingDir h
           }
-  value <- liftIO (RunProcess.run10 (runProcessHandle h) spec (RunProcess.Lazy llvm))
+  value <- liftIO $ RunProcess.run00 (runProcessHandle h) spec
   case value of
-    Right _ ->
-      return ()
+    Right _ -> do
+      forM_ objectList $ \object -> do
+        copyFile (stagingDir h </> stagingObjectPath object) (finalObjectPath object)
+        setModificationTime (finalObjectPath object) (objectTimeStamp object)
     Left err ->
       throwError $ newError' err
 
-clangBaseOpt :: String -> Path Abs File -> [String]
-clangBaseOpt targetTriple outputPath =
+clangBaseOpt :: String -> [String]
+clangBaseOpt targetTriple =
   [ "-xir",
     "-target",
     targetTriple,
     "-O2",
     "-flto=thin",
-    "-c",
-    "-",
-    "-o",
-    toFilePath outputPath
+    "-c"
   ]
+
+ceilingDiv :: Int -> Int -> Int
+ceilingDiv numerator denominator =
+  (numerator + denominator - 1) `div` denominator
+
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf size xs = do
+  case xs of
+    [] ->
+      []
+    _ -> do
+      let (chunk, rest) = splitAt size xs
+      chunk : chunksOf size rest

--- a/src/Kernel/Common/Handle/Global/Platform.hs
+++ b/src/Kernel/Common/Handle/Global/Platform.hs
@@ -37,6 +37,7 @@ import System.Directory
 import System.Environment (lookupEnv)
 import System.Info qualified as SI
 import System.Process (CmdSpec (RawCommand))
+import Text.ParserCombinators.ReadP (readP_to_S)
 
 data Handle = Handle
   { _arch :: Arch.Arch,
@@ -79,7 +80,7 @@ new loggerHandle = do
     _os <- getOS' Nothing
     _clangTargetTriple <- resolveClangTargetTriple _arch _os
     let _baseSize = Arch.dataSizeOf _arch
-    _clangDigest <- calculateClangDigest loggerHandle
+    _clangDigest <- calculateClangDigest loggerHandle _clangTargetTriple
     return $ Handle {..}
 
 getArch' :: Maybe Hint -> App Arch.Arch
@@ -130,14 +131,56 @@ resolveClangTargetTriple arch os = do
       return "x86_64-unknown-linux-gnu"
     (Arch.Arm64, O.Linux) ->
       return "aarch64-unknown-linux-gnu"
-    (Arch.Arm64, O.Darwin) ->
-      return "arm64-apple-darwin"
+    (Arch.Arm64, O.Darwin) -> do
+      deploymentTarget <- resolveMacOSDeploymentTarget
+      return $ "arm64-apple-macosx" <> deploymentTarget
     _ -> do
       let p = P.Platform {P.arch = arch, P.os = os}
       raiseError' $ "Unsupported target platform: " <> P.reify p
 
-calculateClangDigest :: Logger.Handle -> App T.Text
-calculateClangDigest h = do
+resolveMacOSDeploymentTarget :: App String
+resolveMacOSDeploymentTarget = do
+  mDeploymentTarget <- liftIO $ lookupEnv "MACOSX_DEPLOYMENT_TARGET"
+  case mDeploymentTarget of
+    Nothing ->
+      return "11.0.0"
+    Just deploymentTarget ->
+      normalizeMacOSDeploymentTarget deploymentTarget
+
+normalizeMacOSDeploymentTarget :: String -> App String
+normalizeMacOSDeploymentTarget deploymentTarget = do
+  let parsedVersionList =
+        [ parsedVersion
+          | (parsedVersion, rest) <- readP_to_S V.parseVersion deploymentTarget,
+            null rest
+        ]
+  case parsedVersionList of
+    [parsedVersion] -> do
+      let componentList = V.versionBranch parsedVersion
+      case componentList of
+        [major] ->
+          validateMacOSDeploymentTarget deploymentTarget [major, 0, 0]
+        [major, minor] ->
+          validateMacOSDeploymentTarget deploymentTarget [major, minor, 0]
+        [major, minor, patch] ->
+          validateMacOSDeploymentTarget deploymentTarget [major, minor, patch]
+        _ ->
+          invalidMacOSDeploymentTarget deploymentTarget
+    _ ->
+      invalidMacOSDeploymentTarget deploymentTarget
+
+validateMacOSDeploymentTarget :: String -> [Int] -> App String
+validateMacOSDeploymentTarget original componentList = do
+  if componentList < [11, 0, 0]
+    then raiseError' $ "MACOSX_DEPLOYMENT_TARGET must be at least 11.0 for arm64: " <> T.pack original
+    else return $ V.showVersion $ V.makeVersion componentList
+
+invalidMacOSDeploymentTarget :: String -> App a
+invalidMacOSDeploymentTarget deploymentTarget =
+  raiseError' $ "Invalid MACOSX_DEPLOYMENT_TARGET: " <> T.pack deploymentTarget
+
+calculateClangDigest :: Logger.Handle -> String -> App T.Text
+calculateClangDigest h targetTriple = do
   clang <- liftIO getClang
   let spec = RunProcess.Spec {cmdspec = RawCommand clang ["--version"], cwd = Nothing}
   let h' = RunProcess.new h
@@ -145,7 +188,8 @@ calculateClangDigest h = do
   case output of
     Right value -> do
       liftIO $ Logger.report h $ "Clang info:\n" <> decodeUtf8 value
-      return $ decodeUtf8 $ hashAndEncode value
+      let targetInfo = encodeUtf8 $ "\nTarget triple: " <> T.pack targetTriple
+      return $ decodeUtf8 $ hashAndEncode $ value <> targetInfo
     Left err ->
       throwError $ newError' err
 

--- a/src/Kernel/Emit/Emit.hs
+++ b/src/Kernel/Emit/Emit.hs
@@ -64,13 +64,21 @@ emit h lowCode = do
   case lowCode of
     LC.LowCodeMain mainDef lowCodeInfo -> do
       main <- emitMain h mainDef
+      let moduleHeader = emitModuleHeader h
       let argDef = emitArgDef
       (header, body) <- emitLowCodeInfo h lowCodeInfo
-      return $ buildByteString $ header ++ argDef ++ main ++ body
+      return $ buildByteString $ moduleHeader ++ header ++ argDef ++ main ++ body
     LC.LowCodeNormal lowCodeInfo -> do
+      let moduleHeader = emitModuleHeader h
       let argDecl = emitArgDecl
       (header, body) <- emitLowCodeInfo h lowCodeInfo
-      return $ buildByteString $ header ++ argDecl ++ body
+      return $ buildByteString $ moduleHeader ++ header ++ argDecl ++ body
+
+emitModuleHeader :: Handle -> [Builder]
+emitModuleHeader h = do
+  let platformHandle = Global.platformHandle $ globalHandle h
+  let targetTriple = Platform.getClangTargetTriple platformHandle
+  ["target triple = \"" <> TE.encodeUtf8Builder (T.pack targetTriple) <> "\""]
 
 emitLowCodeInfo :: Handle -> LC.LowCodeInfo -> IO ([Builder], [Builder])
 emitLowCodeInfo h (declEnv, defList, staticTextList) = do

--- a/src/Language/Comp/Reduce.hs
+++ b/src/Language/Comp/Reduce.hs
@@ -7,6 +7,7 @@ where
 
 import Data.HashMap.Strict qualified as Map
 import Data.IntMap qualified as IntMap
+import Data.List (foldl')
 import Gensym.Handle qualified as Gensym
 import Language.Common.CreateSymbol qualified as Gensym
 import Language.Common.Ident
@@ -31,8 +32,12 @@ new substHandle gensymHandle defMap = do
 
 unionSubst :: Handle -> C.SubstValue -> Handle
 unionSubst (Handle {..}) newSubst = do
-  let subst' = IntMap.union newSubst subst
+  let subst' = IntMap.foldlWithKey' insertSubst subst newSubst
   Handle {subst = subst', ..}
+
+insertSubst :: C.SubstValue -> Int -> C.Value -> C.SubstValue
+insertSubst currentSubst ident value = do
+  IntMap.insert ident value currentSubst
 
 reduce :: Handle -> C.Comp -> IO C.Comp
 reduce h term = do
@@ -52,65 +57,14 @@ reduce h term = do
           return $ C.PiElimDownElim forceInline v' ds'
     C.SigmaElim shouldDeallocate offset size xs v e -> do
       let v' = Subst.substValue (subst h) v
-      case v' of
-        C.SigmaIntro _ ds
-          | length ds >= offset + length xs -> do
-              let ds' = take (length xs) $ drop offset ds
-              let h' = unionSubst h (IntMap.fromList (zip (map Ident.toInt xs) ds'))
-              reduce h' e
-        _ -> do
-          xs' <- mapM (Gensym.newIdentFromIdent (gensymHandle h)) xs
-          let h' = unionSubst h (IntMap.fromList (zip (map Ident.toInt xs) (map C.VarLocal xs')))
-          e' <- reduce h' e
-          case e' of
-            C.UpIntro (C.SigmaIntro _ ds)
-              | offset == 0,
-                length xs == size,
-                Just ys <- mapM extractIdent ds,
-                xs' == ys ->
-                  return $ C.UpIntro v -- eta-reduce (full read only)
-            C.Unreachable ->
-              return C.Unreachable
-            _ ->
-              case xs' of
-                [] ->
-                  return e'
-                _ ->
-                  return $ C.SigmaElim shouldDeallocate offset size xs' v' e'
+      reduceSigmaElim h shouldDeallocate offset size xs v' e
     C.UpIntro d -> do
       return $ C.UpIntro $ Subst.substValue (subst h) d
     C.UpIntroVoid -> do
       return C.UpIntroVoid
     C.UpElim isReducible x e1 e2 -> do
       e1' <- reduce h e1
-      case e1' of
-        C.UpIntro v
-          | isReducible -> do
-              let h' = unionSubst h $ IntMap.singleton (Ident.toInt x) v
-              reduce h' e2
-        C.UpElim isReducible' y ey1 ey2 -> do
-          -- commutative conversion
-          e2' <- reduce h e2
-          reduce h $ C.UpElim isReducible' y ey1 $ C.UpElim isReducible x ey2 e2'
-        C.SigmaElim b offset size ys vy ey -> do
-          -- commutative conversion
-          e2' <- reduce h e2
-          reduce h $ C.SigmaElim b offset size ys vy $ C.UpElim isReducible x ey e2'
-        C.Unreachable ->
-          return C.Unreachable
-        _ -> do
-          x' <- Gensym.newIdentFromIdent (gensymHandle h) x
-          let h' = unionSubst h $ IntMap.singleton (Ident.toInt x) (C.VarLocal x')
-          e2' <- reduce h' e2
-          case e2' of
-            C.Unreachable ->
-              return C.Unreachable
-            C.UpIntro (C.VarLocal y)
-              | x' == y,
-                isReducible ->
-                  return e1' -- eta-reduce
-            _ ->
-              return $ C.UpElim isReducible x' e1' e2'
+      reduceUpElim h isReducible x e1' e2
     C.UpElimCallVoid f vs e2 -> do
       let f' = Subst.substValue (subst h) f
       let vs' = map (Subst.substValue (subst h)) vs
@@ -178,7 +132,9 @@ reduce h term = do
           let defaultBranch' = rewriteWriteToDestBranch dest' sizeComp' defaultBranch
           let caseList' = map (\(tag, branch) -> (tag, rewriteWriteToDestBranch dest' sizeComp' branch)) caseList
           ignoredVar <- Gensym.newIdentFromText (gensymHandle h) "_"
-          reduce h $ C.UpElim True ignoredVar (C.EnumElim fvInfo disc defaultBranch' caseList') cont'
+          let rewritten = C.UpElim True ignoredVar (C.EnumElim fvInfo disc defaultBranch' caseList') cont'
+          refreshed <- Subst.refresh (substHandle h) rewritten
+          reduce h refreshed
         C.Unreachable ->
           return C.Unreachable
         _ ->
@@ -201,6 +157,75 @@ reduce h term = do
           return $ C.Free x' size cont'
     C.Unreachable -> do
       return C.Unreachable
+
+reduceSigmaElim :: Handle -> Bool -> Int -> Int -> [Ident] -> C.Value -> C.Comp -> IO C.Comp
+reduceSigmaElim h shouldDeallocate offset size xs v e = do
+  case v of
+    C.SigmaIntro _ ds
+      | length ds >= offset + length xs -> do
+          let ds' = take (length xs) $ drop offset ds
+          let h' = unionSubst h (IntMap.fromList (zip (map Ident.toInt xs) ds'))
+          reduce h' e
+    _ -> do
+      let h' = deleteSubstList h xs
+      e' <- reduce h' e
+      case e' of
+        C.UpIntro (C.SigmaIntro _ ds)
+          | offset == 0,
+            length xs == size,
+            Just ys <- mapM extractIdent ds,
+            xs == ys ->
+              return $ C.UpIntro v
+        C.Unreachable ->
+          return C.Unreachable
+        _ -> do
+          case xs of
+            [] ->
+              return e'
+            _ ->
+              return $ C.SigmaElim shouldDeallocate offset size xs v e'
+
+reduceUpElim :: Handle -> C.IsReducible -> Ident -> C.Comp -> C.Comp -> IO C.Comp
+reduceUpElim h isReducible x e1 e2 = do
+  case e1 of
+    C.UpIntro v
+      | isReducible -> do
+          let h' = unionSubst h $ IntMap.singleton (Ident.toInt x) v
+          reduce h' e2
+    C.UpElim isReducible' y ey1 ey2 -> do
+      e2' <- reduce h e2
+      reduceUpElim h isReducible' y ey1 $ C.UpElim isReducible x ey2 e2'
+    C.SigmaElim shouldDeallocate offset size ys vy ey -> do
+      e2' <- reduce h e2
+      reduceSigmaElim h shouldDeallocate offset size ys vy $ C.UpElim isReducible x ey e2'
+    C.Unreachable ->
+      return C.Unreachable
+    _ -> do
+      let h' = deleteSubst h x
+      e2' <- reduce h' e2
+      case e2' of
+        C.Unreachable ->
+          return C.Unreachable
+        C.UpIntro (C.VarLocal y)
+          | x == y,
+            isReducible ->
+              return e1
+        _ ->
+          return $ C.UpElim isReducible x e1 e2'
+
+deleteSubst :: Handle -> Ident -> Handle
+deleteSubst h ident = do
+  let subst' = IntMap.delete (Ident.toInt ident) (subst h)
+  h {subst = subst'}
+
+deleteSubstList :: Handle -> [Ident] -> Handle
+deleteSubstList h identList = do
+  let subst' = foldl' deleteSubstByIdent (subst h) identList
+  h {subst = subst'}
+
+deleteSubstByIdent :: C.SubstValue -> Ident -> C.SubstValue
+deleteSubstByIdent currentSubst ident = do
+  IntMap.delete (Ident.toInt ident) currentSubst
 
 rewriteWriteToDestBranch ::
   C.Value ->
@@ -229,8 +254,9 @@ valueToEnumInt value = do
 graftVoidReduce :: Handle -> C.Comp -> C.Comp -> IO C.Comp
 graftVoidReduce h e cont = do
   case graftVoid e cont of
-    Just e' ->
-      reduce h e'
+    Just e' -> do
+      refreshed <- Subst.refresh (substHandle h) e'
+      reduce h refreshed
     Nothing ->
       return e
 


### PR DESCRIPTION
- reduce the number of spawned clang processes
- avoid unnecessary renaming when reducing polarized terms